### PR TITLE
Fix CI: initialize new HealthInfo.auth_failure field in API tests

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1111,6 +1111,7 @@ mod tests {
             health_info: HealthInfo {
                 state: HealthState::Running,
                 last_output: String::new(),
+                auth_failure: false,
             },
         }
     }


### PR DESCRIPTION
## Summary
- Fixes CI compile failure after HealthInfo gained auth_failure
- Updates API handler test helper to initialize auth_failure: false

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test -- --test-threads=1