### PR TITLE
feat: tmux setup, detach keybinding, and quit confirmation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -72,6 +72,8 @@ pub struct App {
     pub pending_confirm: Option<ConfirmAction>,
     pub filter: String,
     pub status_message: Option<String>,
+    /// Warning that persists across tick clears (e.g., tmux misconfiguration)
+    pub persistent_warning: Option<String>,
     pub projects: Vec<Project>,
     pub project_input_mode: bool,
     pub project_input: String,
@@ -111,6 +113,7 @@ impl App {
             pending_confirm: None,
             filter: String::new(),
             status_message: None,
+            persistent_warning: None,
             projects: projects::load_projects(),
             project_input_mode: false,
             project_input: String::new(),
@@ -630,9 +633,16 @@ impl App {
         self.status_message = Some(msg.into());
     }
 
-    /// Clear status message
+    /// Set a persistent warning that survives clear_status() calls
+    pub fn set_persistent_warning(&mut self, msg: impl Into<String>) {
+        let msg = msg.into();
+        self.persistent_warning = Some(msg.clone());
+        self.status_message = Some(msg);
+    }
+
+    /// Clear status message (persistent warnings are restored)
     pub fn clear_status(&mut self) {
-        self.status_message = None;
+        self.status_message = self.persistent_warning.clone();
     }
 
     /// Get counts by health state: (running, idle)

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,7 +446,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
 
     // Warn if tmux config is missing recommended settings
     if tmux_setup_needed() {
-        app.set_status("⚠ tmux not configured for omar — run 'omar setup-tmux' to fix");
+        app.set_persistent_warning("⚠ tmux not configured for omar — run 'omar setup-tmux' to fix");
     }
 
     // Initial refresh

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -13,13 +13,14 @@ use crate::tmux::HealthState;
 
 /// Render the entire dashboard
 pub fn render(frame: &mut Frame, app: &App) {
+    let status_height = if app.status_message.is_some() { 4 } else { 3 };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),      // Status bar
-            Constraint::Percentage(55), // Agent grid + projects sidebar
-            Constraint::Min(8),         // Manager panel (~33%)
-            Constraint::Length(1),      // Help bar
+            Constraint::Length(status_height), // Status bar (taller when warning shown)
+            Constraint::Percentage(55),        // Agent grid + projects sidebar
+            Constraint::Min(8),                // Manager panel (~33%)
+            Constraint::Length(1),             // Help bar
         ])
         .split(frame.area());
 


### PR DESCRIPTION
## Summary
- Add `omar setup-tmux` subcommand that detects missing tmux settings (mouse, extended-keys, clipboard), previews changes, and appends to `~/.tmux.conf` on confirmation
- Add `z` keybinding to detach from tmux while agents keep running ("Hold the line")
- Warn in dashboard status bar on startup if tmux is misconfigured, directing users to `omar setup-tmux`
- Change quit from `q` to `Q` (Shift+Q) with confirmation dialog warning that the EA session will be killed
- `Esc` no longer quits at root, `Ctrl+C` triggers confirmation dialog
- Unify kill/quit confirm dialogs into a single `ConfirmAction` enum and shared renderer
- Fix: tmux warning now persists across tick refreshes (uses `persistent_warning` field + dynamic status bar height)

## Test plan
- [x] Run `omar setup-tmux` on a fresh tmux config — verify it lists missing settings and applies on confirmation
- [x] Run `omar setup-tmux` when already configured — verify "already configured" message
- [x] Press `z` in dashboard — verify tmux detaches and agents keep running
- [x] Run `omar` again after detach — verify dashboard relaunches and reconnects
- [x] Start dashboard without extended-keys — verify status bar warning appears and persists
- [x] Press `Q` — verify confirmation dialog appears with EA kill warning
- [x] Press `y` in confirm dialog — verify quit; press any other key — verify cancel
- [x] Press `q` — verify it does nothing (no accidental quit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)