### PR TITLE
Drain buffered events after popup closes and enlarge popup to 90%

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -329,7 +329,7 @@ impl App {
     pub fn attach_selected(&self) -> Result<()> {
         if let Some(agent) = self.selected_agent() {
             self.client
-                .attach_popup(&agent.session.name, "80%", "80%")?;
+                .attach_popup(&agent.session.name, "90%", "90%")?;
         }
         Ok(())
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -62,4 +62,11 @@ impl EventHandler {
     pub async fn next(&mut self) -> Option<AppEvent> {
         self.rx.recv().await
     }
+
+    /// Drain all buffered events, discarding them.
+    /// Call after a blocking operation (e.g. tmux popup) to skip
+    /// stale ticks and only process fresh events going forward.
+    pub fn drain(&mut self) {
+        while self.rx.try_recv().is_ok() {}
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,6 +340,8 @@ async fn run_dashboard(config: Config) -> Result<()> {
                                 if let Err(e) = app.attach_selected() {
                                     app.set_status(format!("Error: {}", e));
                                 }
+                                // Discard ticks that accumulated while popup was open
+                                events.drain();
                                 // Force redraw after popup closes
                                 terminal.clear()?;
                             } else {
@@ -352,6 +354,8 @@ async fn run_dashboard(config: Config) -> Result<()> {
                                 // Restore terminal
                                 execute!(terminal.backend_mut(), EnterAlternateScreen)?;
                                 enable_raw_mode()?;
+                                // Discard ticks that accumulated while popup was open
+                                events.drain();
                                 terminal.clear()?;
 
                                 if let Err(e) = result {


### PR DESCRIPTION
## Summary
- Fix rapid-fire UI updates after dismissing tmux popup by draining stale tick events from the unbounded channel
- Add `EventHandler::drain()` method to discard all buffered events
- Enlarge popup window from 80% to 90%

## Test plan
- [x] Open dashboard, attach to an agent via Enter, stay in popup for several seconds, then exit — verify no rapid update burst
- [x] Verify popup now fills 90% of the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)