### PR TITLE
docs: add planning and session continuation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Lead an army of 300 agents to solve humanity's biggest problems.
 #### Prerequisites
 
 - **tmux 3.0+** — `brew install tmux` (macOS) or `apt install tmux` (Debian/Ubuntu)
-- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [Codex CLI](https://developers.openai.com/codex/cli), or [Opencode](https://github.com/anomalyco/opencode)
+- [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [Codex CLI](https://developers.openai.com/codex/cli), [Cursor](https://www.cursor.com/), or [Opencode](https://github.com/anomalyco/opencode)
 
 #### One-liner (recommended)
 
@@ -101,6 +101,7 @@ Omar auto-detects which agent backend is available on your system:
 |---------|---------------|
 | [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) | `omar` (default) |
 | [Codex CLI](https://developers.openai.com/codex/cli) | `omar --agent codex` |
+| [Cursor](https://www.cursor.com/) | `omar --agent cursor` |
 | [Opencode](https://github.com/anomalyco/opencode) | `omar --agent opencode` |
 
 ## License

--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -20,6 +20,25 @@ IMPORTANT: When spawning sub-agents, you MUST use the OMAR HTTP API (curl comman
 Do NOT use your internal Task tool, background agents, or any built-in multi-agent features.
 The OMAR API creates real tmux sessions that appear in the OMAR dashboard.
 
+## Planning Mode
+
+Planning mode is available across supported backends. For design docs, investigations, or tasks that explicitly ask for a plan, prefer the backend's planning mode when it is available. On Codex, Claude, and Opencode, `Shift-Tab` cycles collaboration modes in the TUI.
+
+## Session Continuation
+
+Session continuation is not the default workflow. Prefer spawning a fresh worker unless the user or your parent explicitly asks you to continue a previous worker or chat.
+
+When continuation is explicitly requested, prefer the backend's native resume or fork behavior through the OMAR `command` override instead of reconstructing context by hand.
+
+Backend-specific examples:
+- Codex: `codex resume <SESSION_ID>` or `codex fork <SESSION_ID>`
+- Claude: `claude --resume <SESSION_ID>` or `claude --resume <SESSION_ID> --fork-session`
+- Opencode: `opencode --session <SESSION_ID>` or `opencode --session <SESSION_ID> --fork`
+
+Notes:
+- Prefer explicit session IDs over `--last` / `--continue`; those shortcuts are unreliable when several workers share a cwd.
+- Use fork-style continuation when you want prior context as input but want a new branch of work.
+
 ## Workflow
 
 1. Receive your assigned task from the first user message (YOUR NAME, YOUR PARENT, YOUR TASK)

--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -35,6 +35,25 @@ The API automatically injects the agent system prompt when a task is provided. Y
 
 Name agents with short, descriptive names (e.g., `auth`, `api`, `refactor`).
 
+## Planning Mode
+
+Planning mode is available across supported backends. For design, investigation, or explicitly plan-only tasks, prefer putting the worker into the backend's planning mode when terminal control is available. On Codex, Claude, and Opencode, `Shift-Tab` cycles collaboration modes in the TUI.
+
+## Session Continuation
+
+Session continuation is not the normal OMAR workflow. Prefer spawning a fresh worker unless the user explicitly asks to continue a previous worker or chat.
+
+When continuation is explicitly requested, prefer a backend-specific `command` override that uses the backend's native resume or fork behavior rather than reconstructing context manually.
+
+Backend-specific examples:
+- Codex: `codex resume <SESSION_ID>` or `codex fork <SESSION_ID>`
+- Claude: `claude --resume <SESSION_ID>` or `claude --resume <SESSION_ID> --fork-session`
+- Opencode: `opencode --session <SESSION_ID>` or `opencode --session <SESSION_ID> --fork`
+
+Notes:
+- Prefer explicit session IDs over `--last` / `--continue` because multiple workers may share the same cwd.
+- Use fork-style continuation when you want prior context as input but want a fresh branch of work.
+
 ## HTTP API Reference (localhost:9876)
 
 ### Backends API


### PR DESCRIPTION
## Summary
- Add Planning Mode section to EA and agent prompts (use backend's planning mode for design/investigation tasks)
- Add Session Continuation section to EA and agent prompts (prefer fresh workers; use native resume/fork when explicitly requested)
- Add Cursor to README prerequisites and supported backends table

## Test plan
- [x] All 75 unit tests pass
- [x] Build succeeds (prompts are embedded at compile time)
- [ ] Verify prompts render correctly in agent sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)