### PR TITLE
feat: multi-EA support with EaContext, spawn, and cycling

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -12,7 +12,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
 
 use super::models::*;
-use crate::app::{SharedApp, MANAGER_SESSION_NAME};
+use crate::app::SharedApp;
 use crate::computer::{self, ComputerLock};
 use crate::manager::{build_agent_command, prompts_dir};
 use crate::memory;
@@ -165,13 +165,12 @@ pub async fn get_agent_summary(
             let session = a.session.name.clone();
             let health = a.health.as_str().to_string();
 
-            let tasks = memory::load_worker_tasks();
-            let task = tasks.get(&session).cloned();
+            let task = app.worker_tasks().get(&session).cloned();
 
-            let status = memory::load_agent_status(&session);
+            let status = memory::load_agent_status(&app.ea().state_dir, &session);
 
-            let parents = memory::load_agent_parents();
-            let children: Vec<String> = parents
+            let children: Vec<String> = app
+                .agent_parents()
                 .iter()
                 .filter(|(_, parent)| **parent == session)
                 .map(|(child, _)| display_name(&prefix, child).to_string())
@@ -213,7 +212,7 @@ pub async fn update_agent_status(
         ));
     }
 
-    memory::save_agent_status(&session_name, &req.status);
+    memory::save_agent_status(&app.ea().state_dir, &session_name, &req.status);
 
     Ok(Json(StatusResponse {
         status: "updated".to_string(),
@@ -248,11 +247,7 @@ pub async fn spawn_agent(
     }
 
     // Get workdir
-    let workdir = req.workdir.unwrap_or_else(|| {
-        std::env::current_dir()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| ".".to_string())
-    });
+    let workdir = req.workdir.unwrap_or_else(crate::app::current_workdir);
 
     // Build the agent command — with system prompt via native CLI flag if a role is set
     let base_command = req
@@ -267,7 +262,7 @@ pub async fn spawn_agent(
         // Any agent with a role or task gets the unified agent prompt
         let parent = req.parent.as_deref().unwrap_or("ea");
         let task = req.task.as_deref().unwrap_or("");
-        let prompt_file = prompts_dir().join("agent.md");
+        let prompt_file = prompts_dir(app.ea()).join("agent.md");
         build_agent_command(
             &base_command,
             &prompt_file,
@@ -288,15 +283,16 @@ pub async fn spawn_agent(
     }
 
     // Save parent mapping if explicitly provided
+    let state_dir = app.ea().state_dir.clone();
     if let Some(ref parent) = req.parent {
         let resolved_parent = resolve_session_name(&prefix, parent);
-        memory::save_agent_parent(&name, &resolved_parent);
+        memory::save_agent_parent(&state_dir, &name, &resolved_parent);
     }
 
     // Send first user message after a delay
     if let Some(task) = req.task {
         // Always persist the original (short) task for dashboard display
-        memory::save_worker_task(&name, &task);
+        memory::save_worker_task(&state_dir, &name, &task);
 
         let short = display_name(&prefix, &name);
         let user_msg = format!("YOUR NAME: {}\nYOUR TASK: {}", short, task);
@@ -351,8 +347,12 @@ pub async fn kill_agent(
     let prefix = app.client().prefix().to_string();
     let session_name = resolve_session_name(&prefix, &id);
 
-    // Don't allow killing manager via API
-    if session_name == MANAGER_SESSION_NAME || id == MANAGER_SESSION_NAME {
+    // Don't allow killing any EA manager via API
+    let is_ea = app
+        .eas
+        .iter()
+        .any(|e| session_name == e.session_name || id == e.session_name);
+    if is_ea {
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse {
@@ -382,7 +382,7 @@ pub async fn kill_agent(
     }
 
     // Clean up parent mapping and cancel pending events for the killed agent
-    memory::remove_agent_parent(&session_name);
+    memory::remove_agent_parent(&app.ea().state_dir, &session_name);
     let short_name = display_name(&prefix, &session_name).to_string();
     state.scheduler.cancel_by_receiver(&short_name);
 
@@ -443,8 +443,9 @@ pub async fn send_input(
 }
 
 /// GET /api/projects
-pub async fn list_projects() -> Json<ListProjectsResponse> {
-    let projects = projects::load_projects();
+pub async fn list_projects(State(state): State<Arc<ApiState>>) -> Json<ListProjectsResponse> {
+    let app = state.app.lock().await;
+    let projects = projects::load_projects(&app.ea().state_dir);
     let list: Vec<ProjectResponse> = projects
         .iter()
         .map(|p| ProjectResponse {
@@ -457,9 +458,11 @@ pub async fn list_projects() -> Json<ListProjectsResponse> {
 
 /// POST /api/projects
 pub async fn add_project(
+    State(state): State<Arc<ApiState>>,
     Json(req): Json<AddProjectRequest>,
 ) -> Result<Json<ProjectResponse>, (StatusCode, Json<ErrorResponse>)> {
-    match projects::add_project(&req.name) {
+    let app = state.app.lock().await;
+    match projects::add_project(&app.ea().state_dir, &req.name) {
         Ok(id) => Ok(Json(ProjectResponse { id, name: req.name })),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -472,9 +475,11 @@ pub async fn add_project(
 
 /// DELETE /api/projects/:id
 pub async fn complete_project(
+    State(state): State<Arc<ApiState>>,
     Path(id): Path<usize>,
 ) -> Result<Json<StatusResponse>, (StatusCode, Json<ErrorResponse>)> {
-    match projects::remove_project(id) {
+    let app = state.app.lock().await;
+    match projects::remove_project(&app.ea().state_dir, id) {
         Ok(true) => Ok(Json(StatusResponse {
             status: "completed".to_string(),
             message: Some(format!("Project {} removed", id)),
@@ -549,6 +554,24 @@ pub async fn list_events(
         .collect();
 
     Json(EventListResponse { events })
+}
+
+/// GET /api/eas
+pub async fn list_eas(State(state): State<Arc<ApiState>>) -> Json<ListEasResponse> {
+    let app = state.app.lock().await;
+    let eas = app
+        .eas
+        .iter()
+        .enumerate()
+        .map(|(i, ea)| EaInfo {
+            id: ea.id.clone(),
+            display_name: ea.display_name.clone(),
+            session_name: ea.session_name.clone(),
+            active: i == app.active_ea,
+            manager_running: app.managers[i].is_some(),
+        })
+        .collect();
+    Json(ListEasResponse { eas })
 }
 
 /// DELETE /api/events/:id

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -57,6 +57,7 @@ pub fn create_router(state: Arc<ApiState>) -> Router {
             "/api/computer/mouse-position",
             get(handlers::computer_mouse_position),
         )
+        .route("/api/eas", get(handlers::list_eas))
         .layer(cors)
         .with_state(state)
 }

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -279,3 +279,21 @@ pub struct ComputerAvailabilityResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub screen_size: Option<ScreenSizeResponse>,
 }
+
+// ── EA models ──
+
+/// EA info in list response
+#[derive(Debug, Serialize)]
+pub struct EaInfo {
+    pub id: String,
+    pub display_name: String,
+    pub session_name: String,
+    pub active: bool,
+    pub manager_running: bool,
+}
+
+/// Response for listing EAs
+#[derive(Debug, Serialize)]
+pub struct ListEasResponse {
+    pub eas: Vec<EaInfo>,
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,27 +4,22 @@ use anyhow::Result;
 use std::collections::HashMap;
 
 use crate::config::Config;
-use crate::manager::MANAGER_SESSION;
+use crate::manager::EaContext;
 use crate::memory;
+
+/// Resolve the current working directory as a String, falling back to ".".
+pub fn current_workdir() -> String {
+    std::env::current_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| ".".to_string())
+}
 use crate::projects::{self, Project};
 use crate::scheduler::{ScheduledEvent, TickerBuffer};
 use crate::tmux::{HealthChecker, HealthInfo, HealthState, Session, TmuxClient};
 use crate::DASHBOARD_SESSION;
 
-// Re-export for API handlers
-pub use crate::manager::MANAGER_SESSION as MANAGER_SESSION_NAME;
-
 /// Shared app state for API access
 pub type SharedApp = App;
-
-/// What kind of confirmation the user is being prompted for.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConfirmAction {
-    /// Kill the selected agent
-    Kill,
-    /// Quit omar (kills EA)
-    Quit,
-}
 
 /// Information about an agent for display
 #[derive(Debug, Clone)]
@@ -63,26 +58,26 @@ pub struct AgentGroup<'a> {
 /// Application state
 pub struct App {
     pub agents: Vec<AgentInfo>,
-    pub manager: Option<AgentInfo>,
     pub command_tree: Vec<CommandTreeNode>,
     pub selected: usize,
     pub manager_selected: bool,
     pub should_quit: bool,
     pub show_help: bool,
-    pub pending_confirm: Option<ConfirmAction>,
+    pub show_confirm_kill: bool,
+    pub show_confirm_kill_ea: bool,
     pub filter: String,
     pub status_message: Option<String>,
-    /// Warning that persists across tick clears (e.g., tmux misconfiguration)
-    pub persistent_warning: Option<String>,
     pub projects: Vec<Project>,
     pub project_input_mode: bool,
     pub project_input: String,
+    pub ea_input_mode: bool,
+    pub ea_input: String,
     pub show_events: bool,
     pub scheduled_events: Vec<ScheduledEvent>,
     pub ticker: TickerBuffer,
     pub ticker_offset: usize,
     pub show_debug_console: bool,
-    /// Session name of the agent shown in the bottom panel (default: MANAGER_SESSION)
+    /// Session name of the agent shown in the bottom panel
     pub focus_parent: String,
     /// Stack for Esc navigation (drill-up restores previous parent)
     focus_stack: Vec<String>,
@@ -90,6 +85,14 @@ pub struct App {
     pub focus_child_indices: Vec<usize>,
     agent_parents: HashMap<String, String>,
     worker_tasks: HashMap<String, String>,
+    /// All EA contexts
+    pub eas: Vec<EaContext>,
+    /// Index of the active (focused) EA
+    pub active_ea: usize,
+    /// Manager sessions for each EA (parallel to `eas`)
+    pub managers: Vec<Option<AgentInfo>>,
+    /// Cached summaries for non-active EAs: (agent_count, running_count)
+    ea_summaries: Vec<(usize, usize)>,
     client: TmuxClient,
     health_checker: HealthChecker,
     default_command: String,
@@ -102,31 +105,47 @@ impl App {
         let client = TmuxClient::new(&config.dashboard.session_prefix);
         let health_checker = HealthChecker::new(client.clone(), config.health.idle_warning);
 
+        // Load persisted EA list, falling back to the default EA
+        let ea_ids = memory::load_ea_ids();
+        let eas: Vec<EaContext> = if ea_ids.is_empty() {
+            vec![EaContext::default()]
+        } else {
+            ea_ids.iter().map(|id| EaContext::new(id)).collect()
+        };
+        let managers = vec![None; eas.len()];
+        let ea_summaries = vec![(0, 0); eas.len()];
+        let active_ea = 0;
+
         Self {
             agents: Vec::new(),
-            manager: None,
             command_tree: Vec::new(),
             selected: 0,
             manager_selected: true,
             should_quit: false,
             show_help: false,
-            pending_confirm: None,
+            show_confirm_kill: false,
+            show_confirm_kill_ea: false,
             filter: String::new(),
             status_message: None,
-            persistent_warning: None,
-            projects: projects::load_projects(),
+            projects: projects::load_projects(&eas[active_ea].state_dir),
             project_input_mode: false,
             project_input: String::new(),
+            ea_input_mode: false,
+            ea_input: String::new(),
             show_events: false,
             scheduled_events: Vec::new(),
             ticker,
             ticker_offset: 0,
             show_debug_console: false,
-            focus_parent: MANAGER_SESSION.to_string(),
+            focus_parent: eas[active_ea].session_name.clone(),
             focus_stack: Vec::new(),
             focus_child_indices: Vec::new(),
             agent_parents: HashMap::new(),
             worker_tasks: HashMap::new(),
+            eas,
+            active_ea,
+            managers,
+            ea_summaries,
             client,
             health_checker,
             default_command: config.agent.default_command.clone(),
@@ -135,11 +154,18 @@ impl App {
         }
     }
 
+    /// Active EA context (shorthand)
+    pub fn ea(&self) -> &EaContext {
+        &self.eas[self.active_ea]
+    }
+
     /// True when any popup or input overlay is active.
     pub fn has_popup(&self) -> bool {
         self.show_help
-            || self.pending_confirm.is_some()
+            || self.show_confirm_kill
+            || self.show_confirm_kill_ea
             || self.project_input_mode
+            || self.ea_input_mode
             || self.show_events
             || self.show_debug_console
     }
@@ -150,42 +176,45 @@ impl App {
 
     /// Refresh the list of agents
     pub fn refresh(&mut self) -> Result<()> {
-        // Ensure manager exists
-        self.ensure_manager()?;
-
         // Get all sessions
         let sessions = self.client.list_all_sessions()?;
 
-        // Separate manager from other agents, filtering out non-omar sessions
-        let mut manager_session = None;
+        // Separate managers from other agents, filtering out non-omar sessions
+        let mut manager_map: HashMap<String, Session> = HashMap::new();
         let mut other_sessions = Vec::new();
 
         for session in sessions {
-            if session.name == MANAGER_SESSION {
-                manager_session = Some(session);
-            } else if session.name == DASHBOARD_SESSION {
-                // Skip the dashboard's own tmux session
-                continue;
-            } else if !self.session_prefix.is_empty()
-                && !session.name.starts_with(&self.session_prefix)
+            if self.eas.iter().any(|e| e.session_name == session.name) {
+                manager_map.insert(session.name.clone(), session);
+            } else if session.name == DASHBOARD_SESSION
+                || (!self.session_prefix.is_empty()
+                    && !session.name.starts_with(&self.session_prefix))
             {
-                // Skip sessions that don't match the configured prefix
                 continue;
             } else {
                 other_sessions.push(session);
             }
         }
 
-        // Update manager info
-        self.manager = manager_session.map(|session| {
-            let health_info = self.health_checker.check_detailed(&session.name);
-            let health = health_info.state;
-            AgentInfo {
-                session,
-                health,
-                health_info,
-            }
-        });
+        // Start any EA managers not yet running (using the session list we already have)
+        self.ensure_managers(&manager_map)?;
+
+        // Update managers for all EAs
+        self.managers = self
+            .eas
+            .iter()
+            .map(|ea| {
+                manager_map.remove(&ea.session_name).map(|session| {
+                    let health_info = self.health_checker.check_detailed(&session.name);
+                    let health = health_info.state;
+                    AgentInfo {
+                        session,
+                        health,
+                        health_info,
+                    }
+                })
+            })
+            .collect();
 
         // Update agents list (excluding attached sessions)
         // Attached sessions are likely the user's main terminal, not agents
@@ -212,7 +241,7 @@ impl App {
             .agents
             .iter()
             .map(|a| a.session.name.clone())
-            .chain(self.manager.iter().map(|m| m.session.name.clone()))
+            .chain(self.manager().iter().map(|m| m.session.name.clone()))
             .collect();
         self.health_checker.retain_sessions(&active);
 
@@ -223,21 +252,40 @@ impl App {
                 .retain(|a| a.session.name.to_lowercase().contains(&filter));
         }
 
-        // Reload projects from file (picks up API-side changes)
-        self.projects = projects::load_projects();
+        // Reload active EA's projects, parent mappings, and worker tasks
+        self.reload_ea_state();
 
-        // Load parent mappings, worker tasks, and build the chain-of-command tree
-        self.agent_parents = memory::load_agent_parents();
-        self.worker_tasks = memory::load_worker_tasks();
-        self.command_tree = build_tree(
+        // Pre-compute per-EA summaries for non-active EAs (avoids disk I/O in tree builder)
+        self.ea_summaries = self
+            .eas
+            .iter()
+            .enumerate()
+            .map(|(i, ea)| {
+                if i == self.active_ea {
+                    (0, 0) // Not used for active EA
+                } else {
+                    let parents = memory::load_agent_parents(&ea.state_dir);
+                    let count = parents.len();
+                    let running = self
+                        .agents
+                        .iter()
+                        .filter(|a| parents.contains_key(&a.session.name))
+                        .filter(|a| a.health == HealthState::Running)
+                        .count();
+                    (count, running)
+                }
+            })
+            .collect();
+
+        self.command_tree = build_multi_tree(
             &self.agents,
-            self.manager.as_ref(),
+            &self.managers,
             &self.agent_parents,
             &self.session_prefix,
+            &self.eas,
+            self.active_ea,
+            &self.ea_summaries,
         );
-
-        // Recompute focus children indices
-        self.focus_child_indices = self.compute_focus_child_indices();
 
         // Keep selection in bounds relative to focus children
         if !self.manager_selected
@@ -250,25 +298,31 @@ impl App {
         Ok(())
     }
 
-    /// Ensure manager session exists, start if not
-    fn ensure_manager(&self) -> Result<()> {
-        if self.client.has_session(MANAGER_SESSION)? {
-            return Ok(());
+    /// Start manager sessions for EAs that aren't already running.
+    /// Uses the pre-fetched session map to avoid extra tmux subprocess calls.
+    fn ensure_managers(&self, existing: &HashMap<String, Session>) -> Result<()> {
+        let workdir = current_workdir();
+
+        for ea in &self.eas {
+            if existing.contains_key(&ea.session_name) {
+                continue;
+            }
+
+            // Build command with EA system prompt + memory baked in
+            let cmd = crate::manager::build_ea_command(&self.default_command, ea);
+
+            self.client
+                .new_session(&ea.session_name, &cmd, Some(&workdir))?;
+
+            // Write memory after creating manager
+            memory::write_memory(
+                &ea.state_dir,
+                &ea.session_name,
+                &self.agents,
+                None,
+                &self.client,
+            );
         }
-
-        // Build command with EA system prompt + memory baked in
-        let cmd = crate::manager::build_ea_command(&self.default_command);
-
-        // Start manager session — system prompt set at process start
-        let workdir = std::env::current_dir()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| ".".to_string());
-
-        self.client
-            .new_session(MANAGER_SESSION, &cmd, Some(&workdir))?;
-
-        // Write memory after creating manager
-        memory::write_memory(&self.agents, None, &self.client);
 
         Ok(())
     }
@@ -283,9 +337,149 @@ impl App {
         &self.agents
     }
 
-    /// Get manager info (for API)
+    /// Get active manager info (for API)
     pub fn manager(&self) -> Option<&AgentInfo> {
-        self.manager.as_ref()
+        self.managers[self.active_ea].as_ref()
+    }
+
+    /// Write memory state for the active EA
+    fn flush_memory(&self) {
+        memory::write_memory(
+            &self.ea().state_dir,
+            &self.ea().session_name,
+            &self.agents,
+            self.manager(),
+            &self.client,
+        );
+    }
+
+    /// Reset focus navigation to the active EA root
+    fn reset_focus(&mut self) {
+        self.focus_parent = self.ea().session_name.clone();
+        self.focus_stack.clear();
+        self.manager_selected = true;
+        self.selected = 0;
+    }
+
+    /// Reload projects, agent parents, worker tasks, and focus indices for the active EA
+    fn reload_ea_state(&mut self) {
+        self.projects = projects::load_projects(&self.ea().state_dir);
+        self.agent_parents = memory::load_agent_parents(&self.ea().state_dir);
+        self.worker_tasks = memory::load_worker_tasks(&self.ea().state_dir);
+        self.focus_child_indices = self.compute_focus_child_indices();
+    }
+
+    /// Persist the current EA ID list to disk
+    fn persist_ea_ids(&self) {
+        let ids: Vec<String> = self.eas.iter().map(|e| e.id.clone()).collect();
+        memory::save_ea_ids(&ids);
+    }
+
+    /// Add a new EA, persist, and ensure its manager starts
+    pub fn add_ea(&mut self, id: &str) -> Result<()> {
+        // Sanitize: only allow alphanumeric, dash, underscore
+        if id.is_empty()
+            || !id
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        {
+            anyhow::bail!("EA ID must be alphanumeric (dashes/underscores allowed)");
+        }
+
+        // Check for duplicate
+        if self.eas.iter().any(|e| e.id == id) {
+            anyhow::bail!("EA '{}' already exists", id);
+        }
+
+        // Transitioning from single to multi-EA: adopt untracked agents
+        // into the default EA so they don't vanish from the dashboard.
+        if self.eas.len() == 1 {
+            let default_ea = &self.eas[0];
+            let mut parents = memory::load_agent_parents(&default_ea.state_dir);
+            let mut adopted = false;
+            for agent in &self.agents {
+                if !parents.contains_key(&agent.session.name) {
+                    parents.insert(agent.session.name.clone(), default_ea.session_name.clone());
+                    adopted = true;
+                }
+            }
+            if adopted {
+                memory::write_agent_parents(&default_ea.state_dir, &parents);
+            }
+        }
+
+        let ea = EaContext::new(id);
+        std::fs::create_dir_all(&ea.state_dir).ok();
+        self.eas.push(ea);
+        self.managers.push(None);
+        self.ea_summaries.push((0, 0));
+        self.persist_ea_ids();
+
+        // Switch to the new EA
+        self.active_ea = self.eas.len() - 1;
+        self.reset_focus();
+        self.reload_ea_state();
+
+        Ok(())
+    }
+
+    /// Remove an EA and kill all its sessions
+    pub fn remove_ea(&mut self, index: usize) -> Result<()> {
+        if self.eas.len() <= 1 {
+            anyhow::bail!("Cannot remove the last EA");
+        }
+        if index >= self.eas.len() {
+            anyhow::bail!("EA index out of range");
+        }
+
+        let ea = &self.eas[index];
+
+        // Kill the manager session
+        let _ = self.client.kill_session(&ea.session_name);
+
+        // Kill all agents that belong to this EA (workers/PMs)
+        let parents = memory::load_agent_parents(&ea.state_dir);
+        for child in parents.keys() {
+            let _ = self.client.kill_session(child);
+        }
+
+        self.eas.remove(index);
+        self.managers.remove(index);
+        self.ea_summaries.remove(index);
+        self.persist_ea_ids();
+
+        // Fix active_ea
+        if self.active_ea >= self.eas.len() {
+            self.active_ea = self.eas.len() - 1;
+        }
+        self.reset_focus();
+
+        Ok(())
+    }
+
+    /// Switch active EA by index
+    pub fn switch_ea(&mut self, index: usize) {
+        if index < self.eas.len() && index != self.active_ea {
+            self.active_ea = index;
+            self.reset_focus();
+            self.reload_ea_state();
+        }
+    }
+
+    /// Cycle to next EA
+    pub fn next_ea(&mut self) {
+        let next = (self.active_ea + 1) % self.eas.len();
+        self.switch_ea(next);
+    }
+
+    /// Cycle to previous EA
+    pub fn prev_ea(&mut self) {
+        let prev = if self.active_ea == 0 {
+            self.eas.len() - 1
+        } else {
+            self.active_ea - 1
+        };
+        self.switch_ea(prev);
     }
 
     /// Group agents into PM → worker hierarchies for grid display
@@ -311,18 +505,23 @@ impl App {
     /// Compute indices into self.agents for focus_parent's direct children
     fn compute_focus_child_indices(&self) -> Vec<usize> {
         let mut indices = Vec::new();
-        if self.focus_parent == MANAGER_SESSION {
-            // Root view: show agents that are direct children of EA, plus orphans
+        if self.focus_parent == self.ea().session_name {
+            // Root view: show agents that are direct children of EA
             for (i, agent) in self.agents.iter().enumerate() {
-                let parent = self.agent_parents.get(&agent.session.name);
-                match parent {
-                    // Explicit child of EA (manager session)
-                    Some(p) if *p == MANAGER_SESSION => indices.push(i),
-                    // Has a live parent that is NOT the EA → belongs deeper in the tree
-                    Some(p) if self.agents.iter().any(|a| a.session.name == *p) => {}
-                    // Parent is dead or missing → show as orphan at root
-                    _ => indices.push(i),
+                if let Some(p) = self.agent_parents.get(&agent.session.name) {
+                    if *p == self.ea().session_name {
+                        // Explicit child of EA
+                        indices.push(i);
+                    } else if !self.agents.iter().any(|a| a.session.name == *p) {
+                        // Parent is dead → show as orphan at root
+                        indices.push(i);
+                    }
+                    // else: has a live parent deeper in the tree
+                } else if self.eas.len() <= 1 {
+                    // Single EA: untracked agents show as orphans (backward compat)
+                    indices.push(i);
                 }
+                // Multi-EA: agents not in agent_parents belong to a different EA; skip.
             }
         } else {
             // Non-root: show agents whose parent matches focus_parent
@@ -347,8 +546,8 @@ impl App {
 
     /// Get AgentInfo for the focus parent
     pub fn focus_parent_info(&self) -> Option<&AgentInfo> {
-        if self.focus_parent == MANAGER_SESSION {
-            self.manager.as_ref()
+        if self.focus_parent == self.ea().session_name {
+            self.manager()
         } else {
             self.agents
                 .iter()
@@ -358,7 +557,7 @@ impl App {
 
     /// Check if an agent has children (is a PM or EA)
     fn agent_has_children(&self, session_name: &str) -> bool {
-        if session_name == MANAGER_SESSION {
+        if session_name == self.ea().session_name {
             return true;
         }
         self.agent_parents.values().any(|p| p == session_name)
@@ -366,9 +565,8 @@ impl App {
 
     /// Count children for a given agent
     pub fn child_count(&self, session_name: &str) -> usize {
-        if session_name == MANAGER_SESSION {
-            // Count PMs + orphans
-            return self.compute_focus_child_indices().len();
+        if session_name == self.ea().session_name {
+            return self.focus_child_indices.len();
         }
         self.agent_parents
             .values()
@@ -380,7 +578,7 @@ impl App {
     pub fn breadcrumb(&self) -> Vec<String> {
         let mut crumbs: Vec<String> = vec!["EA".to_string()];
         for session in &self.focus_stack {
-            if *session == MANAGER_SESSION {
+            if *session == self.ea().session_name {
                 continue; // Already added EA
             }
             let short = session
@@ -389,7 +587,7 @@ impl App {
             crumbs.push(short.to_string());
         }
         // Add current focus parent if not EA
-        if self.focus_parent != MANAGER_SESSION {
+        if self.focus_parent != self.ea().session_name {
             let short = self
                 .focus_parent
                 .strip_prefix(&self.session_prefix)
@@ -524,25 +722,25 @@ impl App {
             // Safety: don't kill attached sessions (user's terminal)
             if agent.session.attached {
                 self.status_message = Some("Cannot kill attached session".to_string());
-                self.pending_confirm = None;
+                self.show_confirm_kill = false;
                 return Ok(());
             }
 
             // Safety: don't kill manager from 'd' key (use separate mechanism)
-            if agent.session.name == MANAGER_SESSION {
+            if agent.session.name == self.ea().session_name {
                 self.status_message = Some("Cannot kill manager with 'd'".to_string());
-                self.pending_confirm = None;
+                self.show_confirm_kill = false;
                 return Ok(());
             }
 
             let name = agent.session.name.clone();
             self.client.kill_session(&name)?;
-            memory::remove_agent_parent(&name);
+            memory::remove_agent_parent(&self.ea().state_dir, &name);
             self.status_message = Some(format!("Killed agent: {}", name));
             self.refresh()?;
-            memory::write_memory(&self.agents, self.manager.as_ref(), &self.client);
+            self.flush_memory();
         }
-        self.pending_confirm = None;
+        self.show_confirm_kill = false;
         Ok(())
     }
 
@@ -577,9 +775,7 @@ impl App {
 
         let name = self.generate_agent_name();
         let workdir = if self.default_workdir == "." {
-            std::env::current_dir()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_else(|_| ".".to_string())
+            current_workdir()
         } else {
             self.default_workdir.clone()
         };
@@ -596,7 +792,7 @@ impl App {
             self.selected = pos;
         }
 
-        memory::write_memory(&self.agents, self.manager.as_ref(), &self.client);
+        self.flush_memory();
 
         Ok(())
     }
@@ -606,16 +802,9 @@ impl App {
         self.status_message = Some(msg.into());
     }
 
-    /// Set a persistent warning that survives clear_status() calls
-    pub fn set_persistent_warning(&mut self, msg: impl Into<String>) {
-        let msg = msg.into();
-        self.persistent_warning = Some(msg.clone());
-        self.status_message = Some(msg);
-    }
-
-    /// Clear status message (persistent warnings are restored)
+    /// Clear status message
     pub fn clear_status(&mut self) {
-        self.status_message = self.persistent_warning.clone();
+        self.status_message = None;
     }
 
     /// Get counts by health state: (running, idle)
@@ -631,7 +820,7 @@ impl App {
             }
         }
 
-        if let Some(ref manager) = self.manager {
+        if let Some(manager) = self.manager() {
             match manager.health {
                 HealthState::Running => running += 1,
                 HealthState::Idle => idle += 1,
@@ -643,7 +832,7 @@ impl App {
 
     /// Get total agent count (including manager)
     pub fn total_agents(&self) -> usize {
-        self.agents.len() + if self.manager.is_some() { 1 } else { 0 }
+        self.agents.len() + if self.manager().is_some() { 1 } else { 0 }
     }
 
     /// Get focus parent pane output (more lines for display)
@@ -658,16 +847,16 @@ impl App {
 
     /// Add a project and update memory
     pub fn add_project(&mut self, name: &str) {
-        let _ = projects::add_project(name);
-        self.projects = projects::load_projects();
-        memory::write_memory(&self.agents, self.manager.as_ref(), &self.client);
+        let _ = projects::add_project(&self.ea().state_dir, name);
+        self.projects = projects::load_projects(&self.ea().state_dir);
+        self.flush_memory();
     }
 
     /// Complete (remove) a project by id and update memory
     pub fn complete_project(&mut self, id: usize) {
-        let _ = projects::remove_project(id);
-        self.projects = projects::load_projects();
-        memory::write_memory(&self.agents, self.manager.as_ref(), &self.client);
+        let _ = projects::remove_project(&self.ea().state_dir, id);
+        self.projects = projects::load_projects(&self.ea().state_dir);
+        self.flush_memory();
     }
 }
 
@@ -738,6 +927,70 @@ pub fn build_agent_groups<'a>(
     groups
 }
 
+/// Build a multi-root command tree — one subtree per EA.
+///
+/// The active EA is fully expanded. Non-active EAs show a single collapsed
+/// root node with a summary (agent count, running count).
+pub fn build_multi_tree(
+    agents: &[AgentInfo],
+    managers: &[Option<AgentInfo>],
+    agent_parents: &HashMap<String, String>,
+    session_prefix: &str,
+    eas: &[EaContext],
+    active_ea: usize,
+    ea_summaries: &[(usize, usize)],
+) -> Vec<CommandTreeNode> {
+    let mut nodes = Vec::new();
+    for (i, ea) in eas.iter().enumerate() {
+        let manager = managers.get(i).and_then(|m| m.as_ref());
+        let is_last_root = i == eas.len() - 1;
+
+        if i == active_ea {
+            // Active EA: full subtree
+            let subtree = build_tree(
+                agents,
+                manager,
+                agent_parents,
+                session_prefix,
+                ea,
+                eas.len() > 1,
+            );
+            for (j, mut node) in subtree.into_iter().enumerate() {
+                if j == 0 && eas.len() > 1 {
+                    node.is_last_sibling = is_last_root;
+                }
+                nodes.push(node);
+            }
+        } else {
+            // Non-active EA: collapsed root with pre-computed summary
+            let ea_health = manager.map(|m| m.health).unwrap_or(HealthState::Idle);
+            let (child_count, running) = ea_summaries.get(i).copied().unwrap_or((0, 0));
+
+            let summary = if child_count == 0 {
+                format!("{} (no agents)", ea.display_name)
+            } else {
+                format!(
+                    "{} ({} agent{}, {} running)",
+                    ea.display_name,
+                    child_count,
+                    if child_count == 1 { "" } else { "s" },
+                    running
+                )
+            };
+
+            nodes.push(CommandTreeNode {
+                name: summary,
+                session_name: ea.session_name.clone(),
+                health: ea_health,
+                depth: 0,
+                is_last_sibling: is_last_root,
+                ancestor_is_last: vec![],
+            });
+        }
+    }
+    nodes
+}
+
 /// Build the chain-of-command tree from current agents and parent mappings.
 ///
 /// Tree structure (recursive, arbitrary depth):
@@ -751,14 +1004,16 @@ pub fn build_tree(
     manager: Option<&AgentInfo>,
     agent_parents: &HashMap<String, String>,
     session_prefix: &str,
+    ea: &EaContext,
+    multi_ea: bool,
 ) -> Vec<CommandTreeNode> {
     let mut nodes = Vec::new();
 
     // Root: EA
     let ea_health = manager.map(|m| m.health).unwrap_or(HealthState::Idle);
     nodes.push(CommandTreeNode {
-        name: "Executive Assistant".to_string(),
-        session_name: MANAGER_SESSION.to_string(),
+        name: ea.display_name.clone(),
+        session_name: ea.session_name.clone(),
         health: ea_health,
         depth: 0,
         is_last_sibling: true,
@@ -772,7 +1027,7 @@ pub fn build_tree(
     for agent in agents {
         if let Some(parent_session) = agent_parents.get(&agent.session.name) {
             // Check that the parent actually exists (either as agent or EA)
-            let parent_exists = *parent_session == MANAGER_SESSION
+            let parent_exists = *parent_session == ea.session_name
                 || agents.iter().any(|a| a.session.name == *parent_session);
             if parent_exists {
                 children_map
@@ -780,15 +1035,18 @@ pub fn build_tree(
                     .or_default()
                     .push(agent);
             } else {
+                // Parent listed but no longer running — show as orphan under this EA
                 orphans.push(agent);
             }
-        } else {
+        } else if !multi_ea {
+            // Single EA: untracked agents show as orphans (backward compat)
             orphans.push(agent);
         }
+        // Multi-EA: agents not in agent_parents belong to a different EA; skip.
     }
 
     // Recursively add nodes starting from EA's children
-    let ea_children = children_map.get(MANAGER_SESSION);
+    let ea_children = children_map.get(&ea.session_name as &str);
     let total_root_children = ea_children.map(|c| c.len()).unwrap_or(0) + orphans.len();
 
     #[allow(clippy::too_many_arguments)]
@@ -849,7 +1107,7 @@ pub fn build_tree(
     add_children(
         &mut nodes,
         &children_map,
-        MANAGER_SESSION,
+        &ea.session_name,
         1,
         &[true], // EA is always last at depth 0
         session_prefix,
@@ -901,6 +1159,7 @@ pub fn build_tree(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::manager::MANAGER_SESSION;
     use crate::tmux::{HealthInfo, HealthState, Session};
 
     fn make_agent(name: &str, health: HealthState) -> AgentInfo {
@@ -1061,7 +1320,14 @@ mod tests {
         let agents = vec![];
         let ea = make_agent("omar-agent-ea", HealthState::Running);
         let parents = HashMap::new();
-        let tree = build_tree(&agents, Some(&ea), &parents, "omar-agent-");
+        let tree = build_tree(
+            &agents,
+            Some(&ea),
+            &parents,
+            "omar-agent-",
+            &EaContext::default(),
+            false,
+        );
 
         assert_eq!(tree.len(), 1);
         assert_eq!(tree[0].name, "Executive Assistant");
@@ -1090,7 +1356,14 @@ mod tests {
             "omar-agent-rest-api".to_string(),
         );
 
-        let tree = build_tree(&agents, Some(&ea), &parents, "omar-agent-");
+        let tree = build_tree(
+            &agents,
+            Some(&ea),
+            &parents,
+            "omar-agent-",
+            &EaContext::default(),
+            false,
+        );
 
         // EA + rest-api + 2 children = 4 nodes
         assert_eq!(tree.len(), 4);
@@ -1109,14 +1382,32 @@ mod tests {
 
     #[test]
     fn test_build_tree_orphan_agents() {
+        // Agents tracked by this EA (in agent_parents) but whose parent
+        // session doesn't exist should show as orphans under the EA.
         let agents = vec![
             make_agent("omar-agent-debug", HealthState::Running),
             make_agent("omar-agent-test", HealthState::Idle),
         ];
         let ea = make_agent("omar-agent-ea", HealthState::Running);
-        let parents = HashMap::new();
+        let mut parents = HashMap::new();
+        // Both agents point to a dead parent → orphan under EA
+        parents.insert(
+            "omar-agent-debug".to_string(),
+            "omar-agent-dead-pm".to_string(),
+        );
+        parents.insert(
+            "omar-agent-test".to_string(),
+            "omar-agent-dead-pm".to_string(),
+        );
 
-        let tree = build_tree(&agents, Some(&ea), &parents, "omar-agent-");
+        let tree = build_tree(
+            &agents,
+            Some(&ea),
+            &parents,
+            "omar-agent-",
+            &EaContext::default(),
+            false,
+        );
 
         // EA + 2 orphans directly under EA = 3 nodes
         assert_eq!(tree.len(), 3);
@@ -1142,7 +1433,14 @@ mod tests {
         parents.insert("omar-agent-b".to_string(), "omar-agent-a".to_string());
         parents.insert("omar-agent-c".to_string(), "omar-agent-b".to_string());
 
-        let tree = build_tree(&agents, Some(&ea), &parents, "omar-agent-");
+        let tree = build_tree(
+            &agents,
+            Some(&ea),
+            &parents,
+            "omar-agent-",
+            &EaContext::default(),
+            false,
+        );
 
         assert_eq!(tree.len(), 4);
         assert_eq!(tree[0].name, "Executive Assistant");
@@ -1165,7 +1463,14 @@ mod tests {
             "omar-agent-gone".to_string(),
         );
 
-        let tree = build_tree(&agents, Some(&ea), &parents, "omar-agent-");
+        let tree = build_tree(
+            &agents,
+            Some(&ea),
+            &parents,
+            "omar-agent-",
+            &EaContext::default(),
+            false,
+        );
 
         // worker1 should be orphan under EA since parent doesn't exist
         assert_eq!(tree.len(), 2);
@@ -1177,7 +1482,7 @@ mod tests {
 
     #[test]
     fn test_focus_children_root_shows_direct_ea_children_and_orphans() {
-        // EA -> api (with children: api-worker, auth), orphan
+        // EA -> api (with children: api-worker, auth), orphan (dead parent)
         let agents = [
             make_agent("omar-agent-api", HealthState::Running),
             make_agent("omar-agent-api-worker", HealthState::Running),
@@ -1191,19 +1496,23 @@ mod tests {
             "omar-agent-api".to_string(),
         );
         parents.insert("omar-agent-auth".to_string(), "omar-agent-api".to_string());
+        // Orphan's parent is dead — tracked by this EA but parent session gone
+        parents.insert(
+            "omar-agent-orphan".to_string(),
+            "omar-agent-dead-pm".to_string(),
+        );
 
-        // Compute focus children at root using the new logic
+        // Compute focus children at root (only agents in agent_parents)
         let mut indices = Vec::new();
         for (i, agent) in agents.iter().enumerate() {
-            let parent = parents.get(&agent.session.name);
-            match parent {
-                Some(p) if *p == MANAGER_SESSION => indices.push(i),
-                Some(p) if agents.iter().any(|a| a.session.name == *p) => {}
-                _ => indices.push(i),
+            if let Some(p) = parents.get(&agent.session.name) {
+                if *p == MANAGER_SESSION || !agents.iter().any(|a| a.session.name == *p) {
+                    indices.push(i);
+                }
             }
         }
 
-        // Root should show: api (EA child) + orphan (no parent)
+        // Root should show: api (EA child) + orphan (dead parent)
         assert_eq!(indices.len(), 2);
         assert_eq!(agents[indices[0]].session.name, "omar-agent-api");
         assert_eq!(agents[indices[1]].session.name, "omar-agent-orphan");
@@ -1294,5 +1603,69 @@ mod tests {
             crumbs.push(short.to_string());
         }
         assert_eq!(crumbs, vec!["EA", "rest-api"]);
+    }
+
+    #[test]
+    fn test_build_multi_tree_active_expanded_others_collapsed() {
+        let agents = vec![
+            make_agent("omar-agent-pm-rest-api", HealthState::Running),
+            make_agent("omar-agent-worker-1", HealthState::Idle),
+        ];
+        let ea_default = EaContext::default();
+        let ea_backend = EaContext::new("backend");
+        let eas = vec![ea_default.clone(), ea_backend.clone()];
+
+        let managers = vec![
+            Some(make_agent(MANAGER_SESSION, HealthState::Running)),
+            Some(make_agent(&ea_backend.session_name, HealthState::Running)),
+        ];
+
+        let mut parents = HashMap::new();
+        parents.insert(
+            "omar-agent-pm-rest-api".to_string(),
+            MANAGER_SESSION.to_string(),
+        );
+        parents.insert(
+            "omar-agent-worker-1".to_string(),
+            "omar-agent-pm-rest-api".to_string(),
+        );
+
+        // Pre-computed summaries: active EA (unused), backend EA (0 agents)
+        let ea_summaries = vec![(0, 0), (0, 0)];
+
+        // Active EA = 0 (default): first EA expanded, second collapsed
+        let tree = build_multi_tree(
+            &agents,
+            &managers,
+            &parents,
+            "omar-agent-",
+            &eas,
+            0,
+            &ea_summaries,
+        );
+
+        // First node: active EA root (expanded)
+        assert_eq!(tree[0].depth, 0);
+        assert_eq!(tree[0].session_name, MANAGER_SESSION);
+        assert!(!tree[0].is_last_sibling); // not last — there's a second EA
+
+        // There should be child nodes (PM + worker) for the active EA
+        let active_children: Vec<_> = tree.iter().skip(1).take_while(|n| n.depth > 0).collect();
+        assert!(
+            !active_children.is_empty(),
+            "active EA should have expanded children"
+        );
+
+        // Last node: collapsed EA root
+        let last = tree.last().unwrap();
+        assert_eq!(last.depth, 0);
+        assert_eq!(last.session_name, ea_backend.session_name);
+        assert!(last.is_last_sibling);
+        // Collapsed EA name includes summary
+        assert!(
+            last.name.contains("EA: backend"),
+            "collapsed name should contain EA display name: {}",
+            last.name
+        );
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{self, Event, KeyEvent};
+use crossterm::event::{self, Event, KeyEvent, KeyEventKind};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -45,7 +45,7 @@ impl EventHandler {
                         // Poll for crossterm events
                         if event::poll(Duration::from_millis(0)).unwrap_or(false) {
                             match event::read() {
-                                Ok(Event::Key(key)) => AppEvent::Key(key),
+                                Ok(Event::Key(key)) if key.kind == KeyEventKind::Press => AppEvent::Key(key),
                                 Ok(Event::Resize(w, h)) => AppEvent::Resize(w, h),
                                 _ => continue,
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use tokio::sync::Mutex;
 use app::App;
 use config::Config;
 use event::{AppEvent, EventHandler};
+use manager::EaContext;
 use tmux::TmuxClient;
 
 /// Tmux session name used when omar auto-launches into tmux
@@ -79,9 +80,6 @@ enum Commands {
         #[command(subcommand)]
         action: Option<ManagerAction>,
     },
-
-    /// Configure tmux for optimal omar experience
-    SetupTmux,
 }
 
 #[derive(Subcommand)]
@@ -112,15 +110,17 @@ async fn main() -> Result<()> {
         }
         Some(Commands::List) => list_agents(&client),
         Some(Commands::Kill { name }) => kill_agent(&client, &name),
-        Some(Commands::SetupTmux) => setup_tmux(),
-        Some(Commands::Manager { action }) => match action {
-            Some(ManagerAction::Start) | None => {
-                manager::start_manager(&client, &config.agent.default_command)
+        Some(Commands::Manager { action }) => {
+            let ea = EaContext::default();
+            match action {
+                Some(ManagerAction::Start) | None => {
+                    manager::start_manager(&client, &config.agent.default_command, &ea)
+                }
+                Some(ManagerAction::Orchestrate) => {
+                    manager::run_manager_orchestration(&client, &config.agent.default_command, &ea)
+                }
             }
-            Some(ManagerAction::Orchestrate) => {
-                manager::run_manager_orchestration(&client, &config.agent.default_command)
-            }
-        },
+        }
         None => {
             if std::env::var("TMUX").is_err() {
                 relaunch_in_tmux()
@@ -201,139 +201,6 @@ fn relaunch_in_tmux() -> Result<()> {
     // exec() replaces the current process; only returns on error
     let err = cmd.exec();
     anyhow::bail!("Failed to launch tmux: {}", err)
-}
-
-/// Recommended tmux settings for omar, keyed by option name.
-const TMUX_RECOMMENDED: &[(&str, &str, &str)] = &[
-    ("mouse", "set -g mouse on", "mouse scrolling and selection"),
-    (
-        "extended-keys",
-        "set -g extended-keys on",
-        "Shift+Enter in agents",
-    ),
-    (
-        "set-clipboard",
-        "set -g set-clipboard on",
-        "clipboard integration",
-    ),
-];
-
-/// Additional raw lines that need to appear in tmux.conf (checked by substring).
-const TMUX_EXTRA_LINES: &[(&str, &str, &str)] = &[
-    (
-        "terminal-features',*:extkeys'",
-        "set -as terminal-features ',*:extkeys'",
-        "extended key passthrough",
-    ),
-    (
-        "terminal-features',*:clipboard'",
-        "set -as terminal-features ',*:clipboard'",
-        "clipboard passthrough",
-    ),
-];
-
-/// Check if any recommended tmux settings are missing.
-fn tmux_setup_needed() -> bool {
-    for &(opt, _, _) in TMUX_RECOMMENDED {
-        if let Ok(out) = std::process::Command::new("tmux")
-            .args(["show-options", "-gv", opt])
-            .output()
-        {
-            let val = String::from_utf8_lossy(&out.stdout);
-            if val.trim() != "on" {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// Interactive tmux configuration setup.
-fn setup_tmux() -> Result<()> {
-    use std::io::Write;
-
-    let conf_path = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".tmux.conf");
-
-    let existing = std::fs::read_to_string(&conf_path).unwrap_or_default();
-
-    // Collect missing settings
-    let mut to_add: Vec<(&str, &str)> = Vec::new();
-
-    for &(opt, line, desc) in TMUX_RECOMMENDED {
-        if !existing.contains(line) {
-            // Also check if the option is already set at runtime
-            let already_on = std::process::Command::new("tmux")
-                .args(["show-options", "-gv", opt])
-                .output()
-                .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "on")
-                .unwrap_or(false);
-            if !already_on {
-                to_add.push((line, desc));
-            }
-        }
-    }
-
-    let normalized = existing.replace(' ', "");
-    for &(needle, line, desc) in TMUX_EXTRA_LINES {
-        if !normalized.contains(needle) {
-            to_add.push((line, desc));
-        }
-    }
-
-    if to_add.is_empty() {
-        println!("✓ tmux is already configured for omar.");
-        return Ok(());
-    }
-
-    println!(
-        "The following settings will be added to {}:\n",
-        conf_path.display()
-    );
-    for (line, desc) in &to_add {
-        println!("  {}  # {}", line, desc);
-    }
-
-    print!("\nApply? [Y/n] ");
-    std::io::stdout().flush()?;
-
-    let mut input = String::new();
-    std::io::stdin().read_line(&mut input)?;
-    let input = input.trim().to_lowercase();
-
-    if !input.is_empty() && input != "y" && input != "yes" {
-        println!("Aborted.");
-        return Ok(());
-    }
-
-    // Append to tmux.conf
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&conf_path)?;
-
-    writeln!(file, "\n# omar recommended settings")?;
-    for (line, _) in &to_add {
-        writeln!(file, "{}", line)?;
-    }
-
-    // Apply to running tmux server
-    if std::process::Command::new("tmux")
-        .args(["list-sessions"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-    {
-        let _ = std::process::Command::new("tmux")
-            .args(["source-file", &conf_path.to_string_lossy()])
-            .status();
-        println!("✓ Applied to ~/.tmux.conf and reloaded tmux.");
-    } else {
-        println!("✓ Applied to ~/.tmux.conf (tmux not running, will take effect next session).");
-    }
-
-    Ok(())
 }
 
 /// Locate the `omar-slack` binary. Checks next to the current executable
@@ -449,6 +316,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
         scheduler.clone(),
         ticker.clone(),
         popup_receiver.clone(),
+        config.dashboard.session_prefix.clone(),
     ));
 
     // Start API server if enabled
@@ -490,11 +358,6 @@ async fn run_dashboard(config: Config) -> Result<()> {
         _ => {}
     }
 
-    // Warn if tmux config is missing recommended settings
-    if tmux_setup_needed() {
-        app.set_persistent_warning("⚠ tmux not configured for omar — run 'omar setup-tmux' to fix");
-    }
-
     // Initial refresh
     if let Err(e) = app.refresh() {
         app.set_status(format!("Error: {}", e));
@@ -512,6 +375,40 @@ async fn run_dashboard(config: Config) -> Result<()> {
         if let Some(event) = events.next().await {
             match event {
                 AppEvent::Key(key) => {
+                    // Handle EA input mode
+                    if app.ea_input_mode {
+                        match key.code {
+                            KeyCode::Esc => {
+                                app.ea_input_mode = false;
+                                app.ea_input.clear();
+                            }
+                            KeyCode::Enter => {
+                                let id = app.ea_input.clone();
+                                let id = id.trim();
+                                if !id.is_empty() {
+                                    match app.add_ea(id) {
+                                        Ok(()) => {
+                                            app.set_status(format!("EA '{}' created", id));
+                                        }
+                                        Err(e) => {
+                                            app.set_status(format!("Error: {}", e));
+                                        }
+                                    }
+                                }
+                                app.ea_input_mode = false;
+                                app.ea_input.clear();
+                            }
+                            KeyCode::Backspace => {
+                                app.ea_input.pop();
+                            }
+                            KeyCode::Char(c) => {
+                                app.ea_input.push(c);
+                            }
+                            _ => {}
+                        }
+                        continue;
+                    }
+
                     // Handle project input mode
                     if app.project_input_mode {
                         match key.code {
@@ -539,23 +436,38 @@ async fn run_dashboard(config: Config) -> Result<()> {
                         continue;
                     }
 
-                    // Handle confirmation dialog (kill or quit)
-                    if let Some(action) = app.pending_confirm {
+                    // Handle confirmation dialog
+                    if app.show_confirm_kill {
                         match key.code {
-                            KeyCode::Char('y') | KeyCode::Char('Y') => match action {
-                                app::ConfirmAction::Kill => {
-                                    if let Err(e) = app.kill_selected() {
+                            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                                if let Err(e) = app.kill_selected() {
+                                    app.set_status(format!("Error: {}", e));
+                                }
+                            }
+                            _ => {
+                                app.show_confirm_kill = false;
+                            }
+                        }
+                        continue;
+                    }
+
+                    // Handle EA kill confirmation dialog
+                    if app.show_confirm_kill_ea {
+                        match key.code {
+                            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                                let name = app.ea().display_name.clone();
+                                match app.remove_ea(app.active_ea) {
+                                    Ok(()) => {
+                                        app.set_status(format!("Removed EA '{}'", name));
+                                    }
+                                    Err(e) => {
                                         app.set_status(format!("Error: {}", e));
                                     }
                                 }
-                                app::ConfirmAction::Quit => {
-                                    app.should_quit = true;
-                                }
-                            },
-                            _ => {
-                                app.pending_confirm = None;
                             }
+                            _ => {}
                         }
+                        app.show_confirm_kill_ea = false;
                         continue;
                     }
 
@@ -568,7 +480,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
                     // Handle events popup
                     if app.show_events {
                         match key.code {
-                            KeyCode::Esc | KeyCode::Char('e') => {
+                            KeyCode::Esc | KeyCode::Char('e') | KeyCode::Char('q') => {
                                 app.show_events = false;
                             }
                             _ => {}
@@ -579,7 +491,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
                     // Handle debug console popup
                     if app.show_debug_console {
                         match key.code {
-                            KeyCode::Esc | KeyCode::Char('D') => {
+                            KeyCode::Esc | KeyCode::Char('D') | KeyCode::Char('q') => {
                                 app.show_debug_console = false;
                             }
                             _ => {}
@@ -589,11 +501,13 @@ async fn run_dashboard(config: Config) -> Result<()> {
 
                     // Normal key handling
                     match key.code {
-                        KeyCode::Char('Q') => {
-                            app.pending_confirm = Some(app::ConfirmAction::Quit);
+                        KeyCode::Char('q') => {
+                            app.should_quit = true;
                         }
                         KeyCode::Esc => {
-                            app.drill_up();
+                            if !app.drill_up() {
+                                app.should_quit = true;
+                            }
                         }
                         KeyCode::Tab | KeyCode::Right => {
                             app.drill_down();
@@ -602,7 +516,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
                             app.drill_up();
                         }
                         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.pending_confirm = Some(app::ConfirmAction::Quit);
+                            app.should_quit = true;
                         }
                         KeyCode::Char('j') | KeyCode::Down => {
                             app.next();
@@ -653,7 +567,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
                         }
                         KeyCode::Char('d') => {
                             if app.selected_agent().is_some() {
-                                app.pending_confirm = Some(app::ConfirmAction::Kill);
+                                app.show_confirm_kill = true;
                             }
                         }
                         KeyCode::Char('p') => {
@@ -670,6 +584,24 @@ async fn run_dashboard(config: Config) -> Result<()> {
                             app.scheduled_events = scheduler.list();
                             app.scheduled_events.sort_by_key(|e| e.timestamp);
                             app.show_events = true;
+                        }
+                        KeyCode::Char('E') => {
+                            app.ea_input_mode = true;
+                        }
+                        KeyCode::Char('X') => {
+                            if app.eas.len() > 1 {
+                                app.show_confirm_kill_ea = true;
+                            } else {
+                                app.set_status("Cannot remove the last EA");
+                            }
+                        }
+                        KeyCode::Char(']') => {
+                            app.next_ea();
+                            app.set_status(format!("Switched to {}", app.ea().display_name));
+                        }
+                        KeyCode::Char('[') => {
+                            app.prev_ea();
+                            app.set_status(format!("Switched to {}", app.ea().display_name));
                         }
                         KeyCode::Char('D') => {
                             app.show_debug_console = true;
@@ -720,13 +652,9 @@ async fn run_dashboard(config: Config) -> Result<()> {
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
 
-    // Kill the EA session on exit
-    if app
-        .client()
-        .has_session(crate::manager::MANAGER_SESSION)
-        .unwrap_or(false)
-    {
-        let _ = app.client().kill_session(crate::manager::MANAGER_SESSION);
+    // Kill all EA sessions on exit
+    for ea in &app.eas {
+        let _ = app.client().kill_session(&ea.session_name);
     }
 
     // Kill Slack bridge on exit

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -12,8 +12,58 @@ use crate::memory;
 use crate::tmux::TmuxClient;
 use protocol::{parse_manager_message, ManagerMessage, ProposedAgent};
 
-/// Manager session name (exported for use in app.rs)
+/// Legacy constant — use `EaContext` instead.
 pub const MANAGER_SESSION: &str = "omar-agent-ea";
+
+/// The EA ID used for the default (legacy) EA instance.
+pub const DEFAULT_EA_ID: &str = "default";
+
+/// Context for a single EA instance. Encapsulates the session name,
+/// display name, and state directory so the codebase can support
+/// multiple EAs without hardcoded constants.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct EaContext {
+    /// Short identifier (e.g. "default", "backend")
+    pub id: String,
+    /// Full tmux session name (e.g. "omar-agent-ea")
+    pub session_name: String,
+    /// Human-readable name for UI (e.g. "Executive Assistant")
+    pub display_name: String,
+    /// Root directory for this EA's persistent state (e.g. ~/.omar/)
+    pub state_dir: PathBuf,
+}
+
+impl EaContext {
+    /// Create a new EA with the given ID.
+    /// - `"default"` produces the legacy layout (session `"omar-agent-ea"`, state in `~/.omar/`)
+    /// - Any other ID produces `"omar-agent-ea-{id}"` and `~/.omar/{id}/`
+    pub fn new(id: &str) -> Self {
+        let base = memory::omar_base_dir();
+
+        if id == DEFAULT_EA_ID {
+            Self {
+                id: DEFAULT_EA_ID.to_string(),
+                session_name: MANAGER_SESSION.to_string(),
+                display_name: "Executive Assistant".to_string(),
+                state_dir: base,
+            }
+        } else {
+            Self {
+                id: id.to_string(),
+                session_name: format!("omar-agent-ea-{}", id),
+                display_name: format!("EA: {}", id),
+                state_dir: base.join(id),
+            }
+        }
+    }
+}
+
+impl Default for EaContext {
+    fn default() -> Self {
+        Self::new(DEFAULT_EA_ID)
+    }
+}
 
 // Embed prompt files at compile time so they work regardless of CWD.
 const PROMPT_EA: &str = include_str!("../../prompts/executive-assistant.md");
@@ -29,12 +79,10 @@ const EMBEDDED_PROMPTS: &[(&str, &str)] = &[
     ("agent.md", PROMPT_AGENT),
 ];
 
-/// Return the `~/.omar/prompts/` directory, writing embedded prompts on first call.
-pub fn prompts_dir() -> PathBuf {
-    let dir = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".omar")
-        .join("prompts");
+/// Return the prompts directory inside the EA's state dir, writing
+/// embedded prompts on first call.
+pub fn prompts_dir(ea: &EaContext) -> PathBuf {
+    let dir = ea.state_dir.join("prompts");
     std::fs::create_dir_all(&dir).ok();
 
     for (name, content) in EMBEDDED_PROMPTS {
@@ -93,11 +141,11 @@ pub fn build_agent_command(
 /// Build an EA command with memory state baked into the system prompt.
 ///
 /// Reads the EA prompt, appends the latest memory snapshot, writes a
-/// combined file to `~/.omar/ea_prompt_combined.md`, and returns the
-/// CLI command with the combined file as the system prompt.
-pub fn build_ea_command(base_command: &str) -> String {
-    let prompt_file = prompts_dir().join("executive-assistant.md");
-    let mem = memory::load_memory();
+/// combined file to the EA's state directory, and returns the CLI
+/// command with the combined file as the system prompt.
+pub fn build_ea_command(base_command: &str, ea: &EaContext) -> String {
+    let prompt_file = prompts_dir(ea).join("executive-assistant.md");
+    let mem = memory::load_memory(&ea.state_dir);
 
     if mem.is_empty() {
         return build_agent_command(base_command, &prompt_file, &[]);
@@ -109,32 +157,28 @@ pub fn build_ea_command(base_command: &str) -> String {
         prompt_content, mem
     );
 
-    let combined_path = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".omar")
-        .join("ea_prompt_combined.md");
-    std::fs::create_dir_all(combined_path.parent().unwrap()).ok();
+    let combined_path = ea.state_dir.join("ea_prompt_combined.md");
     std::fs::write(&combined_path, &combined).ok();
 
     build_agent_command(base_command, &combined_path, &[])
 }
 
 /// Start the manager agent session
-pub fn start_manager(client: &TmuxClient, command: &str) -> Result<()> {
+pub fn start_manager(client: &TmuxClient, command: &str, ea: &EaContext) -> Result<()> {
     // Check if manager already exists
-    if client.has_session(MANAGER_SESSION)? {
+    if client.has_session(&ea.session_name)? {
         println!("Manager session already exists. Attaching...");
-        client.attach_session(MANAGER_SESSION)?;
+        client.attach_session(&ea.session_name)?;
         return Ok(());
     }
 
     // Build command with EA system prompt + memory baked in
-    let cmd = build_ea_command(command);
+    let cmd = build_ea_command(command, ea);
 
     // Create manager session — system prompt set at process start
     println!("Starting manager agent...");
     client.new_session(
-        MANAGER_SESSION,
+        &ea.session_name,
         &cmd,
         Some(&std::env::current_dir()?.to_string_lossy()),
     )?;
@@ -144,19 +188,19 @@ pub fn start_manager(client: &TmuxClient, command: &str) -> Result<()> {
 
     // Attach to the session
     println!("Attaching to manager session...");
-    client.attach_session(MANAGER_SESSION)?;
+    client.attach_session(&ea.session_name)?;
 
     Ok(())
 }
 
 /// Run the manager in orchestration mode (interactive)
-pub fn run_manager_orchestration(client: &TmuxClient, command: &str) -> Result<()> {
+pub fn run_manager_orchestration(client: &TmuxClient, command: &str, ea: &EaContext) -> Result<()> {
     println!("=== OMAR Manager Orchestration Mode ===\n");
 
     // Check if manager exists
-    if !client.has_session(MANAGER_SESSION)? {
+    if !client.has_session(&ea.session_name)? {
         println!("No manager session found. Starting one...");
-        start_manager(client, command)?;
+        start_manager(client, command, ea)?;
         return Ok(());
     }
 
@@ -174,19 +218,19 @@ pub fn run_manager_orchestration(client: &TmuxClient, command: &str) -> Result<(
                 print_help();
             }
             "status" | "s" => {
-                show_status(client)?;
+                show_status(client, ea)?;
             }
             "attach" | "a" => {
-                client.attach_session(MANAGER_SESSION)?;
+                client.attach_session(&ea.session_name)?;
             }
             "check" | "c" => {
-                check_manager_output(client)?;
+                check_manager_output(client, ea)?;
             }
             "approve" | "y" => {
-                approve_plan(client, command)?;
+                approve_plan(client, command, ea)?;
             }
             "reject" | "n" => {
-                reject_plan(client)?;
+                reject_plan(client, ea)?;
             }
             "quit" | "q" => {
                 println!("Exiting orchestration mode.");
@@ -202,7 +246,7 @@ pub fn run_manager_orchestration(client: &TmuxClient, command: &str) -> Result<(
             }
             _ if !input.is_empty() => {
                 // Send to manager as a request
-                send_to_manager(client, input)?;
+                send_to_manager(client, input, ea)?;
             }
             _ => {}
         }
@@ -227,12 +271,12 @@ OMAR Manager Commands:
     );
 }
 
-fn show_status(client: &TmuxClient) -> Result<()> {
+fn show_status(client: &TmuxClient, ea: &EaContext) -> Result<()> {
     println!("\n=== Agent Status ===");
 
     // Show manager
-    if client.has_session(MANAGER_SESSION)? {
-        let output = client.capture_pane(MANAGER_SESSION, 3)?;
+    if client.has_session(&ea.session_name)? {
+        let output = client.capture_pane(&ea.session_name, 3)?;
         println!("Manager: Active");
         println!(
             "  Last output: {}",
@@ -261,8 +305,8 @@ fn show_status(client: &TmuxClient) -> Result<()> {
     Ok(())
 }
 
-fn check_manager_output(client: &TmuxClient) -> Result<()> {
-    let output = client.capture_pane(MANAGER_SESSION, 50)?;
+fn check_manager_output(client: &TmuxClient, ea: &EaContext) -> Result<()> {
+    let output = client.capture_pane(&ea.session_name, 50)?;
 
     if let Some(msg) = parse_manager_message(&output) {
         match msg {
@@ -303,8 +347,8 @@ fn check_manager_output(client: &TmuxClient) -> Result<()> {
     Ok(())
 }
 
-fn approve_plan(client: &TmuxClient, command: &str) -> Result<()> {
-    let output = client.capture_pane(MANAGER_SESSION, 50)?;
+fn approve_plan(client: &TmuxClient, command: &str, ea: &EaContext) -> Result<()> {
+    let output = client.capture_pane(&ea.session_name, 50)?;
 
     if let Some(ManagerMessage::Plan {
         description,
@@ -315,7 +359,7 @@ fn approve_plan(client: &TmuxClient, command: &str) -> Result<()> {
         println!("Spawning {} worker agents...\n", agents.len());
 
         for agent in &agents {
-            spawn_worker(client, agent, command)?;
+            spawn_worker(client, agent, command, ea)?;
         }
 
         // Notify manager that plan was approved
@@ -328,7 +372,7 @@ fn approve_plan(client: &TmuxClient, command: &str) -> Result<()> {
                 .collect::<Vec<_>>()
                 .join(", ")
         );
-        send_to_manager(client, &approval_msg)?;
+        send_to_manager(client, &approval_msg, ea)?;
 
         println!("\nAll agents spawned. Use 'status' to monitor progress.");
     } else {
@@ -338,22 +382,26 @@ fn approve_plan(client: &TmuxClient, command: &str) -> Result<()> {
     Ok(())
 }
 
-fn reject_plan(client: &TmuxClient) -> Result<()> {
+fn reject_plan(client: &TmuxClient, ea: &EaContext) -> Result<()> {
     print!("Reason for rejection: ");
     io::stdout().flush()?;
 
     let mut reason = String::new();
     io::stdin().read_line(&mut reason)?;
 
-    send_to_manager(client, &format!("Plan rejected. Reason: {}", reason.trim()))?;
+    send_to_manager(
+        client,
+        &format!("Plan rejected. Reason: {}", reason.trim()),
+        ea,
+    )?;
     println!("Rejection sent to manager.");
 
     Ok(())
 }
 
-fn send_to_manager(client: &TmuxClient, message: &str) -> Result<()> {
-    client.send_keys_literal(MANAGER_SESSION, message)?;
-    client.send_keys(MANAGER_SESSION, "Enter")?;
+fn send_to_manager(client: &TmuxClient, message: &str, ea: &EaContext) -> Result<()> {
+    client.send_keys_literal(&ea.session_name, message)?;
+    client.send_keys(&ea.session_name, "Enter")?;
     println!("Sent to manager: {}", message);
     Ok(())
 }
@@ -372,7 +420,12 @@ fn send_to_agent(client: &TmuxClient, agent: &str, message: &str) -> Result<()> 
     Ok(())
 }
 
-fn spawn_worker(client: &TmuxClient, agent: &ProposedAgent, command: &str) -> Result<()> {
+fn spawn_worker(
+    client: &TmuxClient,
+    agent: &ProposedAgent,
+    command: &str,
+    ea: &EaContext,
+) -> Result<()> {
     let session_name = format!("{}{}", client.prefix(), agent.name);
 
     if client.has_session(&session_name)? {
@@ -382,7 +435,7 @@ fn spawn_worker(client: &TmuxClient, agent: &ProposedAgent, command: &str) -> Re
 
     // Build command with worker system prompt (template vars substituted via sed)
     let parent_name = client.prefix().to_string() + "manager";
-    let prompt_file = prompts_dir().join("worker.md");
+    let prompt_file = prompts_dir(ea).join("worker.md");
     let cmd = build_agent_command(
         command,
         &prompt_file,
@@ -405,7 +458,7 @@ fn spawn_worker(client: &TmuxClient, agent: &ProposedAgent, command: &str) -> Re
     client.send_keys(&session_name, "Enter")?;
 
     // Persist worker task description
-    memory::save_worker_task(&session_name, &agent.task);
+    memory::save_worker_task(&ea.state_dir, &session_name, &agent.task);
 
     println!("  {} - spawned ({})", agent.name, agent.role);
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,50 +1,47 @@
-//! Persistent memory — state snapshots in ~/.omar/memory.md
+//! Persistent memory — state snapshots in the EA's state directory.
 //!
-//! Writes a human-readable markdown snapshot of the current OMAR state
-//! so a newly created manager session can resume seamlessly.
+//! All path functions accept a `state_dir` parameter (the EA's root
+//! state directory, e.g. `~/.omar/`) so multiple EAs can maintain
+//! independent state.
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::app::AgentInfo;
 use crate::projects;
 use crate::tmux::TmuxClient;
 
-/// Ensure ~/.omar/ exists and return it
-fn omar_dir() -> PathBuf {
-    let dir = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".omar");
-    fs::create_dir_all(&dir).ok();
-    dir
+/// Ensure a directory exists, creating it if needed.
+fn ensure_dir(state_dir: &Path) {
+    fs::create_dir_all(state_dir).ok();
 }
 
 /// Path to the memory file
-fn memory_path() -> PathBuf {
-    omar_dir().join("memory.md")
+fn memory_path(state_dir: &Path) -> std::path::PathBuf {
+    state_dir.join("memory.md")
 }
 
 /// Path to worker task descriptions
-fn worker_tasks_path() -> PathBuf {
-    omar_dir().join("worker_tasks.json")
+fn worker_tasks_path(state_dir: &Path) -> std::path::PathBuf {
+    state_dir.join("worker_tasks.json")
 }
 
 /// Path to agent parent mappings (child → parent)
-fn agent_parents_path() -> PathBuf {
-    omar_dir().join("agent_parents.json")
+fn agent_parents_path(state_dir: &Path) -> std::path::PathBuf {
+    state_dir.join("agent_parents.json")
 }
 
 /// Save a worker's task description (upsert)
-pub fn save_worker_task(session: &str, task: &str) {
-    let mut tasks = load_worker_tasks();
+pub fn save_worker_task(state_dir: &Path, session: &str, task: &str) {
+    let mut tasks = load_worker_tasks(state_dir);
     tasks.insert(session.to_string(), task.to_string());
-    write_worker_tasks(&tasks);
+    write_worker_tasks(state_dir, &tasks);
 }
 
 /// Load all worker task mappings
-pub fn load_worker_tasks() -> HashMap<String, String> {
-    let path = worker_tasks_path();
+pub fn load_worker_tasks(state_dir: &Path) -> HashMap<String, String> {
+    let path = worker_tasks_path(state_dir);
     match fs::read_to_string(&path) {
         Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
         Err(_) => HashMap::new(),
@@ -52,23 +49,24 @@ pub fn load_worker_tasks() -> HashMap<String, String> {
 }
 
 /// Write worker tasks to disk
-fn write_worker_tasks(tasks: &HashMap<String, String>) {
-    let path = worker_tasks_path();
+fn write_worker_tasks(state_dir: &Path, tasks: &HashMap<String, String>) {
+    ensure_dir(state_dir);
+    let path = worker_tasks_path(state_dir);
     if let Ok(json) = serde_json::to_string_pretty(tasks) {
         fs::write(&path, json).ok();
     }
 }
 
 /// Save a child→parent mapping (upsert)
-pub fn save_agent_parent(child: &str, parent: &str) {
-    let mut parents = load_agent_parents();
+pub fn save_agent_parent(state_dir: &Path, child: &str, parent: &str) {
+    let mut parents = load_agent_parents(state_dir);
     parents.insert(child.to_string(), parent.to_string());
-    write_agent_parents(&parents);
+    write_agent_parents(state_dir, &parents);
 }
 
 /// Load all child→parent mappings
-pub fn load_agent_parents() -> HashMap<String, String> {
-    let path = agent_parents_path();
+pub fn load_agent_parents(state_dir: &Path) -> HashMap<String, String> {
+    let path = agent_parents_path(state_dir);
     match fs::read_to_string(&path) {
         Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
         Err(_) => HashMap::new(),
@@ -76,59 +74,67 @@ pub fn load_agent_parents() -> HashMap<String, String> {
 }
 
 /// Write agent parents to disk
-fn write_agent_parents(parents: &HashMap<String, String>) {
-    let path = agent_parents_path();
+pub fn write_agent_parents(state_dir: &Path, parents: &HashMap<String, String>) {
+    ensure_dir(state_dir);
+    let path = agent_parents_path(state_dir);
     if let Ok(json) = serde_json::to_string_pretty(parents) {
         fs::write(&path, json).ok();
     }
 }
 
 /// Remove a child→parent mapping
-pub fn remove_agent_parent(child: &str) {
-    let mut parents = load_agent_parents();
+pub fn remove_agent_parent(state_dir: &Path, child: &str) {
+    let mut parents = load_agent_parents(state_dir);
     parents.remove(child);
-    write_agent_parents(&parents);
+    write_agent_parents(state_dir, &parents);
 }
 
 /// Directory for agent status files
-fn status_dir() -> PathBuf {
-    let dir = omar_dir().join("status");
-    fs::create_dir_all(&dir).ok();
-    dir
+fn status_dir(state_dir: &Path) -> std::path::PathBuf {
+    state_dir.join("status")
 }
 
-/// Load an agent's self-reported status from ~/.omar/status/<session>.md
-pub fn load_agent_status(session_name: &str) -> Option<String> {
-    let path = status_dir().join(format!("{}.md", session_name));
+/// Load an agent's self-reported status
+pub fn load_agent_status(state_dir: &Path, session_name: &str) -> Option<String> {
+    let path = status_dir(state_dir).join(format!("{}.md", session_name));
     fs::read_to_string(&path)
         .ok()
         .filter(|s| !s.trim().is_empty())
 }
 
-/// Save an agent's status to ~/.omar/status/<session>.md
-pub fn save_agent_status(session_name: &str, status: &str) {
-    let path = status_dir().join(format!("{}.md", session_name));
+/// Save an agent's status
+pub fn save_agent_status(state_dir: &Path, session_name: &str, status: &str) {
+    let dir = status_dir(state_dir);
+    fs::create_dir_all(&dir).ok();
+    let path = dir.join(format!("{}.md", session_name));
     fs::write(&path, status).ok();
 }
 
 /// Load the memory file contents (empty string if missing)
-pub fn load_memory() -> String {
-    let path = memory_path();
+pub fn load_memory(state_dir: &Path) -> String {
+    let path = memory_path(state_dir);
     fs::read_to_string(&path).unwrap_or_default()
 }
 
-/// Write a full state snapshot to ~/.omar/memory.md
+/// Write a full state snapshot to the EA's state directory.
 ///
 /// Captures: active projects, worker states + tasks, manager status,
 /// and the manager's recent conversation context.
-pub fn write_memory(agents: &[AgentInfo], manager: Option<&AgentInfo>, client: &TmuxClient) {
-    let projects = projects::load_projects();
-    let mut worker_tasks = load_worker_tasks();
+pub fn write_memory(
+    state_dir: &Path,
+    ea_session: &str,
+    agents: &[AgentInfo],
+    manager: Option<&AgentInfo>,
+    client: &TmuxClient,
+) {
+    ensure_dir(state_dir);
+    let projects = projects::load_projects(state_dir);
+    let mut worker_tasks = load_worker_tasks(state_dir);
 
     // Clean up stale entries from worker_tasks (sessions that no longer exist)
     let active_sessions: Vec<String> = agents.iter().map(|a| a.session.name.clone()).collect();
     worker_tasks.retain(|k, _| active_sessions.contains(k));
-    write_worker_tasks(&worker_tasks);
+    write_worker_tasks(state_dir, &worker_tasks);
 
     // Note: agent_parents cleanup is intentionally NOT done here.
     // write_memory() can be called with a stale agents list (e.g., from
@@ -174,7 +180,7 @@ pub fn write_memory(agents: &[AgentInfo], manager: Option<&AgentInfo>, client: &
 
     // Manager's recent context (last ~20 lines of pane output)
     if manager.is_some() {
-        if let Ok(output) = client.capture_pane(crate::manager::MANAGER_SESSION, 20) {
+        if let Ok(output) = client.capture_pane(ea_session, 20) {
             let trimmed: Vec<&str> = output
                 .lines()
                 .map(|l| l.trim_end())
@@ -190,6 +196,40 @@ pub fn write_memory(agents: &[AgentInfo], manager: Option<&AgentInfo>, client: &
         }
     }
 
-    let path = memory_path();
+    let path = memory_path(state_dir);
     fs::write(&path, &out).ok();
+}
+
+// ── Shared paths ──
+
+/// Base directory for all OMAR state (`~/.omar/`).
+pub fn omar_base_dir() -> std::path::PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".omar")
+}
+
+// ── EA list persistence ──
+
+/// Path to the global EA list (lives in the base ~/.omar/ directory, not per-EA)
+fn eas_path() -> std::path::PathBuf {
+    omar_base_dir().join("eas.json")
+}
+
+/// Load the list of EA IDs from ~/.omar/eas.json
+pub fn load_ea_ids() -> Vec<String> {
+    let path = eas_path();
+    match fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Save the list of EA IDs to ~/.omar/eas.json
+pub fn save_ea_ids(ids: &[String]) {
+    ensure_dir(&omar_base_dir());
+    let path = eas_path();
+    if let Ok(json) = serde_json::to_string_pretty(ids) {
+        fs::write(&path, json).ok();
+    }
 }

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -1,11 +1,11 @@
-//! Project management — CRUD on ~/.omar/tasks.md
+//! Project management — CRUD on tasks.md inside an EA's state directory.
 //!
 //! File format: numbered lines like `1. Project name`
 //! Renumbered sequentially on every save.
 
 use anyhow::Result;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct Project {
@@ -13,18 +13,15 @@ pub struct Project {
     pub name: String,
 }
 
-/// Path to the projects file (~/.omar/tasks.md)
-pub fn projects_path() -> PathBuf {
-    let dir = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".omar");
-    fs::create_dir_all(&dir).ok();
-    dir.join("tasks.md")
+/// Path to the projects file inside the EA's state directory.
+pub fn projects_path(state_dir: &Path) -> PathBuf {
+    fs::create_dir_all(state_dir).ok();
+    state_dir.join("tasks.md")
 }
 
 /// Load projects from file
-pub fn load_projects() -> Vec<Project> {
-    let path = projects_path();
+pub fn load_projects(state_dir: &Path) -> Vec<Project> {
+    let path = projects_path(state_dir);
     let content = match fs::read_to_string(&path) {
         Ok(c) => c,
         Err(_) => return Vec::new(),
@@ -56,8 +53,8 @@ fn parse_projects(content: &str) -> Vec<Project> {
 }
 
 /// Save projects to file (renumbered 1..n)
-pub fn save_projects(projects: &[Project]) -> Result<()> {
-    let path = projects_path();
+pub fn save_projects(state_dir: &Path, projects: &[Project]) -> Result<()> {
+    let path = projects_path(state_dir);
     let content: String = projects
         .iter()
         .enumerate()
@@ -74,25 +71,25 @@ pub fn save_projects(projects: &[Project]) -> Result<()> {
 }
 
 /// Add a project, returns new id
-pub fn add_project(name: &str) -> Result<usize> {
-    let mut projects = load_projects();
+pub fn add_project(state_dir: &Path, name: &str) -> Result<usize> {
+    let mut projects = load_projects(state_dir);
     let id = projects.len() + 1;
     projects.push(Project {
         id,
         name: name.to_string(),
     });
-    save_projects(&projects)?;
+    save_projects(state_dir, &projects)?;
     Ok(id)
 }
 
 /// Remove a project by id (1-based), returns whether it was found
-pub fn remove_project(id: usize) -> Result<bool> {
-    let mut projects = load_projects();
+pub fn remove_project(state_dir: &Path, id: usize) -> Result<bool> {
+    let mut projects = load_projects(state_dir);
     if id == 0 || id > projects.len() {
         return Ok(false);
     }
     projects.remove(id - 1);
-    save_projects(&projects)?;
+    save_projects(state_dir, &projects)?;
     Ok(true)
 }
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -161,8 +161,8 @@ impl Scheduler {
     }
 }
 
-pub(crate) fn deliver_to_tmux(receiver: &str, message: &str, ticker: &TickerBuffer) {
-    let target = format!("omar-agent-{}", receiver);
+pub(crate) fn deliver_to_tmux(prefix: &str, receiver: &str, message: &str, ticker: &TickerBuffer) {
+    let target = format!("{}{}", prefix, receiver);
     let result = Command::new("tmux")
         .args(["send-keys", "-t", &target, "-l", message])
         .output();
@@ -211,6 +211,7 @@ pub async fn run_event_loop(
     scheduler: Arc<Scheduler>,
     ticker: TickerBuffer,
     popup_receiver: PopupReceiver,
+    session_prefix: String,
 ) {
     loop {
         let next_ts = {
@@ -286,7 +287,7 @@ pub async fn run_event_loop(
                         continue;
                     }
                     let message = format_delivery(&batch, earliest_ts);
-                    deliver_to_tmux(receiver, &message, &ticker);
+                    deliver_to_tmux(&session_prefix, receiver, &message, &ticker);
 
                     // Re-insert recurring events with a fresh timestamp and ID
                     for ev in &batch {
@@ -487,9 +488,14 @@ mod tests {
             return;
         }
 
-        // deliver_to_tmux prepends "omar-agent-" to the receiver name
+        // deliver_to_tmux prepends the session prefix to the receiver name
         let ticker = TickerBuffer::new();
-        deliver_to_tmux("test-deliver", "hello-from-scheduler", &ticker);
+        deliver_to_tmux(
+            "omar-agent-",
+            "test-deliver",
+            "hello-from-scheduler",
+            &ticker,
+        );
 
         // Give tmux a moment to process the send-keys
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -540,7 +546,7 @@ mod tests {
         let ticker = TickerBuffer::new();
         let handle = tokio::spawn(async move {
             tokio::select! {
-                _ = run_event_loop(sched, ticker, new_popup_receiver()) => {}
+                _ = run_event_loop(sched, ticker, new_popup_receiver(), "omar-agent-".to_string()) => {}
                 _ = tokio::time::sleep(std::time::Duration::from_secs(3)) => {}
             }
         });

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -7,20 +7,19 @@ use ratatui::{
 };
 use regex::Regex;
 
-use crate::app::{AgentInfo, App, ConfirmAction};
+use crate::app::{AgentInfo, App};
 use crate::memory;
 use crate::tmux::HealthState;
 
 /// Render the entire dashboard
 pub fn render(frame: &mut Frame, app: &App) {
-    let status_height = if app.status_message.is_some() { 4 } else { 3 };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(status_height), // Status bar (taller when warning shown)
-            Constraint::Percentage(55),        // Agent grid + projects sidebar
-            Constraint::Min(8),                // Manager panel (~33%)
-            Constraint::Length(1),             // Help bar
+            Constraint::Length(3),      // Status bar
+            Constraint::Percentage(55), // Agent grid + projects sidebar
+            Constraint::Min(8),         // Manager panel (~33%)
+            Constraint::Length(1),      // Help bar
         ])
         .split(frame.area());
 
@@ -57,12 +56,20 @@ pub fn render(frame: &mut Frame, app: &App) {
         render_help_popup(frame);
     }
 
-    if let Some(action) = app.pending_confirm {
-        render_confirm_dialog(frame, app, action);
+    if app.show_confirm_kill {
+        render_confirm_kill(frame, app);
+    }
+
+    if app.show_confirm_kill_ea {
+        render_confirm_kill_ea(frame, app);
     }
 
     if app.project_input_mode {
         render_project_input(frame, app);
+    }
+
+    if app.ea_input_mode {
+        render_ea_input(frame, app);
     }
 
     if app.show_events {
@@ -82,18 +89,32 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         .unwrap()
         .as_nanos() as u64;
 
+    let ea_short_name = app
+        .ea()
+        .session_name
+        .strip_prefix(app.client().prefix())
+        .unwrap_or(&app.ea().session_name);
     let next_ea_event = app
         .scheduled_events
         .iter()
-        .filter(|e| e.receiver == "ea")
+        .filter(|e| e.receiver == ea_short_name)
         .min_by_key(|e| e.timestamp);
     let next_event = app.scheduled_events.iter().min_by_key(|e| e.timestamp);
 
-    let mut status_text = vec![
-        Span::styled(
-            "One-Man Army ",
-            Style::default().add_modifier(Modifier::BOLD),
-        ),
+    let mut status_text = vec![Span::styled(
+        "One-Man Army ",
+        Style::default().add_modifier(Modifier::BOLD),
+    )];
+    if app.eas.len() > 1 {
+        status_text.push(Span::raw("| "));
+        status_text.push(Span::styled(
+            format!("{} ", app.ea().display_name),
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    status_text.extend([
         Span::raw("| Agents: "),
         Span::styled(format!("{}", total), Style::default().fg(Color::White)),
         Span::raw(" | "),
@@ -108,7 +129,7 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             format!("{}", app.scheduled_events.len()),
             Style::default().fg(Color::Cyan),
         ),
-    ];
+    ]);
 
     if let Some(event) = next_ea_event {
         status_text.push(Span::raw(" | EA Wake: "));
@@ -235,8 +256,8 @@ fn render_focus_parent(frame: &mut Frame, app: &App, area: Rect) {
 
         // Build display title based on focus parent type
         let parent_name = &app.focus_parent;
-        let display_title = if *parent_name == crate::manager::MANAGER_SESSION {
-            "Executive Assistant".to_string()
+        let display_title = if *parent_name == app.ea().session_name {
+            app.ea().display_name.clone()
         } else {
             let short = parent_name
                 .strip_prefix(app.client().prefix())
@@ -405,17 +426,23 @@ fn render_command_tree(frame: &mut Frame, app: &App, area: Rect) {
 
         if node.depth == 0 {
             // Root (EA): no connector, just name + icon
+            let is_active_ea = node.session_name == app.ea().session_name;
             let name_style = if is_focus {
                 Style::default()
                     .fg(Color::Magenta)
                     .add_modifier(Modifier::BOLD)
-            } else {
+            } else if is_active_ea {
                 Style::default()
-                    .fg(Color::White)
+                    .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD)
+            } else {
+                // Non-active EA (collapsed) — dimmed
+                Style::default().fg(Color::DarkGray)
             };
             if is_focus {
                 spans.push(Span::styled("►", Style::default().fg(Color::Magenta)));
+            } else if is_active_ea && app.eas.len() > 1 {
+                spans.push(Span::styled("▸", Style::default().fg(Color::Cyan)));
             }
             spans.push(Span::styled(format!(" {} ", node.name), name_style));
             spans.push(Span::styled(icon, Style::default().fg(health_color)));
@@ -547,13 +574,14 @@ fn render_summary_card(
     }
 
     // Status line (from status file, fallback to last_output)
-    let status_text = memory::load_agent_status(&agent.session.name).unwrap_or_else(|| {
-        if agent.health_info.last_output.is_empty() {
-            "waiting for the agent to report status".to_string()
-        } else {
-            agent.health_info.last_output.clone()
-        }
-    });
+    let status_text = memory::load_agent_status(&app.ea().state_dir, &agent.session.name)
+        .unwrap_or_else(|| {
+            if agent.health_info.last_output.is_empty() {
+                "waiting for the agent to report status".to_string()
+            } else {
+                agent.health_info.last_output.clone()
+            }
+        });
     lines.push(Line::from(vec![
         Span::styled("Status: ", Style::default().fg(Color::Yellow)),
         Span::styled(status_text, Style::default().fg(Color::White)),
@@ -583,15 +611,21 @@ fn render_summary_card(
             if remaining.is_empty() || w == 0 {
                 break;
             }
-            if remaining.len() <= w {
+            // Find the byte index corresponding to `w` characters (not bytes)
+            let byte_limit = remaining
+                .char_indices()
+                .nth(w)
+                .map(|(i, _)| i)
+                .unwrap_or(remaining.len());
+            if byte_limit >= remaining.len() {
                 wrapped.push(remaining.to_string());
                 remaining = "";
             } else {
                 // Try to break at a word boundary
-                let break_at = remaining[..w]
+                let break_at = remaining[..byte_limit]
                     .rfind(' ')
                     .map(|i| i + 1) // include the space on the current line
-                    .unwrap_or(w);
+                    .unwrap_or(byte_limit);
                 wrapped.push(remaining[..break_at].trim_end().to_string());
                 remaining = &remaining[break_at..];
             }
@@ -633,8 +667,10 @@ fn render_summary_card(
                 } else {
                     // Last line: truncate with ellipsis
                     let w = if is_first { first_width } else { cont_width };
-                    let truncated = if text.len() > w.saturating_sub(3) && w > 3 {
-                        format!("{}...", &text[..w - 3])
+                    let char_count = text.chars().count();
+                    let truncated = if char_count > w.saturating_sub(3) && w > 3 {
+                        let end: String = text.chars().take(w - 3).collect();
+                        format!("{}...", end)
                     } else {
                         format!("{}...", text)
                     };
@@ -660,7 +696,7 @@ fn render_summary_card(
 }
 
 fn render_help_bar(frame: &mut Frame, app: &App, area: Rect) {
-    let at_root = app.focus_parent == crate::manager::MANAGER_SESSION;
+    let at_root = app.focus_parent == app.ea().session_name;
 
     let mut help_text = vec![
         Span::styled("↑↓", Style::default().add_modifier(Modifier::BOLD)),
@@ -686,6 +722,23 @@ fn render_help_bar(frame: &mut Frame, app: &App, area: Rect) {
             Style::default().add_modifier(Modifier::BOLD),
         ));
         help_text.push(Span::raw(":Back "));
+    }
+    help_text.push(Span::styled(
+        "E",
+        Style::default().add_modifier(Modifier::BOLD),
+    ));
+    help_text.push(Span::raw(":New EA "));
+    if app.eas.len() > 1 {
+        help_text.push(Span::styled(
+            "[/]",
+            Style::default().add_modifier(Modifier::BOLD),
+        ));
+        help_text.push(Span::raw(":Cycle EA "));
+        help_text.push(Span::styled(
+            "X",
+            Style::default().add_modifier(Modifier::BOLD),
+        ));
+        help_text.push(Span::raw(":Kill EA "));
     }
     help_text.push(Span::styled(
         "?",
@@ -785,51 +838,32 @@ fn render_help_popup(frame: &mut Frame) {
     frame.render_widget(paragraph, area);
 }
 
-fn render_confirm_dialog(frame: &mut Frame, app: &App, action: ConfirmAction) {
-    let (title, heading, detail, hint, width) = match action {
-        ConfirmAction::Kill => {
-            let name = app
-                .selected_agent()
-                .map(|a| a.session.name.clone())
-                .unwrap_or_else(|| "?".to_string());
-            (" Confirm ", "Kill this agent?", name, String::new(), 40)
-        }
-        ConfirmAction::Quit => (
-            " Confirm Quit ",
-            "Quit omar?",
-            "This will kill the EA session.".to_string(),
-            "Press z to walk away instead.".to_string(),
-            50,
-        ),
-    };
+fn render_confirm_dialog(frame: &mut Frame, message: &str, target_name: &str) {
+    let area = centered_rect(40, 20, frame.area());
 
-    let area = centered_rect(width, 20, frame.area());
-
-    let mut content = vec![
+    let content = vec![
         Line::from(""),
         Line::from(Span::styled(
-            heading,
+            message,
             Style::default().add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
-        Line::from(Span::styled(detail, Style::default().fg(Color::Yellow))),
+        Line::from(Span::styled(
+            target_name.to_string(),
+            Style::default().fg(Color::Yellow),
+        )),
+        Line::from(""),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("y", Style::default().fg(Color::Green)),
+            Span::raw(": Yes  "),
+            Span::styled("n", Style::default().fg(Color::Red)),
+            Span::raw(": No"),
+        ]),
     ];
-    if !hint.is_empty() {
-        content.push(Line::from(Span::styled(
-            hint,
-            Style::default().fg(Color::DarkGray),
-        )));
-    }
-    content.push(Line::from(""));
-    content.push(Line::from(vec![
-        Span::styled("y", Style::default().fg(Color::Green)),
-        Span::raw(": Yes  "),
-        Span::styled("n", Style::default().fg(Color::Red)),
-        Span::raw(": No"),
-    ]));
 
     let block = Block::default()
-        .title(title)
+        .title(" Confirm ")
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Red));
 
@@ -841,18 +875,40 @@ fn render_confirm_dialog(frame: &mut Frame, app: &App, action: ConfirmAction) {
     frame.render_widget(paragraph, area);
 }
 
-fn render_project_input(frame: &mut Frame, app: &App) {
+fn render_confirm_kill(frame: &mut Frame, app: &App) {
+    let agent_name = app
+        .selected_agent()
+        .map(|a| a.session.name.clone())
+        .unwrap_or_else(|| "?".to_string());
+    render_confirm_dialog(frame, "Kill this agent?", &agent_name);
+}
+
+fn render_confirm_kill_ea(frame: &mut Frame, app: &App) {
+    render_confirm_dialog(
+        frame,
+        "Kill this EA and all its agents?",
+        &app.ea().display_name,
+    );
+}
+
+fn render_text_input_popup(
+    frame: &mut Frame,
+    heading: &str,
+    block_title: &str,
+    color: Color,
+    input: &str,
+) {
     let area = centered_rect(50, 20, frame.area());
 
     let content = vec![
         Line::from(""),
         Line::from(Span::styled(
-            "Add Project",
+            heading.to_string(),
             Style::default().add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(Span::styled(
-            format!("> {}_", app.project_input),
+            format!("> {}_", input),
             Style::default().fg(Color::Cyan),
         )),
         Line::from(""),
@@ -863,9 +919,9 @@ fn render_project_input(frame: &mut Frame, app: &App) {
     ];
 
     let block = Block::default()
-        .title(" New Project ")
+        .title(block_title)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(color));
 
     let paragraph = Paragraph::new(content)
         .block(block)
@@ -873,6 +929,26 @@ fn render_project_input(frame: &mut Frame, app: &App) {
 
     frame.render_widget(Clear, area);
     frame.render_widget(paragraph, area);
+}
+
+fn render_project_input(frame: &mut Frame, app: &App) {
+    render_text_input_popup(
+        frame,
+        "Add Project",
+        " New Project ",
+        Color::Cyan,
+        &app.project_input,
+    );
+}
+
+fn render_ea_input(frame: &mut Frame, app: &App) {
+    render_text_input_popup(
+        frame,
+        "New Executive Assistant",
+        " New EA ",
+        Color::Magenta,
+        &app.ea_input,
+    );
 }
 
 fn render_events_popup(frame: &mut Frame, app: &App) {
@@ -933,12 +1009,7 @@ fn render_events_popup(frame: &mut Frame, app: &App) {
                 }
             };
 
-            // Truncate payload to fit
-            let payload = if event.payload.len() > 30 {
-                format!("{}...", &event.payload[..27])
-            } else {
-                event.payload.clone()
-            };
+            let payload = truncate_str(&event.payload, 30);
 
             lines.push(Line::from(vec![
                 Span::styled(
@@ -1023,8 +1094,9 @@ fn render_debug_console(frame: &mut Frame, app: &App) {
 }
 
 fn truncate_str(s: &str, max_len: usize) -> String {
-    if s.len() > max_len {
-        format!("{}…", &s[..max_len - 1])
+    if s.chars().count() > max_len {
+        let truncated: String = s.chars().take(max_len - 1).collect();
+        format!("{}…", truncated)
     } else {
         s.to_string()
     }


### PR DESCRIPTION
## Summary

Adds multi-EA (Executive Assistant) support to OMAR, allowing multiple independent EAs to run simultaneously in one dashboard.

### Phase 1: EaContext refactoring
- Introduce `EaContext` struct encapsulating EA identity (`id`, `session_name`, `display_name`, `state_dir`)
- Parameterize all `memory.rs` and `projects.rs` functions to accept `state_dir: &Path`
- Thread `EaContext` through `App`, `main.rs`, `api/handlers.rs`, and `ui/dashboard.rs`
- Zero behavioral change — single EA works identically

### Phase 2: Multi-EA lifecycle
- Replace single `ea` with `eas: Vec<EaContext>` and `active_ea` index
- `EaContext::new(id)` creates named EAs with scoped state dirs (`~/.omar/{id}/`)
- Persist EA list to `~/.omar/eas.json`
- `E` keybinding spawns new EA via input dialog
- `X` keybinding kills/removes the active EA with confirmation dialog (disabled for last EA)
- `[`/`]` keybindings cycle active EA
- Parameterize scheduler `deliver_to_tmux` prefix
- API kill protection checks all EA sessions
- EA ID validation: alphanumeric, dashes, and underscores only

### Phase 3: Multi-EA UX polish
- Active EA fully expanded in command tree; non-active EAs collapsed with summary
- Active EA highlighted cyan, non-active dimmed gray
- `GET /api/eas` endpoint lists all EAs with status
- Per-EA agent scoping: each EA's tree only shows its own agents in multi-EA mode
- Auto-adopt untracked agents into default EA when transitioning to multi-EA

### Bug fixes
- **UTF-8 crash**: Fix panic on multi-byte characters in dashboard text (char-based indexing)
- **`z` keybinding regression**: Restore `z` (detach / "Hold the line") lost during merge
- **Key Release ghost input**: Filter to `KeyEventKind::Press` only in event handler
- **Agent scoping**: Prevent agents from leaking across EAs; single-EA backward compat preserved

### Code quality (post-review)
- Extract `render_confirm_dialog` shared by agent kill and EA kill confirmations
- Replace inline truncation with existing `truncate_str` utility
- Extract `flush_memory()`, `reload_ea_state()`, `reset_focus()` helpers
- Add `DEFAULT_EA_ID` constant and `omar_base_dir()` shared utility

## Test plan
- [x] `cargo check` / `cargo clippy` / `cargo fmt` — all clean
- [x] `cargo test` — 59 unit + 11 integration + 7 computer tests pass
- [x] CI — all 8 checks pass (Build, Test, Clippy, Format, Check, Opencode, CI Success)
- [x] Manual: single-EA shows all agents (backward compat)
- [x] Manual: `E` creates new EA with correct name, no ghost input
- [x] Manual: new EA shows "No child agents" (scoped correctly)
- [x] Manual: existing PMs auto-adopted on multi-EA transition
- [x] Manual: `[`/`]` cycles between EAs
- [x] Manual: `X` shows confirmation before killing EA
- [x] Manual: `z` detaches from tmux
- [x] Manual: dashboard handles multi-byte UTF-8 without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)