### PR TITLE
feat: add Action Reasoning & Goal Alignment logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 ansi-to-tui = "7"
 uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
+tracing = "0.1.44"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -16,6 +16,16 @@ You have the judgment to decide. Use this guideline:
 
 When you do the work yourself, you have full access to all tools — reading files, writing code, running tests, etc. When you spawn sub-agents, you are a manager: delegate, monitor, guide, and report.
 
+## Action Reasoning & Goal Alignment
+
+Before you execute any significant action (e.g., modifying files, running bash commands, or spawning sub-agents), you MUST submit a structured log explaining your reasoning for the action and how it respects the user's specification/goal.
+
+```bash
+curl -X POST http://localhost:9876/api/logs \
+  -H "Content-Type: application/json" \
+  -d '{"agent_name": "<YOUR NAME>", "action": "Description of action", "justification": "Why this action aligns with the goal..."}'
+```
+
 IMPORTANT: When spawning sub-agents, you MUST use the OMAR HTTP API (curl commands).
 Do NOT use your internal Task tool, background agents, or any built-in multi-agent features.
 The OMAR API creates real tmux sessions that appear in the OMAR dashboard.

--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -7,6 +7,16 @@ CRITICAL: You are a DISPATCHER. Every user request becomes an agent — no excep
 - Your ONLY allowed actions: spawn agents, monitor agents, kill agents, manage projects, report results.
 - If you catch yourself doing anything other than calling the OMAR API, STOP and spawn an agent instead.
 
+## Action Reasoning & Goal Alignment
+
+Before executing any state-changing `curl` command (e.g., spawning an agent, completing a project, sending a Slack reply), you MUST submit a structured log explaining your reasoning for the action and how it aligns with the user's goal.
+
+```bash
+curl -X POST http://localhost:9876/api/logs \
+  -H "Content-Type: application/json" \
+  -d '{"agent_name": "ea", "action": "Spawning agent X", "justification": "Why this action is necessary and aligns with the user'\''s goal..."}'
+```
+
 IMPORTANT: You MUST use the OMAR HTTP API (curl commands) to spawn and manage agents.
 Do NOT use your internal Task tool, background agents, or any built-in multi-agent features.
 The OMAR API creates real tmux sessions that appear in the OMAR dashboard.

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -633,10 +633,11 @@ pub async fn log_justification(
         justification: req.justification.clone(),
     };
 
-    let ea_name = app.manager()
+    let ea_name = app
+        .manager()
         .map(|m| m.session.name.clone())
         .unwrap_or_else(|| "ea".to_string());
-    
+
     let session_id = app.session_id.clone();
     let filename = format!("justifications_{}_{}.jsonl", ea_name, session_id);
 

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -639,12 +639,16 @@ pub async fn log_justification(
         .unwrap_or_else(|| "ea".to_string());
 
     let session_id = app.session_id.clone();
-    let filename = format!("justifications_{}_{}.jsonl", ea_name, session_id);
 
-    let log_file_path = dirs::home_dir()
+    let log_dir = dirs::home_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join(".omar")
-        .join(filename);
+        .join("logs")
+        .join(&session_id);
+    let _ = std::fs::create_dir_all(&log_dir);
+
+    let filename = format!("justifications_{}.jsonl", ea_name);
+    let log_file_path = log_dir.join(filename);
 
     if let Ok(json_line) = serde_json::to_string(&entry) {
         use tokio::io::AsyncWriteExt;

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -575,6 +575,94 @@ pub async fn complete_project(
     }
 }
 
+// ── Logging handlers ──
+
+/// POST /api/logs
+pub async fn log_justification(
+    State(state): State<Arc<ApiState>>,
+    Json(req): Json<LogRequest>,
+) -> Result<Json<StatusResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let app = state.app.lock().await;
+    let prefix = app.client().prefix().to_string();
+
+    let mut hierarchy_path = Vec::new();
+    let parents = memory::load_agent_parents();
+
+    let mut current_session = resolve_session_name(&prefix, &req.agent_name);
+    // Build path backwards
+    hierarchy_path.push(display_name(&prefix, &current_session).to_string());
+
+    while let Some(parent) = parents.get(&current_session) {
+        if parent == crate::app::MANAGER_SESSION_NAME {
+            hierarchy_path.push("ea".to_string());
+            break;
+        } else {
+            let short_parent = display_name(&prefix, parent).to_string();
+            hierarchy_path.push(short_parent.clone());
+            current_session = parent.clone();
+        }
+    }
+
+    // Reverse to get root -> leaf
+    hierarchy_path.reverse();
+
+    // Ensure ea is the root if not present (e.g. for EA itself)
+    if (hierarchy_path.is_empty() || hierarchy_path[0] != "ea")
+        && (req.agent_name == "ea" || req.agent_name == crate::app::MANAGER_SESSION_NAME)
+    {
+        hierarchy_path.insert(0, "ea".to_string());
+        if hierarchy_path.len() > 1 && hierarchy_path[1] == "ea" {
+            hierarchy_path.remove(1);
+        }
+    }
+
+    // Print human-readable
+    tracing::info!(
+        "Justification [{}] Action: {} | Reason: {}",
+        hierarchy_path.join(" > "),
+        req.action,
+        req.justification
+    );
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let entry = LogEntry {
+        timestamp: now,
+        agent_name: req.agent_name.clone(),
+        hierarchy_path,
+        action: req.action.clone(),
+        justification: req.justification.clone(),
+    };
+
+    let ea_name = app.manager()
+        .map(|m| m.session.name.clone())
+        .unwrap_or_else(|| "ea".to_string());
+    
+    let session_id = app.session_id.clone();
+    let filename = format!("justifications_{}_{}.jsonl", ea_name, session_id);
+
+    let log_file_path = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".omar")
+        .join(filename);
+
+    if let Ok(json_line) = serde_json::to_string(&entry) {
+        use tokio::io::AsyncWriteExt;
+        let file_result: Result<tokio::fs::File, std::io::Error> = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_file_path)
+            .await;
+        if let Ok(mut f) = file_result {
+            let _ = f.write_all(format!("{}\n", json_line).as_bytes()).await;
+        }
+    }
+
+    Ok(Json(StatusResponse {
+        status: "logged".to_string(),
+        message: None,
+    }))
+}
+
 // ── Event Scheduler handlers ──
 
 /// POST /api/events

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -642,7 +642,9 @@ pub async fn log_justification(
         .join(&session_id);
     let _ = std::fs::create_dir_all(&log_dir);
 
-    let log_file_path = log_dir.join("justifications.jsonl");
+    let full_name = resolve_session_name(&prefix, &req.agent_name);
+    let short_name = display_name(&prefix, &full_name);
+    let log_file_path = log_dir.join(format!("{}.jsonl", short_name));
 
     if let Ok(json_line) = serde_json::to_string(&entry) {
         use tokio::io::AsyncWriteExt;

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -633,11 +633,6 @@ pub async fn log_justification(
         justification: req.justification.clone(),
     };
 
-    let ea_name = app
-        .manager()
-        .map(|m| m.session.name.clone())
-        .unwrap_or_else(|| "ea".to_string());
-
     let session_id = app.session_id.clone();
 
     let log_dir = dirs::home_dir()
@@ -647,8 +642,7 @@ pub async fn log_justification(
         .join(&session_id);
     let _ = std::fs::create_dir_all(&log_dir);
 
-    let filename = format!("justifications_{}.jsonl", ea_name);
-    let log_file_path = log_dir.join(filename);
+    let log_file_path = log_dir.join("justifications.jsonl");
 
     if let Ok(json_line) = serde_json::to_string(&entry) {
         use tokio::io::AsyncWriteExt;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -33,6 +33,7 @@ pub fn create_router(state: Arc<ApiState>) -> Router {
         .route("/api/projects", get(handlers::list_projects))
         .route("/api/projects", post(handlers::add_project))
         .route("/api/projects/:id", delete(handlers::complete_project))
+        .route("/api/logs", post(handlers::log_justification))
         .route("/api/events", post(handlers::schedule_event))
         .route("/api/events", get(handlers::list_events))
         .route("/api/events/:id", delete(handlers::cancel_event))

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -324,3 +324,23 @@ pub struct ComputerAvailabilityResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub screen_size: Option<ScreenSizeResponse>,
 }
+
+// ── Logging models ──
+
+/// Request to log a justification
+#[derive(Debug, Deserialize)]
+pub struct LogRequest {
+    pub agent_name: String,
+    pub action: String,
+    pub justification: String,
+}
+
+/// JSONL log entry format
+#[derive(Debug, Serialize)]
+pub struct LogEntry {
+    pub timestamp: String,
+    pub agent_name: String,
+    pub hierarchy_path: Vec<String>,
+    pub action: String,
+    pub justification: String,
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -71,6 +71,8 @@ pub struct AgentGroup<'a> {
 
 /// Application state
 pub struct App {
+    /// Unique session identifier (timestamp) for logs
+    pub session_id: String,
     pub agents: Vec<AgentInfo>,
     pub manager: Option<AgentInfo>,
     pub command_tree: Vec<CommandTreeNode>,
@@ -163,6 +165,7 @@ impl App {
             show_settings: false,
             settings_selected: 0,
             config,
+            session_id: chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string(),
             focus_parent: MANAGER_SESSION.to_string(),
             focus_stack: Vec::new(),
             focus_child_indices: Vec::new(),


### PR DESCRIPTION
Introduces a new `POST /api/logs` endpoint to capture structured reasoning logs from agents.
    
    The logs include the agent's name, action, and reasoning/justification for aligning with the user's goals.
    Logs are written to `~/.omar/justifications_<ea_name>_<session_id>.jsonl` and printed to stdout via tracing for both machine-readability and human inspection.

By incorporating the EA name, we are future proofing for the upcoming multi-EA feature
    
    The filename dynamically incorporates the EA's session name and the current session's timestamp, effectively handling agent restarts and concurrency.
    