### PR TITLE
feat: gemini integration, tui fixes, and new leadership quotes

### DIFF
--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -65,7 +65,7 @@ curl -X POST http://localhost:9876/api/agents \
 ```
 - `name`: agent name (auto-generated if omitted)
 - `task`: task description (providing a task automatically assigns the agent prompt)
-- `backend`: agent backend shorthand — `"claude"`, `"codex"`, `"cursor"`, or `"opencode"` (defaults to config)
+- `backend`: agent backend shorthand — `"claude"`, `"codex"`, `"cursor"`, `"gemini"`, or `"opencode"` (defaults to config)
 - `model`: model override — appended as `--model <value>` (e.g. `"claude-sonnet-4-5-20250514"`, `"o3"`)
 
 #### Spawning with a specific backend and model

--- a/prompts/skills/heterogeneous-backends.md
+++ b/prompts/skills/heterogeneous-backends.md
@@ -22,6 +22,7 @@ curl -X POST http://localhost:9876/api/agents \
 | Claude Code| `"claude"`   | `--model <model-id>`                       |
 | Codex CLI  | `"codex"`    | `--model <model-id>`                       |
 | Cursor     | `"cursor"`   | `--model` passed through but may be ignored |
+| Gemini CLI | `"gemini"`   | `--model <model-id>`                       |
 | OpenCode   | `"opencode"` | `--model <provider>/<model-id>`            |
 
 ### Common model names

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -94,7 +94,7 @@ pub async fn list_backends() -> Json<BackendsResponse> {
     let infos = tokio::task::spawn_blocking(|| {
         use std::process::Command;
 
-        let backends = ["claude", "codex", "cursor", "opencode"];
+        let backends = ["claude", "codex", "cursor", "gemini", "opencode"];
         backends
             .iter()
             .filter_map(|&name| {

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -13,7 +13,7 @@ pub struct SpawnAgentRequest {
     pub workdir: Option<String>,
     /// Command to run (defaults to config). Cannot be used together with `backend`.
     pub command: Option<String>,
-    /// Backend shorthand: "claude", "codex", "cursor", "opencode".
+    /// Backend shorthand: "claude", "codex", "cursor", "gemini", "opencode".
     /// Resolved to the full command via resolve_backend(). Cannot be used together with `command`.
     pub backend: Option<String>,
     /// Model to use (e.g. "claude-sonnet-4-5-20250514", "o3", "anthropic/claude-sonnet-4-5-20250514").

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,7 +142,7 @@ fn detect_agent_command() -> String {
         .output()
         .is_ok_and(|o| o.status.success())
     {
-        return "opencode --dangerously-skip-permissions".to_string();
+        return "OPENCODE_DANGEROUSLY_SKIP_PERMISSIONS=true opencode".to_string();
     }
 
     if Command::new("cursor")
@@ -177,7 +177,7 @@ pub fn resolve_backend(name: &str) -> Result<String, String> {
         }
         "cursor" => Ok("cursor agent --yolo".to_string()),
         "gemini" => Ok("gemini --yolo".to_string()),
-        "opencode" => Ok("opencode --dangerously-skip-permissions".to_string()),
+        "opencode" => Ok("OPENCODE_DANGEROUSLY_SKIP_PERMISSIONS=true opencode".to_string()),
         other => Err(format!(
             "Unknown backend '{}'. Supported: claude, codex, cursor, gemini, opencode",
             other
@@ -407,7 +407,7 @@ default_command = "bash"
         assert_eq!(resolve_backend("gemini").unwrap(), "gemini --yolo");
         assert_eq!(
             resolve_backend("opencode").unwrap(),
-            "opencode --dangerously-skip-permissions"
+            "OPENCODE_DANGEROUSLY_SKIP_PERMISSIONS=true opencode"
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,7 +109,7 @@ fn default_error_patterns() -> Vec<String> {
 }
 
 /// Detect which agent command is available on the system.
-/// Checks PATH for `claude` first, then `opencode`, falling back to `claude`.
+/// Checks PATH for `claude` first, then `codex`, then `cursor`, then `gemini`, then `opencode`, falling back to `claude`.
 fn detect_agent_command() -> String {
     use std::process::Command;
 
@@ -121,12 +121,36 @@ fn detect_agent_command() -> String {
         return "claude --dangerously-skip-permissions".to_string();
     }
 
+    if Command::new("codex")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+    {
+        return "codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox".to_string();
+    }
+
+    if Command::new("gemini")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+    {
+        return "gemini --yolo".to_string();
+    }
+
     if Command::new("opencode")
         .arg("--version")
         .output()
         .is_ok_and(|o| o.status.success())
     {
-        return "opencode".to_string();
+        return "opencode --dangerously-skip-permissions".to_string();
+    }
+
+    if Command::new("cursor")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+    {
+        return "cursor agent --yolo".to_string();
     }
 
     // Fallback to claude even if not found (user may install it later)
@@ -142,7 +166,8 @@ fn default_command() -> String {
 /// - `"claude"` → `"claude --dangerously-skip-permissions"`
 /// - `"codex"` → `"codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox"`
 /// - `"cursor"` → `"cursor agent --yolo"`
-/// - `"opencode"` → `"opencode"`
+/// - `"gemini"` → `"gemini --yolo"`
+/// - `"opencode"` → `"opencode --dangerously-skip-permissions"`
 /// - anything else → error
 pub fn resolve_backend(name: &str) -> Result<String, String> {
     match name {
@@ -151,9 +176,10 @@ pub fn resolve_backend(name: &str) -> Result<String, String> {
             Ok("codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox".to_string())
         }
         "cursor" => Ok("cursor agent --yolo".to_string()),
-        "opencode" => Ok("opencode".to_string()),
+        "gemini" => Ok("gemini --yolo".to_string()),
+        "opencode" => Ok("opencode --dangerously-skip-permissions".to_string()),
         other => Err(format!(
-            "Unknown backend '{}'. Supported: claude, codex, cursor, opencode",
+            "Unknown backend '{}'. Supported: claude, codex, cursor, gemini, opencode",
             other
         )),
     }
@@ -378,7 +404,11 @@ default_command = "bash"
             "codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox"
         );
         assert_eq!(resolve_backend("cursor").unwrap(), "cursor agent --yolo");
-        assert_eq!(resolve_backend("opencode").unwrap(), "opencode");
+        assert_eq!(resolve_backend("gemini").unwrap(), "gemini --yolo");
+        assert_eq!(
+            resolve_backend("opencode").unwrap(),
+            "opencode --dangerously-skip-permissions"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ struct Cli {
     #[arg(short, long)]
     config: Option<String>,
 
-    /// Agent backend to use: claude, codex, cursor, opencode
+    /// Agent backend to use: claude, codex, cursor, gemini, opencode
     #[arg(short, long)]
     agent: Option<String>,
 }

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -39,6 +39,7 @@ enum BackendKind {
     Claude,
     Codex,
     Cursor,
+    Gemini,
     Opencode,
 }
 
@@ -53,6 +54,7 @@ fn detect_backend_token(token: &str) -> Option<BackendKind> {
         "claude" => Some(BackendKind::Claude),
         "codex" => Some(BackendKind::Codex),
         "cursor" => Some(BackendKind::Cursor),
+        "gemini" => Some(BackendKind::Gemini),
         "opencode" => Some(BackendKind::Opencode),
         _ => None,
     }
@@ -70,6 +72,7 @@ fn detect_backend(base_command: &str) -> Option<BackendKind> {
 ///   - claude  → `--system-prompt "$(cat '<path>')"`
 ///   - codex   → `-c "developer_instructions='''$(cat '<path>')'''"`
 ///   - cursor  → positional arg `"Load the <path> file and follow the instructions."`
+///   - gemini  → `-i "$(cat '<path>')"`
 ///   - opencode → `--prompt "$(cat '<path>')"`
 ///   - unknown → returns `base_command` unchanged
 pub fn build_agent_command(base_command: &str, prompt_file: &Path) -> String {
@@ -89,6 +92,9 @@ pub fn build_agent_command(base_command: &str, prompt_file: &Path) -> String {
                 base_command,
                 prompt_file.display()
             )
+        }
+        Some(BackendKind::Gemini) => {
+            format!("TERM=xterm-256color {} -i \"{}\"", base_command, shell_expr)
         }
         Some(BackendKind::Opencode) => format!("{} --prompt \"{}\"", base_command, shell_expr),
         None => base_command.to_string(),
@@ -197,6 +203,27 @@ mod tests {
         assert_eq!(
             cmd,
             "cursor agent --yolo \"Load the '/tmp/prompts/ea.md' file and follow the instructions.\""
+        );
+    }
+
+    #[test]
+    fn test_build_agent_command_gemini() {
+        let cmd = build_agent_command("gemini --yolo", Path::new("/tmp/prompts/ea.md"));
+        assert_eq!(
+            cmd,
+            "TERM=xterm-256color gemini --yolo -i \"$(cat '/tmp/prompts/ea.md')\""
+        );
+    }
+
+    #[test]
+    fn test_build_agent_command_wrapped_gemini() {
+        let cmd = build_agent_command(
+            "env FOO=bar gemini --yolo",
+            Path::new("/tmp/prompts/ea.md"),
+        );
+        assert_eq!(
+            cmd,
+            "TERM=xterm-256color env FOO=bar gemini --yolo -i \"$(cat '/tmp/prompts/ea.md')\""
         );
     }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -217,10 +217,7 @@ mod tests {
 
     #[test]
     fn test_build_agent_command_wrapped_gemini() {
-        let cmd = build_agent_command(
-            "env FOO=bar gemini --yolo",
-            Path::new("/tmp/prompts/ea.md"),
-        );
+        let cmd = build_agent_command("env FOO=bar gemini --yolo", Path::new("/tmp/prompts/ea.md"));
         assert_eq!(
             cmd,
             "TERM=xterm-256color env FOO=bar gemini --yolo -i \"$(cat '/tmp/prompts/ea.md')\""

--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -105,6 +105,7 @@ impl TmuxClient {
     pub fn capture_pane(&self, target: &str, lines: i32) -> Result<String> {
         self.run(&[
             "capture-pane",
+            "-e",
             "-t",
             target,
             "-p",

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -315,6 +315,9 @@ const QUOTES: &[&str] = &[
     "\"Pain and suffering are always inevitable for a large intelligence and a deep heart.\" — Fyodor Dostoevsky",
     // Leo Tolstoy
     "\"Everyone thinks of changing the world, but no one thinks of changing himself.\" — Leo Tolstoy",
+    // Prophetic Tradition
+    "\"The leader of a people is their servant.\" — Prophetic Tradition",
+    "\"All of you are shepherds and each of you is responsible for his flock.\" — Prophetic Tradition",
 ];
 
 pub const QUOTE_COUNT: usize = QUOTES.len();


### PR DESCRIPTION
### Changes

1. **Gemini CLI Integration**
   - Added `gemini` as a first-class backend.
   - **Research Finding**: Forced `TERM=xterm-256color` specifically for Gemini sessions. Research showed that Gemini (built with the Ink framework) requires a high-capability `TERM` variable to render its TUI; otherwise, it falls back to a plain-text 'headless' mode.
   - Switched Gemini flag from `-p` (non-interactive) to `-i` (interactive) to enable the full TUI experience within Omar's panes.

2. **OpenCode Permission Fix**
   - Switched from `--dangerously-skip-permissions` flag to `OPENCODE_DANGEROUSLY_SKIP_PERMISSIONS=true` environment variable.
   - **Research Finding**: While PR #7137 and #9073 in the OpenCode repository proposed the CLI flag for parity with Claude, these are either pending or closed. Verification on version 1.2.27 confirmed the environment variable is the reliable way to enable 'YOLO mode' in stable releases.

3. **Dashboard & TUI Improvements**
   - Updated `tmux capture-pane` to use the `-e` flag. This preserves ANSI color escape sequences, allowing the dashboard to render the colorful TUIs of Gemini, Claude, and OpenCode correctly.
   - Added new leadership quotes from Prophetic traditions focusing on stewardship and responsibility:
     - *"The leader of a people is their servant."*
     - *"All of you are shepherds and each of you is responsible for his flock."*

4. **CI & Standards**
   - Applied `cargo fmt` and resolved Clippy lints.
   - Updated `detect_agent_command` and `resolve_backend` to support all 5 backends with refined priority: Claude, Codex, Gemini, OpenCode, Cursor.
   - Verified 77 unit tests and 10 integration tests pass.