### PR TITLE
ui: show OMAR in dashboard title, make quotes a setting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,10 @@ pub struct DashboardConfig {
     /// Sidebar on right side
     #[serde(default = "default_true")]
     pub sidebar_right: bool,
+
+    /// Show inspirational quotes in the status bar
+    #[serde(default)]
+    pub show_quotes: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -182,6 +186,7 @@ impl Default for DashboardConfig {
             session_prefix: default_session_prefix(),
             show_event_queue: true,
             sidebar_right: true,
+            show_quotes: false,
         }
     }
 }
@@ -256,7 +261,7 @@ impl Config {
 
     /// Number of toggleable settings
     pub fn settings_count(&self) -> usize {
-        2
+        3
     }
 
     /// Get label and current value for a setting by index
@@ -267,6 +272,7 @@ impl Config {
                 self.dashboard.show_event_queue,
             )),
             1 => Some(("Sidebar on right side", self.dashboard.sidebar_right)),
+            2 => Some(("Show inspirational quotes", self.dashboard.show_quotes)),
             _ => None,
         }
     }
@@ -276,6 +282,7 @@ impl Config {
         match index {
             0 => self.dashboard.show_event_queue = !self.dashboard.show_event_queue,
             1 => self.dashboard.sidebar_right = !self.dashboard.sidebar_right,
+            2 => self.dashboard.show_quotes = !self.dashboard.show_quotes,
             _ => {}
         }
         self.save();
@@ -310,7 +317,8 @@ mod tests {
     fn test_settings_toggle() {
         let mut config = Config::default();
         assert!(config.dashboard.show_event_queue);
-        assert_eq!(config.settings_count(), 2);
+        assert!(!config.dashboard.show_quotes);
+        assert_eq!(config.settings_count(), 3);
         assert_eq!(
             config.settings_item(0),
             Some(("Show event queue in sidebar", true))

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -424,10 +424,7 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         .as_nanos() as u64;
 
     let mut status_spans = vec![
-        Span::styled(
-            "One-Man Army ",
-            Style::default().add_modifier(Modifier::BOLD),
-        ),
+        Span::styled("OMAR ", Style::default().add_modifier(Modifier::BOLD)),
         Span::raw("| Agents: "),
         Span::styled(format!("{}", total), Style::default().fg(Color::White)),
         Span::raw(" | "),
@@ -489,9 +486,9 @@ fn render_status_row(frame: &mut Frame, app: &App, status_spans: &[Span], area: 
     let stats = Paragraph::new(Line::from(status_spans.to_vec()));
     frame.render_widget(stats, h_chunks[0]);
 
-    // Right: scrolling quote
+    // Right: scrolling quote (if enabled in settings)
     let quote_width = h_chunks[1].width as usize;
-    if quote_width > 5 {
+    if app.config.dashboard.show_quotes && quote_width > 5 {
         let qi = app.quote_order[app.quote_index % app.quote_order.len()];
         let quote = QUOTES[qi];
         let quote_len = quote.chars().count();


### PR DESCRIPTION
## Summary

- Replace "One-Man Army" with "OMAR" in the top-left dashboard status bar
- Add `show_quotes` toggle to dashboard settings (default: off)
- Inspirational quotes only render when enabled via the settings menu (`S` key)

## Config

```toml
[dashboard]
show_quotes = true  # default: false
```

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)