### PR TITLE
feat: add kill protection for agents

### DIFF
--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -70,6 +70,12 @@ curl -X POST http://localhost:9876/api/agents/<name>/send \
 curl -X DELETE http://localhost:9876/api/agents/<name>
 ```
 
+**Kill protection:** The API enforces two safety rules:
+1. **Popup protection (423 Locked):** If a user has a popup open on the agent in the dashboard, the kill is rejected. Wait for the popup to close.
+2. **Completion check (409 Conflict):** If the agent has not outputted `[PROJECT COMPLETE]` or `[TASK COMPLETE]`, the kill is rejected. Only kill agents that have signalled completion. If you absolutely must force-kill a stuck agent, append `?force=true` to the URL.
+
+You can check an agent's protection and completion state via `GET /api/agents/<name>` — look at the `protected` and `completed` fields.
+
 ### Projects API
 
 #### Add a project
@@ -97,6 +103,7 @@ curl http://localhost:9876/api/agents/<name>
 
 Look for:
 - `[TASK COMPLETE]` — Agent finished all work. Kill it and complete the project.
+- Also check the `completed` and `protected` fields — only kill when `completed: true` and `protected: false`.
 - If the agent appears stuck or idle for too long, send it a nudge via the send endpoint.
 
 ### Detecting Agent Activity State
@@ -112,9 +119,11 @@ This distinction is important: sending input to an agent that is mid-operation c
 
 **Kill and replace — don't nudge repeatedly.** If an agent is stuck (idle too long, stuck in plan mode, not making progress after multiple nudges), do NOT keep nudging it. Kill it and spawn a fresh replacement with the same task and full context. Nudging a stuck agent wastes time — a fresh agent with the same instructions will be more effective.
 
+Because the API requires agents to have signalled completion before they can be killed, you must use `?force=true` when killing a stuck agent that has NOT completed:
+
 ```bash
-# Kill the stuck agent
-curl -X DELETE http://localhost:9876/api/agents/<name>
+# Force-kill the stuck agent (has not signalled [TASK COMPLETE])
+curl -X DELETE http://localhost:9876/api/agents/<name>?force=true
 
 # Spawn a replacement with the same task
 curl -X POST http://localhost:9876/api/agents \
@@ -126,8 +135,9 @@ curl -X POST http://localhost:9876/api/agents \
 
 ## When an Agent Finishes
 
-CRITICAL — you MUST execute ALL three steps every time. Never skip the project deletion.
+CRITICAL — you MUST execute ALL of these steps every time. Never skip the project deletion.
 
+0. Verify the agent is done: `curl http://localhost:9876/api/agents/<name>` — confirm `completed: true` and `protected: false` before proceeding. If `protected: true`, the user has a popup open — wait and retry later.
 1. Kill the agent: `curl -X DELETE http://localhost:9876/api/agents/<name>`
 2. Complete the project: `curl -X DELETE http://localhost:9876/api/projects/<id>` (use the id returned when you created the project)
 3. Verify the project is gone: `curl http://localhost:9876/api/projects` — if the project still appears, delete it again

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -17,13 +17,15 @@ use crate::computer::{self, ComputerLock};
 use crate::manager::{build_agent_command, prompts_dir};
 use crate::memory;
 use crate::projects;
-use crate::scheduler::{event::ScheduledEvent, Scheduler};
+use crate::scheduler::{event::ScheduledEvent, PopupReceiver, Scheduler};
 
 /// Shared state for all API handlers
 pub struct ApiState {
     pub app: Arc<Mutex<SharedApp>>,
     pub scheduler: Arc<Scheduler>,
     pub computer_lock: ComputerLock,
+    /// Tracks which agent currently has a dashboard popup open (if any).
+    pub popup_receiver: PopupReceiver,
 }
 
 /// Resolve a user-facing agent name to a full tmux session name.
@@ -109,17 +111,30 @@ pub async fn get_agent(
 
     match agent {
         Some(a) => {
+            let short = display_name(&prefix, &a.session.name).to_string();
             let output_tail = app
                 .client()
                 .capture_pane(&a.session.name, 50)
                 .unwrap_or_default();
 
+            let protected = state
+                .popup_receiver
+                .lock()
+                .unwrap()
+                .as_deref()
+                .is_some_and(|r| r == short);
+
+            let completed = output_tail.contains("[PROJECT COMPLETE]")
+                || output_tail.contains("[TASK COMPLETE]");
+
             Ok(Json(AgentDetailResponse {
-                id: display_name(&prefix, &a.session.name).to_string(),
+                id: short,
                 status: "running".to_string(),
                 health: a.health.as_str().to_string(),
                 last_output: a.health_info.last_output.clone(),
                 output_tail,
+                protected,
+                completed,
             }))
         }
         None => Err((
@@ -342,14 +357,19 @@ pub async fn spawn_agent(
 }
 
 /// DELETE /api/agents/:id
+///
+/// Query params:
+///   - `force=true`: bypass the activity check (popup protection is never bypassable)
 pub async fn kill_agent(
     State(state): State<Arc<ApiState>>,
     Path(id): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
 ) -> Result<Json<StatusResponse>, (StatusCode, Json<ErrorResponse>)> {
     let app = state.app.lock().await;
 
     let prefix = app.client().prefix().to_string();
     let session_name = resolve_session_name(&prefix, &id);
+    let short_name = display_name(&prefix, &session_name).to_string();
 
     // Don't allow killing manager via API
     if session_name == MANAGER_SESSION_NAME || id == MANAGER_SESSION_NAME {
@@ -371,6 +391,57 @@ pub async fn kill_agent(
         ));
     }
 
+    // ── Protection 1: popup is open on this agent ──
+    // When a user has the agent's popup open in the dashboard, the agent
+    // is untouchable. This cannot be bypassed even with force=true.
+    let popup_active = state
+        .popup_receiver
+        .lock()
+        .unwrap()
+        .as_deref()
+        .is_some_and(|r| r == short_name);
+    if popup_active {
+        return Err((
+            StatusCode::LOCKED,
+            Json(ErrorResponse {
+                error: format!(
+                    "Agent '{}' is protected: a dashboard popup is open on it. \
+                     Close the popup first.",
+                    id
+                ),
+            }),
+        ));
+    }
+
+    // ── Protection 2: agent has not signalled completion ──
+    // Unless ?force=true, refuse to kill an agent whose pane output does
+    // not contain [PROJECT COMPLETE] (for PMs) or [TASK COMPLETE] (for workers).
+    let force = params
+        .get("force")
+        .is_some_and(|v| v.eq_ignore_ascii_case("true"));
+
+    if !force {
+        let output = app
+            .client()
+            .capture_pane(&session_name, 100)
+            .unwrap_or_default();
+        let has_completion_signal =
+            output.contains("[PROJECT COMPLETE]") || output.contains("[TASK COMPLETE]");
+        if !has_completion_signal {
+            return Err((
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    error: format!(
+                        "Agent '{}' has not signalled completion ([PROJECT COMPLETE] or \
+                         [TASK COMPLETE]). It may still be working. To force-kill, use \
+                         DELETE /api/agents/{}?force=true",
+                        id, id
+                    ),
+                }),
+            ));
+        }
+    }
+
     // Kill it
     if let Err(e) = app.client().kill_session(&session_name) {
         return Err((
@@ -383,7 +454,6 @@ pub async fn kill_agent(
 
     // Clean up parent mapping and cancel pending events for the killed agent
     memory::remove_agent_parent(&session_name);
-    let short_name = display_name(&prefix, &session_name).to_string();
     state.scheduler.cancel_by_receiver(&short_name);
 
     Ok(Json(StatusResponse {

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -51,6 +51,10 @@ pub struct AgentDetailResponse {
     pub health: String,
     pub last_output: String,
     pub output_tail: String,
+    /// True when a dashboard popup is open on this agent (kill-protected).
+    pub protected: bool,
+    /// True when the agent's output contains a completion signal.
+    pub completed: bool,
 }
 
 /// Request to send input to an agent

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,6 +454,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
             app: Arc::new(Mutex::new(App::new(&config, ticker.clone()))),
             scheduler: scheduler.clone(),
             computer_lock: computer::new_lock(),
+            popup_receiver: popup_receiver.clone(),
         });
         tokio::spawn(async move {
             if let Err(e) = api::start_server(api_state, &api_config).await {


### PR DESCRIPTION
## Summary
- Adds API-level kill protection so the EA cannot kill agents that are still actively being used
- **Popup guard (423 Locked):** when a user has a dashboard popup open on an agent, `DELETE /api/agents/:id` is rejected — not bypassable
- **Completion check (409 Conflict):** agents must have signalled `[PROJECT COMPLETE]` or `[TASK COMPLETE]` before they can be killed — bypassable with `?force=true` for stuck agents
- Exposes `protected` and `completed` fields in `GET /api/agents/:id` response
- Updates EA prompt to reference these safeguards and use `?force=true` when force-killing stuck PMs

## Test plan
- [x] All 55 unit tests pass
- [x] `cargo clippy -- -D warnings` passes clean
- [x] `cargo fmt` applied
- [ ] Manual test: open popup on agent → verify EA's kill request returns 423
- [ ] Manual test: kill agent without `[PROJECT COMPLETE]` → verify 409 returned
- [ ] Manual test: kill with `?force=true` → verify force-kill works
- [ ] Manual test: kill agent after `[PROJECT COMPLETE]` → verify normal kill works

🤖 Generated with [Claude Code](https://claude.com/claude-code)