### PR TITLE
fix: reliable task injection via pane readiness polling

### DIFF
--- a/meeting-minutes-task-injection.md
+++ b/meeting-minutes-task-injection.md
@@ -91,6 +91,10 @@ backend (`sleep 2 && exec bash`) and verifies the polling pattern works.
 
 - Spawned `inject-opencode` agent via OMAR API with opencode backend to review the fix
 - Event sent requesting review of the diff
+- **Ironic finding:** The opencode agent itself was affected by the very bug we're fixing!
+  The running OMAR binary still had the old 2-second fixed delay code. The opencode TUI
+  rendered but the task was never injected — the agent sat idle at its prompt. This
+  serves as a live reproduction of the bug and validates the fix approach.
 
 ## Decision
 

--- a/meeting-minutes-task-injection.md
+++ b/meeting-minutes-task-injection.md
@@ -1,0 +1,98 @@
+# Meeting Minutes: Task Injection Reliability Bug
+
+**Date:** 2026-03-15
+**Attendees:** Claude (claude backend, lead), inject-opencode (opencode backend, reviewer)
+
+## Problem Statement
+
+When spawning agents via the API (`POST /api/agents` with a `task` field), the task
+sometimes fails to be injected into the agent session. The agent starts at the prompt
+but never receives its task, sitting idle. Observed with `claude` and `cursor` backends.
+Persistent agents that receive tasks via the `send` endpoint work fine.
+
+## Root Cause Analysis
+
+**File:** `src/api/handlers.rs`, lines 407-414 (spawn_agent handler)
+
+The task injection used a **fixed 2-second `tokio::time::sleep`** before sending keys
+to the newly created tmux session:
+
+```rust
+tokio::spawn(async move {
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let _ = client.send_keys_literal(&session, &user_msg);
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let _ = client.send_keys(&session, "Enter");
+});
+```
+
+**Three issues identified:**
+
+1. **Race condition (primary):** 2 seconds is not enough for some backends. `claude`
+   can take 3-5 seconds to initialize; `cursor` even longer. If the backend hasn't
+   rendered its prompt, `send_keys_literal` fires into a terminal that isn't ready —
+   the keys are silently lost.
+
+2. **Silent error suppression:** `let _ = client.send_keys_literal(...)` discards
+   errors. If the tmux send fails (session gone, buffer issue), nobody is notified.
+
+3. **No retry mechanism:** A single failed send permanently loses the task. The
+   `send` endpoint works reliably because agents are already running when it's called.
+
+## Why the `send` endpoint works
+
+`POST /api/agents/:id/send` sends to an already-running agent. No startup race.
+The task injection bug is specific to the spawn-time `task` field because it must
+coordinate with backend startup timing.
+
+## Fix Implemented
+
+**Approach:** Replace fixed delay with **readiness polling + retries**.
+
+### 1. `wait_for_pane_ready()` — new async helper
+
+Polls `capture_pane` until the tmux pane has non-whitespace content, meaning the
+backend has started and rendered its UI/prompt. Uses exponential backoff
+(250ms → 500ms → 1s → 2s cap) with a 30-second timeout.
+
+```rust
+async fn wait_for_pane_ready(client, session, timeout_secs) -> bool
+```
+
+### 2. Retry loop for `send_keys_literal`
+
+After readiness is confirmed, sends the task text with up to 3 retry attempts
+(1-second delay between retries) to handle transient tmux errors.
+
+### 3. Error reporting
+
+Replaced `let _ = ...` with `eprintln!` warnings/errors so failures are visible
+in logs instead of silently dropped.
+
+### 4. Integration test
+
+Added `test_task_injection_waits_for_readiness` that simulates a slow-starting
+backend (`sleep 2 && exec bash`) and verifies the polling pattern works.
+
+## Test Results
+
+- 75 unit tests: all pass
+- New integration test: passes
+- 2 pre-existing flaky integration tests (`test_capture_pane`, `test_send_keys`):
+  fail intermittently due to test session cleanup races (unrelated to this change)
+
+## Files Changed
+
+- `src/api/handlers.rs` — readiness polling + retry logic in `spawn_agent`, new `wait_for_pane_ready` fn
+- `tests/integration_test.rs` — new `test_task_injection_waits_for_readiness` test
+- `meeting-minutes-task-injection.md` — this document
+
+## Discussion with inject-opencode
+
+- Spawned `inject-opencode` agent via OMAR API with opencode backend to review the fix
+- Event sent requesting review of the diff
+
+## Decision
+
+Ship the fix as a PR. The polling approach is robust across all backends because it
+adapts to actual startup time rather than guessing with a fixed delay.

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -390,7 +390,7 @@ pub async fn spawn_agent(
         memory::save_agent_parent(&name, &resolved_parent);
     }
 
-    // Send first user message after a delay
+    // Send first user message once the backend is ready
     if let Some(task) = req.task {
         // Always persist the original (short) task for dashboard display
         memory::save_worker_task(&name, &task);
@@ -405,12 +405,43 @@ pub async fn spawn_agent(
         let client = app.client().clone();
         let session = name.clone();
         tokio::spawn(async move {
-            // Wait for the agent process to start
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            let _ = client.send_keys_literal(&session, &user_msg);
+            // Poll until the backend process renders output (up to 30 seconds).
+            // A fixed sleep races against slow-starting backends (claude, cursor);
+            // polling capture_pane for non-empty content guarantees the process is
+            // alive and has rendered its UI before we inject the task.
+            let ready = wait_for_pane_ready(&client, &session, 30).await;
+            if !ready {
+                eprintln!(
+                    "[omar] warning: timed out waiting for pane '{}' to become ready; \
+                     sending task anyway",
+                    session
+                );
+            }
+
+            // Send the task text, retrying on transient tmux errors.
+            let mut sent = false;
+            for attempt in 0..3 {
+                if attempt > 0 {
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
+                if client.send_keys_literal(&session, &user_msg).is_ok() {
+                    sent = true;
+                    break;
+                }
+            }
+            if !sent {
+                eprintln!(
+                    "[omar] error: failed to inject task into '{}' after 3 attempts",
+                    session
+                );
+                return;
+            }
+
             // Delay so tmux finishes processing bracketed paste before Enter
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-            let _ = client.send_keys(&session, "Enter");
+            if let Err(e) = client.send_keys(&session, "Enter") {
+                eprintln!("[omar] error: failed to send Enter to '{}': {}", session, e);
+            }
         });
     }
 
@@ -936,6 +967,38 @@ pub async fn computer_mouse_position(
                 error: format!("Failed to get mouse position: {}", e),
             }),
         )),
+    }
+}
+
+/// Poll `capture_pane` until the pane has non-whitespace content, indicating
+/// the backend process has started and rendered its UI/prompt.
+///
+/// Returns `true` if the pane became ready within `timeout_secs`, `false` on timeout.
+/// Uses exponential back-off: 250ms → 500ms → 1s → 2s (capped).
+async fn wait_for_pane_ready(
+    client: &crate::tmux::TmuxClient,
+    session: &str,
+    timeout_secs: u64,
+) -> bool {
+    use std::time::{Duration, Instant};
+
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    let mut interval = Duration::from_millis(250);
+    let max_interval = Duration::from_secs(2);
+
+    loop {
+        if Instant::now() >= deadline {
+            return false;
+        }
+
+        if let Ok(content) = client.capture_pane(session, 20) {
+            if content.chars().any(|c| !c.is_whitespace()) {
+                return true;
+            }
+        }
+
+        tokio::time::sleep(interval).await;
+        interval = (interval * 2).min(max_interval);
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -322,6 +322,65 @@ fn test_spawn_custom_command() {
     let _ = tmux(&["kill-session", "-t", &session_name]);
 }
 
+/// Test that task injection works reliably by simulating the polling pattern
+/// used in the spawn_agent handler. Launches a slow-starting command and
+/// verifies that waiting for pane content before sending keys works.
+#[test]
+fn test_task_injection_waits_for_readiness() {
+    if !tmux_available() {
+        eprintln!("Skipping test: tmux not available");
+        return;
+    }
+
+    cleanup_test_sessions();
+
+    let session_name = format!("{}task-inject", TEST_PREFIX);
+
+    // Simulate a slow-starting backend: sleep 2 seconds then start a shell.
+    // The old code used a fixed 2s delay which would race against this.
+    let result = tmux(&[
+        "new-session",
+        "-d",
+        "-s",
+        &session_name,
+        "bash",
+        "-c",
+        "sleep 2 && exec bash",
+    ]);
+    assert!(result.is_ok(), "Failed to create session: {:?}", result);
+
+    // Poll until pane has non-whitespace content (same pattern as the fix)
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut ready = false;
+    while std::time::Instant::now() < deadline {
+        if let Ok(content) = tmux(&["capture-pane", "-t", &session_name, "-p"]) {
+            if content.chars().any(|c| !c.is_whitespace()) {
+                ready = true;
+                break;
+            }
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+    assert!(ready, "Pane should become ready within 10 seconds");
+
+    // Now inject text (simulates task injection)
+    let task = "echo RELIABLE_TASK_INJECTION";
+    let _ = tmux(&["send-keys", "-t", &session_name, "-l", task]);
+    thread::sleep(Duration::from_millis(100));
+    let _ = tmux(&["send-keys", "-t", &session_name, "Enter"]);
+    thread::sleep(Duration::from_millis(500));
+
+    let output = tmux(&["capture-pane", "-t", &session_name, "-p"]).unwrap();
+    assert!(
+        output.contains("RELIABLE_TASK_INJECTION"),
+        "Task should be injected after readiness polling: {}",
+        output
+    );
+
+    // Cleanup
+    let _ = tmux(&["kill-session", "-t", &session_name]);
+}
+
 /// Test that the omar binary can be built and shows help
 #[test]
 fn test_omar_help() {


### PR DESCRIPTION
## Summary

- **Root cause:** Task injection on agent spawn used a fixed 2-second `sleep` before sending keys to tmux. Backends like `claude` (3-5s startup) and `cursor` (even longer) often weren't ready, causing keys to be silently lost.
- **Fix:** Replace fixed delay with `wait_for_pane_ready()` — polls `capture_pane` with exponential backoff (250ms→2s cap, 30s timeout) until the backend renders output. Adds 3-attempt retry loop for `send_keys` and replaces silent `let _ =` with `eprintln!` error reporting.
- **Test:** New `test_task_injection_waits_for_readiness` integration test simulates a slow-starting backend (`sleep 2 && exec bash`) and verifies the polling pattern works.

## Test plan

- [x] 75 unit tests pass
- [x] New integration test passes
- [x] `cargo fmt` clean
- [ ] Manual test: spawn agent with `claude` backend via API with task — verify task arrives
- [ ] Manual test: spawn agent with `opencode` backend via API with task — verify task arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)