### PR TITLE
feat: watchdog agent for auth failure monitoring

### DIFF
--- a/bridges/slack/src/server.rs
+++ b/bridges/slack/src/server.rs
@@ -22,7 +22,8 @@ pub struct ServerState {
 #[derive(Debug, Deserialize)]
 pub struct SlackReplyRequest {
     pub channel: String,
-    pub thread_ts: String,
+    #[serde(default)]
+    pub thread_ts: Option<String>,
     pub text: String,
 }
 
@@ -40,7 +41,7 @@ async fn handle_reply(
     Json(req): Json<SlackReplyRequest>,
 ) -> impl IntoResponse {
     info!(
-        "Reply request: channel={} thread={} text_len={}",
+        "Reply request: channel={} thread={:?} text_len={}",
         req.channel,
         req.thread_ts,
         req.text.len()
@@ -51,7 +52,7 @@ async fn handle_reply(
         .post_message_chunked(
             &req.channel,
             &req.text,
-            Some(&req.thread_ts),
+            req.thread_ts.as_deref(),
             state.max_message_length,
         )
         .await

--- a/prompts/watchdog.md
+++ b/prompts/watchdog.md
@@ -1,0 +1,58 @@
+You are the OMAR Watchdog. You were spawned because one or more agents experienced an authentication failure. Your job is to monitor all agents and notify the user via Slack.
+
+IMPORTANT: You are running on an untrusted/free backend. You do NOT have access to any API keys or secrets. You can only communicate through the OMAR localhost APIs.
+
+## Your Task
+
+1. **Immediately notify the user** via Slack (if a channel is provided)
+2. **Periodically monitor** agent health via the OMAR API
+3. **Send follow-up notifications** if the situation persists or changes
+
+## APIs Available
+
+### OMAR API (agent monitoring)
+
+List all agents and their health:
+```bash
+curl -s http://localhost:9876/api/agents | python3 -m json.tool
+```
+
+Each agent has an `auth_failure` field (true/false) indicating auth problems.
+
+Get details for a specific agent:
+```bash
+curl -s http://localhost:9876/api/agents/<agent-id> | python3 -m json.tool
+```
+
+### Slack Bridge (user notification)
+
+Send a message to a Slack channel:
+```bash
+curl -X POST http://localhost:9877/api/slack/reply \
+  -H "Content-Type: application/json" \
+  -d '{"channel":"<CHANNEL_ID>","text":"your message here"}'
+```
+
+Check if Slack bridge is running:
+```bash
+curl -s http://localhost:9877/api/slack/health
+```
+
+## Behavior
+
+1. Parse the initial message for: failed agent names, Slack channel, API URLs
+2. If Slack channel is configured and bridge is healthy, send an alert:
+   - Include which agents failed
+   - Ask the user to check their subscription / re-authenticate
+3. Every 2 minutes, poll `GET /api/agents` to check current status
+4. If new agents fail, send updated Slack messages
+5. If all agents recover (no more `auth_failure: true`), send a recovery message and output `[TASK COMPLETE]`
+
+## Message Format
+
+Keep Slack messages concise:
+```
+⚠ OMAR Auth Failure
+Affected agents: ea, worker-1, worker-2
+Action needed: please re-authenticate your backend (e.g., run /login in Claude Code)
+```

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -146,6 +146,7 @@ pub async fn list_agents(
             status: "running".to_string(),
             health: a.health.as_str().to_string(),
             last_output: a.health_info.last_output.clone(),
+            auth_failure: a.health_info.auth_failure,
         })
         .collect();
 
@@ -154,6 +155,7 @@ pub async fn list_agents(
         status: "running".to_string(),
         health: m.health.as_str().to_string(),
         last_output: m.health_info.last_output.clone(),
+        auth_failure: m.health_info.auth_failure,
     });
 
     Ok(Json(ListAgentsResponse { agents, manager }))
@@ -202,6 +204,7 @@ pub async fn get_agent(
                 health: a.health.as_str().to_string(),
                 last_output: a.health_info.last_output.clone(),
                 output_tail,
+                auth_failure: a.health_info.auth_failure,
             }))
         }
         None => Err((

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -70,6 +70,7 @@ pub struct AgentInfo {
     pub status: String,
     pub health: String,
     pub last_output: String,
+    pub auth_failure: bool,
 }
 
 /// Response for listing agents
@@ -87,6 +88,7 @@ pub struct AgentDetailResponse {
     pub health: String,
     pub last_output: String,
     pub output_tail: String,
+    pub auth_failure: bool,
 }
 
 /// Request to send input to an agent

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use anyhow::Result;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use crate::config::Config;
@@ -115,12 +115,15 @@ pub struct App {
     pub sidebar_selected: usize,
     client: TmuxClient,
     health_checker: HealthChecker,
+    /// Sessions already respawned with fallback (prevents infinite loops)
+    respawned_sessions: HashSet<String>,
 }
 
 impl App {
     pub fn new(config: Config, ticker: TickerBuffer) -> Self {
         let client = TmuxClient::new(&config.dashboard.session_prefix);
-        let health_checker = HealthChecker::new(client.clone(), config.health.idle_warning);
+        let health_checker = HealthChecker::new(client.clone(), config.health.idle_warning)
+            .with_auth_failure_patterns(config.fallback.auth_failure_patterns.clone());
 
         Self {
             agents: Vec::new(),
@@ -173,6 +176,7 @@ impl App {
             sidebar_selected: 0,
             client,
             health_checker,
+            respawned_sessions: HashSet::new(),
         }
     }
 
@@ -743,6 +747,123 @@ impl App {
         Ok(())
     }
 
+    /// Check all agents for auth failures and spawn mirror agents using the
+    /// fallback command. The original sessions are kept alive so they can
+    /// resume once the backend recovers. Returns true if any mirror was spawned.
+    pub fn check_auth_failures(&mut self, ticker: &TickerBuffer) -> bool {
+        if self.config.fallback.command.is_empty() {
+            return false;
+        }
+
+        // Collect sessions that need a mirror
+        let mut to_mirror: Vec<(String, bool)> = Vec::new(); // (session_name, is_manager)
+
+        if let Some(ref mgr) = self.manager {
+            if mgr.health_info.auth_failure && !self.respawned_sessions.contains(&mgr.session.name)
+            {
+                to_mirror.push((mgr.session.name.clone(), true));
+            }
+        }
+
+        for agent in &self.agents {
+            if agent.health_info.auth_failure
+                && !self.respawned_sessions.contains(&agent.session.name)
+            {
+                to_mirror.push((agent.session.name.clone(), false));
+            }
+        }
+
+        if to_mirror.is_empty() {
+            return false;
+        }
+
+        let fallback_cmd = &self.config.fallback.command;
+        let prefix = self.config.dashboard.session_prefix.clone();
+
+        for (session_name, is_manager) in &to_mirror {
+            let short_name = session_name.strip_prefix(&prefix).unwrap_or(session_name);
+            let mirror_session = format!("{}-fallback", session_name);
+            let mirror_short = format!("{}-fallback", short_name);
+
+            // Skip if mirror already exists
+            if self.client.has_session(&mirror_session).unwrap_or(false) {
+                self.respawned_sessions.insert(session_name.clone());
+                continue;
+            }
+
+            ticker.push(format!(
+                "AUTH FAILURE in '{}' — spawning fallback mirror '{}'",
+                short_name, mirror_short
+            ));
+
+            let task = self.worker_tasks.get(session_name).cloned();
+            let parent = self.agent_parents.get(session_name).cloned();
+
+            let workdir = std::env::current_dir()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| ".".to_string());
+
+            let cmd = if *is_manager {
+                crate::manager::build_ea_command(fallback_cmd)
+            } else if task.is_some() {
+                let prompt_file = crate::manager::prompts_dir().join("agent.md");
+                crate::manager::build_agent_command(fallback_cmd, &prompt_file)
+            } else {
+                fallback_cmd.to_string()
+            };
+
+            if let Err(e) = self
+                .client
+                .new_session(&mirror_session, &cmd, Some(&workdir))
+            {
+                ticker.push(format!(
+                    "Failed to spawn fallback '{}': {}",
+                    mirror_short, e
+                ));
+                continue;
+            }
+
+            // Record parent for the mirror so it shows up in chain-of-command
+            if let Some(ref p) = parent {
+                memory::save_agent_parent(&mirror_session, p);
+            }
+
+            // Send the task to the mirror agent
+            if let Some(ref task_text) = task {
+                memory::save_worker_task(&mirror_session, task_text);
+                let parent_short = parent
+                    .as_deref()
+                    .and_then(|p| p.strip_prefix(&prefix))
+                    .unwrap_or("ea");
+                let user_msg = format!(
+                    "YOUR NAME: {}.\nYOUR PARENT: {}.\nYOUR TASK: {}",
+                    mirror_short, parent_short, task_text
+                );
+                let client = self.client.clone();
+                let session = mirror_session.clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_secs(2));
+                    let _ = client.send_keys_literal(&session, &user_msg);
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                    let _ = client.send_keys(&session, "Enter");
+                });
+            }
+
+            self.respawned_sessions.insert(session_name.clone());
+            ticker.push(format!(
+                "Fallback '{}' running (degraded mode)",
+                mirror_short
+            ));
+        }
+
+        self.set_persistent_warning(format!(
+            "⚠ Auth failure: {} mirror agent(s) spawned with fallback — check subscription",
+            to_mirror.len()
+        ));
+
+        true
+    }
+
     /// Set status message (persists for 3 seconds before auto-clearing)
     pub fn set_status(&mut self, msg: impl Into<String>) {
         self.status_message = Some(msg.into());
@@ -1077,6 +1198,7 @@ mod tests {
             health_info: HealthInfo {
                 state: health,
                 last_output: String::new(),
+                auth_failure: false,
             },
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -818,19 +818,18 @@ impl App {
         // No secrets — only localhost URLs and the Slack channel ID.
         let slack_channel = &self.config.watchdog.slack_channel;
         let failed_list = failed_agents.join(", ");
+        let slack_display = if slack_channel.is_empty() {
+            "(not configured)"
+        } else {
+            slack_channel
+        };
         let task_msg = format!(
             "AUTH FAILURE DETECTED.\n\
-             Failed agents: {}\n\
-             Slack channel: {}\n\
-             Omar API: http://localhost:{}\n\
-             Slack bridge: http://localhost:9877",
-            failed_list,
-            if slack_channel.is_empty() {
-                "(not configured)"
-            } else {
-                slack_channel
-            },
-            self.config.api.port,
+Failed agents: {}\n\
+Slack channel: {}\n\
+Omar API: http://localhost:{}\n\
+Slack bridge: http://localhost:9877",
+            failed_list, slack_display, self.config.api.port,
         );
 
         let client = self.client.clone();

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use anyhow::Result;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Instant;
 
 use crate::config::Config;
@@ -115,15 +115,15 @@ pub struct App {
     pub sidebar_selected: usize,
     client: TmuxClient,
     health_checker: HealthChecker,
-    /// Sessions already respawned with fallback (prevents infinite loops)
-    respawned_sessions: HashSet<String>,
+    /// Whether the watchdog agent has been spawned
+    watchdog_spawned: bool,
 }
 
 impl App {
     pub fn new(config: Config, ticker: TickerBuffer) -> Self {
         let client = TmuxClient::new(&config.dashboard.session_prefix);
         let health_checker = HealthChecker::new(client.clone(), config.health.idle_warning)
-            .with_auth_failure_patterns(config.fallback.auth_failure_patterns.clone());
+            .with_auth_failure_patterns(config.watchdog.auth_failure_patterns.clone());
 
         Self {
             agents: Vec::new(),
@@ -176,7 +176,7 @@ impl App {
             sidebar_selected: 0,
             client,
             health_checker,
-            respawned_sessions: HashSet::new(),
+            watchdog_spawned: false,
         }
     }
 
@@ -747,118 +747,106 @@ impl App {
         Ok(())
     }
 
-    /// Check all agents for auth failures and spawn mirror agents using the
-    /// fallback command. The original sessions are kept alive so they can
-    /// resume once the backend recovers. Returns true if any mirror was spawned.
+    /// Check all agents for auth failures and spawn a single watchdog agent
+    /// to monitor errors and notify the user via Slack. Returns true if the
+    /// watchdog was spawned.
     pub fn check_auth_failures(&mut self, ticker: &TickerBuffer) -> bool {
-        if self.config.fallback.command.is_empty() {
+        if self.config.watchdog.command.is_empty() || self.watchdog_spawned {
             return false;
         }
 
-        // Collect sessions that need a mirror
-        let mut to_mirror: Vec<(String, bool)> = Vec::new(); // (session_name, is_manager)
+        // Collect names of agents with auth failures
+        let prefix = &self.config.dashboard.session_prefix;
+        let mut failed_agents: Vec<String> = Vec::new();
 
         if let Some(ref mgr) = self.manager {
-            if mgr.health_info.auth_failure && !self.respawned_sessions.contains(&mgr.session.name)
-            {
-                to_mirror.push((mgr.session.name.clone(), true));
+            if mgr.health_info.auth_failure {
+                let short = mgr
+                    .session
+                    .name
+                    .strip_prefix(prefix)
+                    .unwrap_or(&mgr.session.name);
+                failed_agents.push(short.to_string());
             }
         }
 
         for agent in &self.agents {
-            if agent.health_info.auth_failure
-                && !self.respawned_sessions.contains(&agent.session.name)
-            {
-                to_mirror.push((agent.session.name.clone(), false));
+            if agent.health_info.auth_failure {
+                let short = agent
+                    .session
+                    .name
+                    .strip_prefix(prefix)
+                    .unwrap_or(&agent.session.name);
+                failed_agents.push(short.to_string());
             }
         }
 
-        if to_mirror.is_empty() {
+        if failed_agents.is_empty() {
             return false;
         }
 
-        let fallback_cmd = &self.config.fallback.command;
-        let prefix = self.config.dashboard.session_prefix.clone();
+        let watchdog_session = format!("{}watchdog", prefix);
 
-        for (session_name, is_manager) in &to_mirror {
-            let short_name = session_name.strip_prefix(&prefix).unwrap_or(session_name);
-            let mirror_session = format!("{}-fallback", session_name);
-            let mirror_short = format!("{}-fallback", short_name);
-
-            // Skip if mirror already exists
-            if self.client.has_session(&mirror_session).unwrap_or(false) {
-                self.respawned_sessions.insert(session_name.clone());
-                continue;
-            }
-
-            ticker.push(format!(
-                "AUTH FAILURE in '{}' — spawning fallback mirror '{}'",
-                short_name, mirror_short
-            ));
-
-            let task = self.worker_tasks.get(session_name).cloned();
-            let parent = self.agent_parents.get(session_name).cloned();
-
-            let workdir = std::env::current_dir()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_else(|_| ".".to_string());
-
-            let cmd = if *is_manager {
-                crate::manager::build_ea_command(fallback_cmd)
-            } else if task.is_some() {
-                let prompt_file = crate::manager::prompts_dir().join("agent.md");
-                crate::manager::build_agent_command(fallback_cmd, &prompt_file)
-            } else {
-                fallback_cmd.to_string()
-            };
-
-            if let Err(e) = self
-                .client
-                .new_session(&mirror_session, &cmd, Some(&workdir))
-            {
-                ticker.push(format!(
-                    "Failed to spawn fallback '{}': {}",
-                    mirror_short, e
-                ));
-                continue;
-            }
-
-            // Record parent for the mirror so it shows up in chain-of-command
-            if let Some(ref p) = parent {
-                memory::save_agent_parent(&mirror_session, p);
-            }
-
-            // Send the task to the mirror agent
-            if let Some(ref task_text) = task {
-                memory::save_worker_task(&mirror_session, task_text);
-                let parent_short = parent
-                    .as_deref()
-                    .and_then(|p| p.strip_prefix(&prefix))
-                    .unwrap_or("ea");
-                let user_msg = format!(
-                    "YOUR NAME: {}.\nYOUR PARENT: {}.\nYOUR TASK: {}",
-                    mirror_short, parent_short, task_text
-                );
-                let client = self.client.clone();
-                let session = mirror_session.clone();
-                std::thread::spawn(move || {
-                    std::thread::sleep(std::time::Duration::from_secs(2));
-                    let _ = client.send_keys_literal(&session, &user_msg);
-                    std::thread::sleep(std::time::Duration::from_millis(500));
-                    let _ = client.send_keys(&session, "Enter");
-                });
-            }
-
-            self.respawned_sessions.insert(session_name.clone());
-            ticker.push(format!(
-                "Fallback '{}' running (degraded mode)",
-                mirror_short
-            ));
+        // Skip if watchdog already exists
+        if self.client.has_session(&watchdog_session).unwrap_or(false) {
+            self.watchdog_spawned = true;
+            return false;
         }
 
+        ticker.push(format!(
+            "AUTH FAILURE in {} agent(s) — spawning watchdog",
+            failed_agents.len()
+        ));
+
+        let watchdog_cmd = &self.config.watchdog.command;
+        let prompt_file = crate::manager::prompts_dir().join("watchdog.md");
+        let cmd = crate::manager::build_agent_command(watchdog_cmd, &prompt_file);
+
+        let workdir = std::env::current_dir()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| ".".to_string());
+
+        if let Err(e) = self
+            .client
+            .new_session(&watchdog_session, &cmd, Some(&workdir))
+        {
+            ticker.push(format!("Failed to spawn watchdog: {}", e));
+            return false;
+        }
+
+        // Build the initial task message for the watchdog.
+        // No secrets — only localhost URLs and the Slack channel ID.
+        let slack_channel = &self.config.watchdog.slack_channel;
+        let failed_list = failed_agents.join(", ");
+        let task_msg = format!(
+            "AUTH FAILURE DETECTED.\n\
+             Failed agents: {}\n\
+             Slack channel: {}\n\
+             Omar API: http://localhost:{}\n\
+             Slack bridge: http://localhost:9877",
+            failed_list,
+            if slack_channel.is_empty() {
+                "(not configured)"
+            } else {
+                slack_channel
+            },
+            self.config.api.port,
+        );
+
+        let client = self.client.clone();
+        let session = watchdog_session;
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(2));
+            let _ = client.send_keys_literal(&session, &task_msg);
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            let _ = client.send_keys(&session, "Enter");
+        });
+
+        self.watchdog_spawned = true;
+
         self.set_persistent_warning(format!(
-            "⚠ Auth failure: {} mirror agent(s) spawned with fallback — check subscription",
-            to_mirror.len()
+            "⚠ Auth failure in {} agent(s) — watchdog monitoring",
+            failed_agents.len()
         ));
 
         true

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,9 @@ pub struct Config {
 
     #[serde(default)]
     pub api: ApiConfig,
+
+    #[serde(default)]
+    pub fallback: FallbackConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,6 +80,18 @@ pub struct ApiConfig {
     /// Port to listen on
     #[serde(default = "default_api_port")]
     pub port: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FallbackConfig {
+    /// Command to use when auth failure is detected (empty = fallback disabled).
+    /// Example: "env ANTHROPIC_API_KEY=sk-or-xxx ANTHROPIC_BASE_URL=https://openrouter.ai/api/v1 claude --dangerously-skip-permissions --model anthropic/claude-sonnet-4-5-20250514"
+    #[serde(default)]
+    pub command: String,
+
+    /// Patterns in agent output that indicate an authentication failure
+    #[serde(default = "default_auth_failure_patterns")]
+    pub auth_failure_patterns: Vec<String>,
 }
 
 fn default_true() -> bool {
@@ -163,6 +178,17 @@ fn default_workdir() -> String {
     ".".to_string()
 }
 
+fn default_auth_failure_patterns() -> Vec<String> {
+    vec![
+        "session expired".to_string(),
+        "authentication failed".to_string(),
+        "please sign in".to_string(),
+        "login required".to_string(),
+        "subscription expired".to_string(),
+        "log in with".to_string(),
+    ]
+}
+
 fn default_api_enabled() -> bool {
     true
 }
@@ -211,6 +237,15 @@ impl Default for ApiConfig {
             enabled: default_api_enabled(),
             host: default_api_host(),
             port: default_api_port(),
+        }
+    }
+}
+
+impl Default for FallbackConfig {
+    fn default() -> Self {
+        Self {
+            command: String::new(),
+            auth_failure_patterns: default_auth_failure_patterns(),
         }
     }
 }
@@ -415,5 +450,43 @@ default_command = "aider --yes"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.agent.default_command, "aider --yes");
+    }
+
+    #[test]
+    fn test_default_fallback_config() {
+        let config = Config::default();
+        assert!(config.fallback.command.is_empty());
+        assert!(!config.fallback.auth_failure_patterns.is_empty());
+        assert!(config
+            .fallback
+            .auth_failure_patterns
+            .iter()
+            .any(|p| p == "session expired"));
+    }
+
+    #[test]
+    fn test_parse_fallback_config() {
+        let toml = r#"
+[fallback]
+command = "env ANTHROPIC_API_KEY=sk-or-xxx claude --dangerously-skip-permissions"
+auth_failure_patterns = ["session expired", "login required"]
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.fallback.command,
+            "env ANTHROPIC_API_KEY=sk-or-xxx claude --dangerously-skip-permissions"
+        );
+        assert_eq!(config.fallback.auth_failure_patterns.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_config_without_fallback_uses_defaults() {
+        let toml = r#"
+[agent]
+default_command = "claude --dangerously-skip-permissions"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.fallback.command.is_empty());
+        assert!(!config.fallback.auth_failure_patterns.is_empty());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ pub struct Config {
     pub api: ApiConfig,
 
     #[serde(default)]
-    pub fallback: FallbackConfig,
+    pub watchdog: WatchdogConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,15 +83,20 @@ pub struct ApiConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FallbackConfig {
-    /// Command to use when auth failure is detected (empty = fallback disabled).
-    /// Example: "env ANTHROPIC_API_KEY=sk-or-xxx ANTHROPIC_BASE_URL=https://openrouter.ai/api/v1 claude --dangerously-skip-permissions --model anthropic/claude-sonnet-4-5-20250514"
+pub struct WatchdogConfig {
+    /// Command to run the watchdog agent (empty = watchdog disabled).
+    /// Should be an untrusted/free backend — no secrets will be passed.
+    /// Example: "opencode --model openrouter/openrouter/free"
     #[serde(default)]
     pub command: String,
 
     /// Patterns in agent output that indicate an authentication failure
     #[serde(default = "default_auth_failure_patterns")]
     pub auth_failure_patterns: Vec<String>,
+
+    /// Slack channel ID for watchdog alerts (empty = no Slack alerts)
+    #[serde(default)]
+    pub slack_channel: String,
 }
 
 fn default_true() -> bool {
@@ -180,12 +185,12 @@ fn default_workdir() -> String {
 
 fn default_auth_failure_patterns() -> Vec<String> {
     vec![
-        "session expired".to_string(),
-        "authentication failed".to_string(),
-        "please sign in".to_string(),
-        "login required".to_string(),
-        "subscription expired".to_string(),
-        "log in with".to_string(),
+        // Claude Code
+        "please run /login".to_string(),
+        // Codex
+        "401 unauthorized".to_string(),
+        // TODO: opencode
+        // TODO: cursor
     ]
 }
 
@@ -241,11 +246,12 @@ impl Default for ApiConfig {
     }
 }
 
-impl Default for FallbackConfig {
+impl Default for WatchdogConfig {
     fn default() -> Self {
         Self {
             command: String::new(),
             auth_failure_patterns: default_auth_failure_patterns(),
+            slack_channel: String::new(),
         }
     }
 }
@@ -453,40 +459,43 @@ default_command = "aider --yes"
     }
 
     #[test]
-    fn test_default_fallback_config() {
+    fn test_default_watchdog_config() {
         let config = Config::default();
-        assert!(config.fallback.command.is_empty());
-        assert!(!config.fallback.auth_failure_patterns.is_empty());
+        assert!(config.watchdog.command.is_empty());
+        assert!(config.watchdog.slack_channel.is_empty());
+        assert!(!config.watchdog.auth_failure_patterns.is_empty());
         assert!(config
-            .fallback
+            .watchdog
             .auth_failure_patterns
             .iter()
-            .any(|p| p == "session expired"));
+            .any(|p| p == "please run /login"));
     }
 
     #[test]
-    fn test_parse_fallback_config() {
+    fn test_parse_watchdog_config() {
         let toml = r#"
-[fallback]
-command = "env ANTHROPIC_API_KEY=sk-or-xxx claude --dangerously-skip-permissions"
+[watchdog]
+command = "claude --dangerously-skip-permissions"
+slack_channel = "C0123456789"
 auth_failure_patterns = ["session expired", "login required"]
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(
-            config.fallback.command,
-            "env ANTHROPIC_API_KEY=sk-or-xxx claude --dangerously-skip-permissions"
+            config.watchdog.command,
+            "claude --dangerously-skip-permissions"
         );
-        assert_eq!(config.fallback.auth_failure_patterns.len(), 2);
+        assert_eq!(config.watchdog.slack_channel, "C0123456789");
+        assert_eq!(config.watchdog.auth_failure_patterns.len(), 2);
     }
 
     #[test]
-    fn test_parse_config_without_fallback_uses_defaults() {
+    fn test_parse_config_without_watchdog_uses_defaults() {
         let toml = r#"
 [agent]
 default_command = "claude --dangerously-skip-permissions"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
-        assert!(config.fallback.command.is_empty());
-        assert!(!config.fallback.auth_failure_patterns.is_empty());
+        assert!(config.watchdog.command.is_empty());
+        assert!(!config.watchdog.auth_failure_patterns.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,6 +148,11 @@ fn relaunch_in_tmux() -> Result<()> {
 const TMUX_RECOMMENDED: &[(&str, &str, &str)] = &[
     ("mouse", "set -g mouse on", "mouse scrolling and selection"),
     (
+        "history-limit",
+        "set -g history-limit 9999",
+        "larger scrollback history",
+    ),
+    (
         "extended-keys",
         "set -g extended-keys always",
         "Shift+Enter in agents",
@@ -434,6 +439,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
 
     // Create app for dashboard (separate instance)
     let tick_rate = Duration::from_secs(config.dashboard.refresh_interval);
+    let app_ticker = ticker.clone();
     let mut app = App::new(config, ticker);
 
     // Show bridge status
@@ -782,6 +788,9 @@ async fn run_dashboard(config: Config) -> Result<()> {
                         if let Err(e) = app.refresh() {
                             app.set_status(format!("Error: {}", e));
                         }
+
+                        // Check for auth failures and respawn with fallback if configured
+                        app.check_auth_failures(&app_ticker);
                     }
 
                     // Keep system_state.md in sync with live state

--- a/src/main.rs
+++ b/src/main.rs
@@ -789,7 +789,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
                             app.set_status(format!("Error: {}", e));
                         }
 
-                        // Check for auth failures and respawn with fallback if configured
+                        // Check for auth failures and spawn watchdog if configured
                         app.check_auth_failures(&app_ticker);
                     }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -10,11 +10,13 @@ pub const MANAGER_SESSION: &str = "omar-agent-ea";
 // Embed prompt files at compile time so they work regardless of CWD.
 const PROMPT_EA: &str = include_str!("../../prompts/executive-assistant.md");
 const PROMPT_AGENT: &str = include_str!("../../prompts/agent.md");
+const PROMPT_WATCHDOG: &str = include_str!("../../prompts/watchdog.md");
 
 /// Embedded prompt files, keyed by filename.
 const EMBEDDED_PROMPTS: &[(&str, &str)] = &[
     ("executive-assistant.md", PROMPT_EA),
     ("agent.md", PROMPT_AGENT),
+    ("watchdog.md", PROMPT_WATCHDOG),
 ];
 
 /// Return the `~/.omar/prompts/` directory, writing embedded prompts on first call.

--- a/src/tmux/health.rs
+++ b/src/tmux/health.rs
@@ -195,6 +195,20 @@ mod tests {
         let session = "omar-test-auth-failure-live";
         let clean_session = "omar-test-auth-failure-clean";
 
+        // Cleanup guard: kill sessions on drop (including panics)
+        struct Cleanup(&'static str, &'static str);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = Command::new("tmux")
+                    .args(["kill-session", "-t", self.0])
+                    .output();
+                let _ = Command::new("tmux")
+                    .args(["kill-session", "-t", self.1])
+                    .output();
+            }
+        }
+        let _cleanup = Cleanup(session, clean_session);
+
         // Cleanup any leftover sessions
         tmux(&["kill-session", "-t", session]);
         tmux(&["kill-session", "-t", clean_session]);
@@ -212,7 +226,6 @@ mod tests {
             "Enter",
         ]) {
             eprintln!("Skipping test: tmux send-keys failed (sandbox or environment issue)");
-            tmux(&["kill-session", "-t", session]);
             return;
         }
         thread::sleep(Duration::from_millis(1000));
@@ -247,9 +260,5 @@ mod tests {
             !info.auth_failure,
             "Should NOT detect auth failure in clean pane"
         );
-
-        // Cleanup
-        tmux(&["kill-session", "-t", session]);
-        tmux(&["kill-session", "-t", clean_session]);
     }
 }

--- a/src/tmux/health.rs
+++ b/src/tmux/health.rs
@@ -36,6 +36,8 @@ pub struct HealthChecker {
     client: TmuxClient,
     /// Last captured pane content per session name
     last_frames: HashMap<String, String>,
+    /// Patterns that indicate auth failure (case-insensitive match)
+    auth_failure_patterns: Vec<String>,
 }
 
 impl HealthChecker {
@@ -43,7 +45,13 @@ impl HealthChecker {
         Self {
             client,
             last_frames: HashMap::new(),
+            auth_failure_patterns: Vec::new(),
         }
+    }
+
+    pub fn with_auth_failure_patterns(mut self, patterns: Vec<String>) -> Self {
+        self.auth_failure_patterns = patterns;
+        self
     }
 
     /// Check the health of a session by comparing against the previous frame.
@@ -72,12 +80,11 @@ impl HealthChecker {
     pub fn check_detailed(&mut self, session_name: &str) -> HealthInfo {
         let state = self.check(session_name);
 
-        let last_output = self
-            .last_frames
-            .get(session_name)
-            .map(|frame| {
-                frame
-                    .lines()
+        let frame = self.last_frames.get(session_name);
+
+        let last_output = frame
+            .map(|f| {
+                f.lines()
                     .next_back()
                     .unwrap_or("")
                     .trim()
@@ -87,7 +94,20 @@ impl HealthChecker {
             })
             .unwrap_or_default();
 
-        HealthInfo { state, last_output }
+        let auth_failure = frame
+            .map(|f| {
+                let lower = f.to_lowercase();
+                self.auth_failure_patterns
+                    .iter()
+                    .any(|pat| lower.contains(&pat.to_lowercase()))
+            })
+            .unwrap_or(false);
+
+        HealthInfo {
+            state,
+            last_output,
+            auth_failure,
+        }
     }
 
     /// Remove stale entries for sessions that no longer exist
@@ -102,6 +122,8 @@ impl HealthChecker {
 pub struct HealthInfo {
     pub state: HealthState,
     pub last_output: String,
+    /// Whether auth failure patterns were detected in the pane output
+    pub auth_failure: bool,
 }
 
 #[cfg(test)]
@@ -118,5 +140,38 @@ mod tests {
     fn test_health_state_icons() {
         assert_eq!(HealthState::Running.icon(), "●");
         assert_eq!(HealthState::Idle.icon(), "○");
+    }
+
+    #[test]
+    fn test_auth_failure_detection_in_frame() {
+        let patterns = vec!["session expired".to_string(), "login required".to_string()];
+
+        // Simulate: frame content contains auth failure
+        let frame_with_auth_failure =
+            "Some output\nError: Your session expired. Please sign in again.\nMore output";
+        let lower = frame_with_auth_failure.to_lowercase();
+        let detected = patterns
+            .iter()
+            .any(|pat| lower.contains(&pat.to_lowercase()));
+        assert!(detected);
+
+        // Simulate: normal frame content
+        let normal_frame = "Building project...\nCompilation successful\nRunning tests";
+        let lower = normal_frame.to_lowercase();
+        let detected = patterns
+            .iter()
+            .any(|pat| lower.contains(&pat.to_lowercase()));
+        assert!(!detected);
+    }
+
+    #[test]
+    fn test_auth_failure_case_insensitive() {
+        let patterns = vec!["session expired".to_string()];
+        let frame = "SESSION EXPIRED: please log in";
+        let lower = frame.to_lowercase();
+        let detected = patterns
+            .iter()
+            .any(|pat| lower.contains(&pat.to_lowercase()));
+        assert!(detected);
     }
 }

--- a/src/tmux/health.rs
+++ b/src/tmux/health.rs
@@ -36,7 +36,7 @@ pub struct HealthChecker {
     client: TmuxClient,
     /// Last captured pane content per session name
     last_frames: HashMap<String, String>,
-    /// Patterns that indicate auth failure (case-insensitive match)
+    /// Patterns that indicate auth failure (pre-lowercased for fast matching)
     auth_failure_patterns: Vec<String>,
 }
 
@@ -50,7 +50,7 @@ impl HealthChecker {
     }
 
     pub fn with_auth_failure_patterns(mut self, patterns: Vec<String>) -> Self {
-        self.auth_failure_patterns = patterns;
+        self.auth_failure_patterns = patterns.into_iter().map(|p| p.to_lowercase()).collect();
         self
     }
 
@@ -99,7 +99,7 @@ impl HealthChecker {
                 let lower = f.to_lowercase();
                 self.auth_failure_patterns
                     .iter()
-                    .any(|pat| lower.contains(&pat.to_lowercase()))
+                    .any(|pat| lower.contains(pat.as_str()))
             })
             .unwrap_or(false);
 
@@ -144,34 +144,112 @@ mod tests {
 
     #[test]
     fn test_auth_failure_detection_in_frame() {
-        let patterns = vec!["session expired".to_string(), "login required".to_string()];
+        let patterns = ["session expired", "login required"];
 
         // Simulate: frame content contains auth failure
         let frame_with_auth_failure =
             "Some output\nError: Your session expired. Please sign in again.\nMore output";
         let lower = frame_with_auth_failure.to_lowercase();
-        let detected = patterns
-            .iter()
-            .any(|pat| lower.contains(&pat.to_lowercase()));
+        let detected = patterns.iter().any(|pat| lower.contains(pat));
         assert!(detected);
 
         // Simulate: normal frame content
         let normal_frame = "Building project...\nCompilation successful\nRunning tests";
         let lower = normal_frame.to_lowercase();
-        let detected = patterns
-            .iter()
-            .any(|pat| lower.contains(&pat.to_lowercase()));
+        let detected = patterns.iter().any(|pat| lower.contains(pat));
         assert!(!detected);
     }
 
     #[test]
     fn test_auth_failure_case_insensitive() {
-        let patterns = vec!["session expired".to_string()];
+        let patterns = ["session expired"];
         let frame = "SESSION EXPIRED: please log in";
         let lower = frame.to_lowercase();
-        let detected = patterns
-            .iter()
-            .any(|pat| lower.contains(&pat.to_lowercase()));
+        let detected = patterns.iter().any(|pat| lower.contains(pat));
         assert!(detected);
+    }
+
+    /// Test auth failure detection via a live tmux session.
+    /// Creates a tmux pane, sends a fake auth failure message,
+    /// and verifies HealthChecker picks it up.
+    #[test]
+    fn test_auth_failure_detection_live_tmux() {
+        use std::process::Command;
+        use std::thread;
+        use std::time::Duration;
+
+        fn tmux(args: &[&str]) -> bool {
+            Command::new("tmux")
+                .args(args)
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        }
+
+        // Check tmux is available
+        if !tmux(&["-V"]) {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let session = "omar-test-auth-failure-live";
+        let clean_session = "omar-test-auth-failure-clean";
+
+        // Cleanup any leftover sessions
+        tmux(&["kill-session", "-t", session]);
+        tmux(&["kill-session", "-t", clean_session]);
+
+        // Create a session with a shell
+        assert!(tmux(&["new-session", "-d", "-s", session]));
+        thread::sleep(Duration::from_millis(500));
+
+        // Send a fake auth failure message into the pane
+        if !tmux(&[
+            "send-keys",
+            "-t",
+            session,
+            "echo 'Please run /login'",
+            "Enter",
+        ]) {
+            eprintln!("Skipping test: tmux send-keys failed (sandbox or environment issue)");
+            tmux(&["kill-session", "-t", session]);
+            return;
+        }
+        thread::sleep(Duration::from_millis(1000));
+
+        // Use HealthChecker to detect it
+        let client = TmuxClient::new("omar-test-");
+        let mut checker = HealthChecker::new(client, 30)
+            .with_auth_failure_patterns(vec!["please run /login".to_string()]);
+
+        let info = checker.check_detailed(session);
+        assert!(
+            info.auth_failure,
+            "Should detect auth failure in pane output, got: {:?}",
+            info.last_output
+        );
+
+        // Also verify a clean session does NOT trigger auth failure
+        assert!(tmux(&["new-session", "-d", "-s", clean_session]));
+        thread::sleep(Duration::from_millis(500));
+
+        assert!(tmux(&[
+            "send-keys",
+            "-t",
+            clean_session,
+            "echo 'all good'",
+            "Enter"
+        ]));
+        thread::sleep(Duration::from_millis(1000));
+
+        let info = checker.check_detailed(clean_session);
+        assert!(
+            !info.auth_failure,
+            "Should NOT detect auth failure in clean pane"
+        );
+
+        // Cleanup
+        tmux(&["kill-session", "-t", session]);
+        tmux(&["kill-session", "-t", clean_session]);
     }
 }


### PR DESCRIPTION
## Summary

- Replace per-session mirror agents with a single **watchdog agent** spawned on a free/untrusted backend
- Watchdog monitors all agent sessions and notifies the user via Slack
- No API keys or secrets are passed to the watchdog (security constraint)
- Rename `[fallback]` config section to `[watchdog]`, add `slack_channel` field
- Expose `auth_failure` field in `GET /api/agents` API responses
- Make `thread_ts` optional in Slack bridge `/api/slack/reply` endpoint (allows new messages, not just replies)
- Pre-lowercase auth failure patterns at init time (Copilot perf feedback)
- Embed `watchdog.md` prompt at compile time
- Fix clippy warnings, README typo

## Config example

```toml
[watchdog]
command = "opencode --model openrouter/openrouter/free"
slack_channel = "C0123456789"
```

## Test plan

- [x] `cargo test` — all 84 unit tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Manual: spawn omar, inject `echo 'Please run /login'` into agent pane, verify watchdog spawns and sends Slack alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)