### PR TITLE
feat: meeting rooms with invites and live room popup

### DIFF
--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -190,6 +190,48 @@ curl http://localhost:9876/api/ea/{{EA_ID}}/events
 curl -X DELETE http://localhost:9876/api/ea/{{EA_ID}}/events/<event-id>
 ```
 
+### Meeting Rooms API
+
+Use meeting rooms for multi-agent discussion when you want one message to reach all participants.
+
+#### Create room
+```bash
+curl -X POST http://localhost:9876/api/ea/{{EA_ID}}/rooms \
+  -H "Content-Type: application/json" \
+  -d '{"name":"design-review","created_by":"<YOUR NAME>"}'
+```
+
+#### Invite another agent
+```bash
+curl -X POST http://localhost:9876/api/ea/{{EA_ID}}/rooms/design-review/invites \
+  -H "Content-Type: application/json" \
+  -d '{"invited_agent":"agent-name","invited_by":"<YOUR NAME>","message":"Join this review"}'
+```
+
+#### Accept/decline invite (for invited agent)
+```bash
+curl -X POST http://localhost:9876/api/ea/{{EA_ID}}/rooms/design-review/invites/<invite-id>/respond \
+  -H "Content-Type: application/json" \
+  -d '{"agent":"<YOUR NAME>","response":"accept"}'
+```
+
+#### Send message to room (broadcast fan-out)
+```bash
+curl -X POST http://localhost:9876/api/ea/{{EA_ID}}/rooms/design-review/messages \
+  -H "Content-Type: application/json" \
+  -d '{"sender":"<YOUR NAME>","payload":"My proposal is ..."}'
+```
+
+#### Read transcript
+```bash
+curl http://localhost:9876/api/ea/{{EA_ID}}/rooms/design-review/transcript
+```
+
+#### Close room
+```bash
+curl -X DELETE http://localhost:9876/api/ea/{{EA_ID}}/rooms/design-review
+```
+
 ## Skills
 
 If your task requires special capabilities, check the skills folder at `prompts/skills/` for detailed instructions. Read the relevant skill file before proceeding. When spawning sub-agents that need a skill, include the skill contents in the agent's task description.

--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -144,13 +144,12 @@ When the EA asks you to run a command and report its output, always relay the ou
 
 ## Status Reporting
 
-OMAR sends you a periodic `[STATUS CHECK]` event every 60 seconds. When you receive one, update your status via the API:
+Status checks are not automatically pushed to you. If your parent asks for status, update it via the API:
 ```bash
 curl -X PUT http://localhost:9876/api/ea/{{EA_ID}}/agents/<YOUR NAME>/status \
   -H "Content-Type: application/json" \
   -d '{"status": "Currently: <brief description of what you are doing>"}'
 ```
-Also update proactively after spawning sub-agents or reaching a milestone.
 
 ## Scheduling and Wake-ups
 

--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -124,6 +124,55 @@ curl http://localhost:9876/api/ea/{{EA_ID}}/projects
 curl -X DELETE http://localhost:9876/api/ea/{{EA_ID}}/projects/<id>
 ```
 
+### Meeting Rooms API
+
+Use meeting rooms for multi-agent discussions where one message should fan out to all participants.
+
+#### Create a room
+```bash
+curl -X POST http://localhost:9876/api/ea/{{EA_ID}}/rooms \
+  -H "Content-Type: application/json" \
+  -d '{"name":"audit-discussion","created_by":"ea"}'
+```
+
+#### List rooms
+```bash
+curl http://localhost:9876/api/ea/{{EA_ID}}/rooms
+```
+
+#### Invite an agent (any participant can invite any agent)
+```bash
+curl -X POST http://localhost:9876/api/ea/{{EA_ID}}/rooms/audit-discussion/invites \
+  -H "Content-Type: application/json" \
+  -d '{"invited_agent":"auditor-2","invited_by":"ea","message":"Join the audit meeting"}'
+```
+
+#### Respond to invite (accept/decline)
+```bash
+curl -X POST http://localhost:9876/api/ea/{{EA_ID}}/rooms/audit-discussion/invites/<invite-id>/respond \
+  -H "Content-Type: application/json" \
+  -d '{"agent":"auditor-2","response":"accept"}'
+```
+
+#### Send room message (fan-out)
+```bash
+curl -X POST http://localhost:9876/api/ea/{{EA_ID}}/rooms/audit-discussion/messages \
+  -H "Content-Type: application/json" \
+  -d '{"sender":"ea","payload":"Please review pipeline_v2 and propose fixes."}'
+```
+
+#### Read transcript
+```bash
+curl http://localhost:9876/api/ea/{{EA_ID}}/rooms/audit-discussion/transcript
+```
+
+#### Close room
+```bash
+curl -X DELETE http://localhost:9876/api/ea/{{EA_ID}}/rooms/audit-discussion
+```
+
+When a room closes (manual close or inactivity timeout), meeting minutes are written under `~/.omar/meetings/`.
+
 ## Monitoring Agents
 
 Poll agent output periodically:

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -19,6 +19,7 @@ use crate::ea;
 use crate::manager::{build_agent_command, prompts_dir};
 use crate::memory;
 use crate::projects;
+use crate::rooms::{InviteDecision, RoomError, RoomRegistry};
 use crate::scheduler::{event::ScheduledEvent, Scheduler};
 use crate::tmux::TmuxClient;
 
@@ -26,6 +27,7 @@ use crate::tmux::TmuxClient;
 pub struct ApiState {
     pub app: Arc<Mutex<App>>,
     pub scheduler: Arc<Scheduler>,
+    pub rooms: Arc<RoomRegistry>,
     pub computer_lock: ComputerLock,
     pub base_prefix: String,
     pub omar_dir: PathBuf,
@@ -86,6 +88,35 @@ fn health_from_activity(activity: i64, idle_warning: i64) -> String {
 
 fn timestamp_is_too_old(timestamp: u64, now: u64) -> bool {
     timestamp < now.saturating_sub(1_000_000_000)
+}
+
+fn room_error_response(err: RoomError) -> (StatusCode, Json<ErrorResponse>) {
+    let status = match err {
+        RoomError::NotFound(_) => StatusCode::NOT_FOUND,
+        RoomError::AlreadyExists(_) => StatusCode::CONFLICT,
+        RoomError::Forbidden(_) => StatusCode::FORBIDDEN,
+        RoomError::Invalid(_) => StatusCode::UNPROCESSABLE_ENTITY,
+    };
+    (
+        status,
+        Json(ErrorResponse {
+            error: err.to_string(),
+        }),
+    )
+}
+
+fn normalize_agent_name(prefix: &str, name: &str) -> String {
+    name.strip_prefix(prefix).unwrap_or(name).to_string()
+}
+
+fn ensure_agent_exists(prefix: &str, name: &str) -> bool {
+    let client = TmuxClient::new(prefix);
+    let session = if name.starts_with(prefix) {
+        name.to_string()
+    } else {
+        format!("{}{}", prefix, name)
+    };
+    client.has_session(&session).unwrap_or(false)
 }
 
 // ── Global handlers ──
@@ -1042,6 +1073,295 @@ pub async fn cancel_event(
             ))
         }
     }
+}
+
+// ── EA-scoped meeting room handlers ──
+
+/// POST /api/ea/:ea_id/rooms
+pub async fn create_room(
+    Path(ea_id): Path<u32>,
+    State(state): State<Arc<ApiState>>,
+    Json(req): Json<CreateRoomRequest>,
+) -> Result<Json<RoomSummaryResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (prefix, _manager, _state_dir) = resolve_ea(ea_id, &state)?;
+    let created_by = normalize_agent_name(&prefix, &req.created_by);
+    let room = state
+        .rooms
+        .create_room(ea_id, req.name.trim(), created_by.trim())
+        .map_err(room_error_response)?;
+    Ok(Json(RoomSummaryResponse {
+        name: room.name,
+        created_by: room.created_by,
+        participant_count: room.participant_count,
+        message_count: room.message_count,
+        last_activity_at: room.last_activity_at,
+    }))
+}
+
+/// GET /api/ea/:ea_id/rooms
+pub async fn list_rooms(
+    Path(ea_id): Path<u32>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ListRoomsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (_prefix, _manager, _state_dir) = resolve_ea(ea_id, &state)?;
+    let rooms = state
+        .rooms
+        .list_rooms(ea_id)
+        .into_iter()
+        .map(|r| RoomSummaryResponse {
+            name: r.name,
+            created_by: r.created_by,
+            participant_count: r.participant_count,
+            message_count: r.message_count,
+            last_activity_at: r.last_activity_at,
+        })
+        .collect();
+    Ok(Json(ListRoomsResponse { rooms }))
+}
+
+/// GET /api/ea/:ea_id/rooms/:room
+pub async fn get_room(
+    Path((ea_id, room)): Path<(u32, String)>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<RoomDetailResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (_prefix, _manager, _state_dir) = resolve_ea(ea_id, &state)?;
+    let snapshot = state.rooms.get_room(ea_id, &room).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("Room '{}' not found", room),
+            }),
+        )
+    })?;
+    Ok(Json(RoomDetailResponse {
+        name: snapshot.name,
+        created_by: snapshot.created_by,
+        participants: snapshot.participants,
+        created_at: snapshot.created_at,
+        last_activity_at: snapshot.last_activity_at,
+    }))
+}
+
+/// DELETE /api/ea/:ea_id/rooms/:room
+pub async fn close_room(
+    Path((ea_id, room)): Path<(u32, String)>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<StatusResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (_prefix, _manager, _state_dir) = resolve_ea(ea_id, &state)?;
+    state
+        .rooms
+        .close_room(ea_id, &room, "manual close")
+        .map_err(room_error_response)?;
+    Ok(Json(StatusResponse {
+        status: "closed".to_string(),
+        message: Some(format!("Closed room '{}'", room)),
+    }))
+}
+
+/// POST /api/ea/:ea_id/rooms/:room/invites
+pub async fn create_room_invite(
+    Path((ea_id, room)): Path<(u32, String)>,
+    State(state): State<Arc<ApiState>>,
+    Json(req): Json<CreateInviteRequest>,
+) -> Result<Json<InviteResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (prefix, _manager, _state_dir) = resolve_ea(ea_id, &state)?;
+    let invited_agent = normalize_agent_name(&prefix, &req.invited_agent);
+    let invited_by = normalize_agent_name(&prefix, &req.invited_by);
+
+    if !ensure_agent_exists(&prefix, &invited_agent) {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ErrorResponse {
+                error: format!("Invited agent '{}' does not exist", invited_agent),
+            }),
+        ));
+    }
+
+    let invite = state
+        .rooms
+        .create_invite(
+            ea_id,
+            &room,
+            &invited_by,
+            &invited_agent,
+            req.message,
+            req.expires_at,
+        )
+        .map_err(room_error_response)?;
+
+    Ok(Json(InviteResponse {
+        id: invite.id,
+        invited_agent: invite.invited_agent,
+        invited_by: invite.invited_by,
+        message: invite.message,
+        created_at: invite.created_at,
+        expires_at: invite.expires_at,
+        status: invite.status.as_str().to_string(),
+        responded_at: invite.responded_at,
+        reason: invite.reason,
+    }))
+}
+
+/// GET /api/ea/:ea_id/rooms/:room/invites
+pub async fn list_room_invites(
+    Path((ea_id, room)): Path<(u32, String)>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ListInvitesResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (_prefix, _manager, _state_dir) = resolve_ea(ea_id, &state)?;
+    let invites = state
+        .rooms
+        .list_invites(ea_id, &room)
+        .map_err(room_error_response)?
+        .into_iter()
+        .map(|i| InviteResponse {
+            id: i.id,
+            invited_agent: i.invited_agent,
+            invited_by: i.invited_by,
+            message: i.message,
+            created_at: i.created_at,
+            expires_at: i.expires_at,
+            status: i.status.as_str().to_string(),
+            responded_at: i.responded_at,
+            reason: i.reason,
+        })
+        .collect();
+    Ok(Json(ListInvitesResponse { invites }))
+}
+
+/// POST /api/ea/:ea_id/rooms/:room/invites/:invite_id/respond
+pub async fn respond_room_invite(
+    Path((ea_id, room, invite_id)): Path<(u32, String, String)>,
+    State(state): State<Arc<ApiState>>,
+    Json(req): Json<RespondInviteRequest>,
+) -> Result<Json<InviteResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (prefix, _manager, _state_dir) = resolve_ea(ea_id, &state)?;
+    let agent = normalize_agent_name(&prefix, &req.agent);
+    let decision = match req.response.as_str() {
+        "accept" => InviteDecision::Accept,
+        "decline" => InviteDecision::Decline,
+        other => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("Invalid response '{}'. Use 'accept' or 'decline'", other),
+                }),
+            ))
+        }
+    };
+
+    let invite = state
+        .rooms
+        .respond_invite(ea_id, &room, &invite_id, &agent, decision, req.reason)
+        .map_err(room_error_response)?;
+
+    Ok(Json(InviteResponse {
+        id: invite.id,
+        invited_agent: invite.invited_agent,
+        invited_by: invite.invited_by,
+        message: invite.message,
+        created_at: invite.created_at,
+        expires_at: invite.expires_at,
+        status: invite.status.as_str().to_string(),
+        responded_at: invite.responded_at,
+        reason: invite.reason,
+    }))
+}
+
+/// DELETE /api/ea/:ea_id/rooms/:room/invites/:invite_id
+pub async fn cancel_room_invite(
+    Path((ea_id, room, invite_id)): Path<(u32, String, String)>,
+    State(state): State<Arc<ApiState>>,
+    Json(req): Json<CancelInviteRequest>,
+) -> Result<Json<InviteResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (prefix, _manager, _state_dir) = resolve_ea(ea_id, &state)?;
+    let cancelled_by = normalize_agent_name(&prefix, &req.cancelled_by);
+    let invite = state
+        .rooms
+        .cancel_invite(ea_id, &room, &invite_id, &cancelled_by)
+        .map_err(room_error_response)?;
+    Ok(Json(InviteResponse {
+        id: invite.id,
+        invited_agent: invite.invited_agent,
+        invited_by: invite.invited_by,
+        message: invite.message,
+        created_at: invite.created_at,
+        expires_at: invite.expires_at,
+        status: invite.status.as_str().to_string(),
+        responded_at: invite.responded_at,
+        reason: invite.reason,
+    }))
+}
+
+/// POST /api/ea/:ea_id/rooms/:room/messages
+pub async fn send_room_message(
+    Path((ea_id, room)): Path<(u32, String)>,
+    State(state): State<Arc<ApiState>>,
+    Json(req): Json<RoomMessageRequest>,
+) -> Result<Json<RoomMessageResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (prefix, _manager, _state_dir) = resolve_ea(ea_id, &state)?;
+    let sender = normalize_agent_name(&prefix, &req.sender);
+    let (msg, recipients) = state
+        .rooms
+        .post_message(ea_id, &room, &sender, &req.payload)
+        .map_err(room_error_response)?;
+
+    for receiver in &recipients {
+        let event = ScheduledEvent {
+            id: uuid::Uuid::new_v4().to_string(),
+            sender: format!("room:{}:{}", room, sender),
+            receiver: receiver.clone(),
+            timestamp: msg.created_at,
+            payload: msg.payload.clone(),
+            created_at: msg.created_at,
+            recurring_ns: None,
+            ea_id,
+        };
+        state.scheduler.insert(event);
+    }
+
+    Ok(Json(RoomMessageResponse {
+        id: msg.id,
+        sender,
+        payload: msg.payload,
+        created_at: msg.created_at,
+        fanout_count: recipients.len(),
+    }))
+}
+
+/// GET /api/ea/:ea_id/rooms/:room/transcript
+pub async fn get_room_transcript(
+    Path((ea_id, room)): Path<(u32, String)>,
+    State(state): State<Arc<ApiState>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<TranscriptResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (_prefix, _manager, _state_dir) = resolve_ea(ea_id, &state)?;
+    let snapshot = state.rooms.get_room(ea_id, &room).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("Room '{}' not found", room),
+            }),
+        )
+    })?;
+    let mut messages = snapshot.transcript;
+    if let Some(limit) = params.get("limit").and_then(|s| s.parse::<usize>().ok()) {
+        if messages.len() > limit {
+            let start = messages.len() - limit;
+            messages = messages.split_off(start);
+        }
+    }
+    let messages = messages
+        .into_iter()
+        .map(|m| TranscriptMessageResponse {
+            id: m.id,
+            sender: m.sender,
+            payload: m.payload,
+            created_at: m.created_at,
+            delivered_to: m.delivered_to,
+            system: m.system,
+        })
+        .collect();
+    Ok(Json(TranscriptResponse { room, messages }))
 }
 
 // ── Computer Use handlers (global — not EA-scoped) ──

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -741,29 +741,6 @@ pub async fn spawn_agent(
         });
     }
 
-    // Schedule a recurring status check — ea_id is structural
-    if has_agent_prompt {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as u64;
-        let interval: u64 = 60_000_000_000; // 60 seconds
-        let event = ScheduledEvent {
-            id: uuid::Uuid::new_v4().to_string(),
-            sender: "omar".to_string(),
-            receiver: short_name.clone(),
-            timestamp: now + interval,
-            payload: format!(
-                "[STATUS CHECK] Update your status via the API: curl -X PUT http://localhost:9876/api/ea/{}/agents/<YOUR NAME>/status -H 'Content-Type: application/json' -d '{{\"status\": \"<1-line status>\"}}'",
-                ea_id
-            ),
-            created_at: now,
-            recurring_ns: Some(interval),
-            ea_id,
-        };
-        state.scheduler.insert(event);
-    }
-
     Ok(Json(SpawnAgentResponse {
         id: short_name,
         status: "running".to_string(),

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1288,7 +1288,10 @@ pub async fn send_room_message(
             sender: format!("room:{}:{}", room, sender),
             receiver: receiver.clone(),
             timestamp: msg.created_at,
-            payload: msg.payload.clone(),
+            payload: format!(
+                "[MEETING:{}] {}: {}\nReply in-room via: POST /api/ea/{}/rooms/{}/messages",
+                room, sender, msg.payload, ea_id, room
+            ),
             created_at: msg.created_at,
             recurring_ns: None,
             ea_id,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -59,6 +59,35 @@ pub fn create_router(state: Arc<ApiState>) -> Router {
         .route("/api/ea/:ea_id/events", post(handlers::schedule_event))
         .route("/api/ea/:ea_id/events", get(handlers::list_events))
         .route("/api/ea/:ea_id/events/:id", delete(handlers::cancel_event))
+        // EA-scoped: meeting rooms
+        .route("/api/ea/:ea_id/rooms", post(handlers::create_room))
+        .route("/api/ea/:ea_id/rooms", get(handlers::list_rooms))
+        .route("/api/ea/:ea_id/rooms/:room", get(handlers::get_room))
+        .route("/api/ea/:ea_id/rooms/:room", delete(handlers::close_room))
+        .route(
+            "/api/ea/:ea_id/rooms/:room/invites",
+            post(handlers::create_room_invite),
+        )
+        .route(
+            "/api/ea/:ea_id/rooms/:room/invites",
+            get(handlers::list_room_invites),
+        )
+        .route(
+            "/api/ea/:ea_id/rooms/:room/invites/:invite_id/respond",
+            post(handlers::respond_room_invite),
+        )
+        .route(
+            "/api/ea/:ea_id/rooms/:room/invites/:invite_id",
+            delete(handlers::cancel_room_invite),
+        )
+        .route(
+            "/api/ea/:ea_id/rooms/:room/messages",
+            post(handlers::send_room_message),
+        )
+        .route(
+            "/api/ea/:ea_id/rooms/:room/transcript",
+            get(handlers::get_room_transcript),
+        )
         // Computer use (global — one screen, one mouse)
         .route("/api/computer/status", get(handlers::computer_status))
         .route("/api/computer/lock", post(handlers::computer_lock_acquire))

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -235,6 +235,106 @@ pub struct EventCancelResponse {
     pub id: String,
 }
 
+// ── Meeting Room models ──
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRoomRequest {
+    pub name: String,
+    pub created_by: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomSummaryResponse {
+    pub name: String,
+    pub created_by: String,
+    pub participant_count: usize,
+    pub message_count: usize,
+    pub last_activity_at: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListRoomsResponse {
+    pub rooms: Vec<RoomSummaryResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomDetailResponse {
+    pub name: String,
+    pub created_by: String,
+    pub participants: Vec<String>,
+    pub created_at: u64,
+    pub last_activity_at: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateInviteRequest {
+    pub invited_agent: String,
+    pub invited_by: String,
+    pub message: Option<String>,
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InviteResponse {
+    pub id: String,
+    pub invited_agent: String,
+    pub invited_by: String,
+    pub message: Option<String>,
+    pub created_at: u64,
+    pub expires_at: Option<u64>,
+    pub status: String,
+    pub responded_at: Option<u64>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListInvitesResponse {
+    pub invites: Vec<InviteResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RespondInviteRequest {
+    pub agent: String,
+    pub response: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CancelInviteRequest {
+    pub cancelled_by: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RoomMessageRequest {
+    pub sender: String,
+    pub payload: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomMessageResponse {
+    pub id: String,
+    pub sender: String,
+    pub payload: String,
+    pub created_at: u64,
+    pub fanout_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TranscriptMessageResponse {
+    pub id: String,
+    pub sender: String,
+    pub payload: String,
+    pub created_at: u64,
+    pub delivered_to: Vec<String>,
+    pub system: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TranscriptResponse {
+    pub room: String,
+    pub messages: Vec<TranscriptMessageResponse>,
+}
+
 // ── Computer Use models ──
 
 /// Request to acquire the computer use lock

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use crate::config::Config;
 use crate::ea::{self, EaId, EaInfo};
 use crate::memory;
 use crate::projects::{self, Project};
+use crate::rooms::{RoomRegistry, RoomSnapshot, RoomSummary};
 use crate::scheduler::{ScheduledEvent, Scheduler, TickerBuffer};
 use crate::tmux::{HealthChecker, HealthInfo, HealthState, Session, TmuxClient};
 use crate::DASHBOARD_SESSION;
@@ -33,6 +34,7 @@ pub enum ConfirmAction {
 pub enum SidebarPanel {
     Projects,
     Events,
+    Rooms,
     ChainOfCommand,
 }
 
@@ -100,6 +102,10 @@ pub struct App {
     pub show_events: bool,
     /// Enlarged sidebar popup (None = hidden)
     pub sidebar_popup: Option<SidebarPanel>,
+    pub room_list_selected: usize,
+    pub active_meeting_room_name: Option<String>,
+    pub active_meeting_room: Option<RoomSnapshot>,
+    pub meeting_rooms: Vec<RoomSummary>,
     pub scheduled_events: Vec<ScheduledEvent>,
     pub ticker: TickerBuffer,
     pub ticker_offset: usize,
@@ -131,6 +137,7 @@ pub struct App {
     default_workdir: String,
     session_prefix: String,
     pub scheduler: Arc<Scheduler>,
+    pub rooms: Arc<RoomRegistry>,
     /// Whether the watchdog agent has been spawned
     watchdog_spawned: bool,
 }
@@ -170,6 +177,7 @@ impl App {
 
         let state_dir = ea::ea_state_dir(active_ea, &omar_dir);
         std::fs::create_dir_all(state_dir.join("status")).ok();
+        let rooms = Arc::new(RoomRegistry::new(omar_dir.clone()));
 
         Self {
             active_ea,
@@ -195,6 +203,10 @@ impl App {
             ea_input: String::new(),
             show_events: false,
             sidebar_popup: None,
+            room_list_selected: 0,
+            active_meeting_room_name: None,
+            active_meeting_room: None,
+            meeting_rooms: Vec::new(),
             scheduled_events: Vec::new(),
             ticker,
             ticker_offset: 0,
@@ -234,6 +246,7 @@ impl App {
             default_workdir: config.agent.default_workdir.clone(),
             session_prefix,
             scheduler,
+            rooms,
             watchdog_spawned: false,
         }
     }
@@ -257,7 +270,12 @@ impl App {
             || self.show_events
             || self.show_debug_console
             || self.show_settings
+            || self.active_meeting_room_name.is_some()
             || self.sidebar_popup.is_some()
+    }
+
+    pub fn rooms_registry(&self) -> Arc<RoomRegistry> {
+        self.rooms.clone()
     }
 
     pub fn client(&self) -> &TmuxClient {
@@ -428,7 +446,70 @@ impl App {
             self.selected = self.focus_child_indices.len() - 1;
         }
 
+        self.refresh_meeting_rooms();
+
         Ok(())
+    }
+
+    pub fn refresh_meeting_rooms(&mut self) {
+        let idle_ns = 10 * 60 * 1_000_000_000u64;
+        let closed = self.rooms.close_inactive(self.active_ea, idle_ns);
+        if !closed.is_empty() {
+            self.set_status(format!(
+                "Meeting ended: {}",
+                closed
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+
+        self.meeting_rooms = self.rooms.list_rooms(self.active_ea);
+        if self.room_list_selected >= self.meeting_rooms.len() {
+            self.room_list_selected = self.meeting_rooms.len().saturating_sub(1);
+        }
+
+        if let Some(ref room_name) = self.active_meeting_room_name {
+            self.active_meeting_room = self.rooms.get_room(self.active_ea, room_name);
+            if self.active_meeting_room.is_none() {
+                self.active_meeting_room_name = None;
+            }
+        }
+    }
+
+    pub fn room_selection_next(&mut self) {
+        if self.meeting_rooms.is_empty() {
+            self.room_list_selected = 0;
+            return;
+        }
+        self.room_list_selected = (self.room_list_selected + 1) % self.meeting_rooms.len();
+    }
+
+    pub fn room_selection_prev(&mut self) {
+        if self.meeting_rooms.is_empty() {
+            self.room_list_selected = 0;
+            return;
+        }
+        self.room_list_selected = if self.room_list_selected == 0 {
+            self.meeting_rooms.len() - 1
+        } else {
+            self.room_list_selected - 1
+        };
+    }
+
+    pub fn open_selected_meeting_room(&mut self) {
+        let Some(room) = self.meeting_rooms.get(self.room_list_selected).cloned() else {
+            self.set_status("No active meeting rooms");
+            return;
+        };
+        self.active_meeting_room_name = Some(room.name.clone());
+        self.active_meeting_room = self.rooms.get_room(self.active_ea, &room.name);
+    }
+
+    pub fn close_meeting_popup(&mut self) {
+        self.active_meeting_room_name = None;
+        self.active_meeting_room = None;
     }
 
     /// Ensure manager session exists, start if not
@@ -725,10 +806,11 @@ impl App {
                 if self.config.dashboard.show_event_queue {
                     SidebarPanel::Events
                 } else {
-                    SidebarPanel::ChainOfCommand
+                    SidebarPanel::Rooms
                 }
             }
-            SidebarPanel::Events => SidebarPanel::ChainOfCommand,
+            SidebarPanel::Events => SidebarPanel::Rooms,
+            SidebarPanel::Rooms => SidebarPanel::ChainOfCommand,
             SidebarPanel::ChainOfCommand => SidebarPanel::Projects,
         };
     }
@@ -738,13 +820,14 @@ impl App {
         self.sidebar_panel = match self.sidebar_panel {
             SidebarPanel::Projects => SidebarPanel::ChainOfCommand,
             SidebarPanel::Events => SidebarPanel::Projects,
-            SidebarPanel::ChainOfCommand => {
+            SidebarPanel::Rooms => {
                 if self.config.dashboard.show_event_queue {
                     SidebarPanel::Events
                 } else {
                     SidebarPanel::Projects
                 }
             }
+            SidebarPanel::ChainOfCommand => SidebarPanel::Rooms,
         };
     }
 
@@ -1178,7 +1261,11 @@ Slack bridge: http://localhost:9877",
         self.show_debug_console = false;
         self.show_settings = false;
         self.sidebar_popup = None;
+        self.active_meeting_room_name = None;
+        self.active_meeting_room = None;
+        self.room_list_selected = 0;
         self.pending_confirm = None;
+        self.refresh_meeting_rooms();
         Ok(())
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -105,6 +105,7 @@ pub struct App {
     pub room_list_selected: usize,
     pub active_meeting_room_name: Option<String>,
     pub active_meeting_room: Option<RoomSnapshot>,
+    pub meeting_popup_offset_from_end: usize,
     pub meeting_rooms: Vec<RoomSummary>,
     pub scheduled_events: Vec<ScheduledEvent>,
     pub ticker: TickerBuffer,
@@ -206,6 +207,7 @@ impl App {
             room_list_selected: 0,
             active_meeting_room_name: None,
             active_meeting_room: None,
+            meeting_popup_offset_from_end: 0,
             meeting_rooms: Vec::new(),
             scheduled_events: Vec::new(),
             ticker,
@@ -505,11 +507,23 @@ impl App {
         };
         self.active_meeting_room_name = Some(room.name.clone());
         self.active_meeting_room = self.rooms.get_room(self.active_ea, &room.name);
+        self.meeting_popup_offset_from_end = 0;
     }
 
     pub fn close_meeting_popup(&mut self) {
         self.active_meeting_room_name = None;
         self.active_meeting_room = None;
+        self.meeting_popup_offset_from_end = 0;
+    }
+
+    pub fn meeting_scroll_older(&mut self, lines: usize) {
+        self.meeting_popup_offset_from_end =
+            self.meeting_popup_offset_from_end.saturating_add(lines);
+    }
+
+    pub fn meeting_scroll_newer(&mut self, lines: usize) {
+        self.meeting_popup_offset_from_end =
+            self.meeting_popup_offset_from_end.saturating_sub(lines);
     }
 
     /// Ensure manager session exists, start if not
@@ -1263,6 +1277,7 @@ Slack bridge: http://localhost:9877",
         self.sidebar_popup = None;
         self.active_meeting_room_name = None;
         self.active_meeting_room = None;
+        self.meeting_popup_offset_from_end = 0;
         self.room_list_selected = 0;
         self.pending_confirm = None;
         self.refresh_meeting_rooms();

--- a/src/app.rs
+++ b/src/app.rs
@@ -105,7 +105,6 @@ pub struct App {
     pub room_list_selected: usize,
     pub active_meeting_room_name: Option<String>,
     pub active_meeting_room: Option<RoomSnapshot>,
-    pub meeting_popup_offset_from_end: usize,
     pub meeting_rooms: Vec<RoomSummary>,
     pub scheduled_events: Vec<ScheduledEvent>,
     pub ticker: TickerBuffer,
@@ -207,7 +206,6 @@ impl App {
             room_list_selected: 0,
             active_meeting_room_name: None,
             active_meeting_room: None,
-            meeting_popup_offset_from_end: 0,
             meeting_rooms: Vec::new(),
             scheduled_events: Vec::new(),
             ticker,
@@ -507,23 +505,11 @@ impl App {
         };
         self.active_meeting_room_name = Some(room.name.clone());
         self.active_meeting_room = self.rooms.get_room(self.active_ea, &room.name);
-        self.meeting_popup_offset_from_end = 0;
     }
 
     pub fn close_meeting_popup(&mut self) {
         self.active_meeting_room_name = None;
         self.active_meeting_room = None;
-        self.meeting_popup_offset_from_end = 0;
-    }
-
-    pub fn meeting_scroll_older(&mut self, lines: usize) {
-        self.meeting_popup_offset_from_end =
-            self.meeting_popup_offset_from_end.saturating_add(lines);
-    }
-
-    pub fn meeting_scroll_newer(&mut self, lines: usize) {
-        self.meeting_popup_offset_from_end =
-            self.meeting_popup_offset_from_end.saturating_sub(lines);
     }
 
     /// Ensure manager session exists, start if not
@@ -1277,7 +1263,6 @@ Slack bridge: http://localhost:9877",
         self.sidebar_popup = None;
         self.active_meeting_room_name = None;
         self.active_meeting_room = None;
-        self.meeting_popup_offset_from_end = 0;
         self.room_list_selected = 0;
         self.pending_confirm = None;
         self.refresh_meeting_rooms();

--- a/src/main.rs
+++ b/src/main.rs
@@ -883,6 +883,18 @@ async fn run_dashboard(config: Config) -> Result<()> {
                             KeyCode::Esc | KeyCode::Enter => {
                                 app.close_meeting_popup();
                             }
+                            KeyCode::Char('k') | KeyCode::Up => {
+                                app.meeting_scroll_older(1);
+                            }
+                            KeyCode::Char('j') | KeyCode::Down => {
+                                app.meeting_scroll_newer(1);
+                            }
+                            KeyCode::PageUp => {
+                                app.meeting_scroll_older(10);
+                            }
+                            KeyCode::PageDown => {
+                                app.meeting_scroll_newer(10);
+                            }
                             _ => {}
                         }
                         continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod event;
 mod manager;
 mod memory;
 mod projects;
+mod rooms;
 mod scheduler;
 mod tmux;
 mod ui;
@@ -638,13 +639,18 @@ async fn run_dashboard(config: Config) -> Result<()> {
     // Start API server if enabled
     if config.api.enabled {
         let api_config = config.api.clone();
-        let (base_prefix, omar_dir) = {
+        let (base_prefix, omar_dir, rooms) = {
             let app_guard = shared_app.lock().await;
-            (app_guard.base_prefix.clone(), app_guard.omar_dir.clone())
+            (
+                app_guard.base_prefix.clone(),
+                app_guard.omar_dir.clone(),
+                app_guard.rooms_registry(),
+            )
         };
         let api_state = Arc::new(api::handlers::ApiState {
             app: shared_app.clone(), // Same Arc — single source of truth
             scheduler: scheduler.clone(),
+            rooms,
             computer_lock: computer::new_lock(),
             base_prefix,
             omar_dir,
@@ -871,11 +877,38 @@ async fn run_dashboard(config: Config) -> Result<()> {
                         continue;
                     }
 
-                    // Handle sidebar enlarged popup
-                    if app.sidebar_popup.is_some() {
+                    // Handle live meeting room popup
+                    if app.active_meeting_room_name.is_some() {
                         match key.code {
                             KeyCode::Esc | KeyCode::Enter => {
+                                app.close_meeting_popup();
+                            }
+                            _ => {}
+                        }
+                        continue;
+                    }
+
+                    // Handle sidebar enlarged popup
+                    if let Some(panel) = app.sidebar_popup {
+                        match key.code {
+                            KeyCode::Esc => {
                                 app.sidebar_popup = None;
+                            }
+                            KeyCode::Enter => {
+                                if panel == app::SidebarPanel::Rooms {
+                                    app.open_selected_meeting_room();
+                                }
+                                app.sidebar_popup = None;
+                            }
+                            KeyCode::Char('j') | KeyCode::Down => {
+                                if panel == app::SidebarPanel::Rooms {
+                                    app.room_selection_next();
+                                }
+                            }
+                            KeyCode::Char('k') | KeyCode::Up => {
+                                if panel == app::SidebarPanel::Rooms {
+                                    app.room_selection_prev();
+                                }
                             }
                             _ => {}
                         }
@@ -986,6 +1019,9 @@ async fn run_dashboard(config: Config) -> Result<()> {
                                     app.scheduled_events.sort_by_key(|e| e.timestamp);
                                     app.show_events = true;
                                 } else {
+                                    if app.sidebar_panel == app::SidebarPanel::Rooms {
+                                        app.refresh_meeting_rooms();
+                                    }
                                     app.sidebar_popup = Some(app.sidebar_panel);
                                 }
                                 continue;
@@ -1128,6 +1164,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
                     // Fix V2: EA-scoped events instead of global list
                     app.scheduled_events = scheduler.list_by_ea(app.active_ea);
                     app.scheduled_events.sort_by_key(|e| e.timestamp);
+                    app.refresh_meeting_rooms();
 
                     // Skip refresh while a popup/input overlay is active
                     // to avoid interrupting user input.

--- a/src/main.rs
+++ b/src/main.rs
@@ -883,18 +883,6 @@ async fn run_dashboard(config: Config) -> Result<()> {
                             KeyCode::Esc | KeyCode::Enter => {
                                 app.close_meeting_popup();
                             }
-                            KeyCode::Char('k') | KeyCode::Up => {
-                                app.meeting_scroll_older(1);
-                            }
-                            KeyCode::Char('j') | KeyCode::Down => {
-                                app.meeting_scroll_newer(1);
-                            }
-                            KeyCode::PageUp => {
-                                app.meeting_scroll_older(10);
-                            }
-                            KeyCode::PageDown => {
-                                app.meeting_scroll_newer(10);
-                            }
                             _ => {}
                         }
                         continue;

--- a/src/rooms.rs
+++ b/src/rooms.rs
@@ -1,0 +1,679 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::RwLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InviteDecision {
+    Accept,
+    Decline,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InviteStatus {
+    Pending,
+    Accepted,
+    Declined,
+    Expired,
+    Cancelled,
+}
+
+impl InviteStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            InviteStatus::Pending => "pending",
+            InviteStatus::Accepted => "accepted",
+            InviteStatus::Declined => "declined",
+            InviteStatus::Expired => "expired",
+            InviteStatus::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InviteRecord {
+    pub id: String,
+    pub invited_agent: String,
+    pub invited_by: String,
+    pub message: Option<String>,
+    pub created_at: u64,
+    pub expires_at: Option<u64>,
+    pub status: InviteStatus,
+    pub responded_at: Option<u64>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RoomMessage {
+    pub id: String,
+    pub sender: String,
+    pub payload: String,
+    pub created_at: u64,
+    pub delivered_to: Vec<String>,
+    pub system: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct RoomSummary {
+    pub name: String,
+    pub created_by: String,
+    pub participant_count: usize,
+    pub message_count: usize,
+    pub last_activity_at: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct RoomSnapshot {
+    pub name: String,
+    pub created_by: String,
+    pub participants: Vec<String>,
+    pub transcript: Vec<RoomMessage>,
+    pub invites: Vec<InviteRecord>,
+    pub created_at: u64,
+    pub last_activity_at: u64,
+}
+
+#[derive(Debug, Clone)]
+struct Room {
+    name: String,
+    created_by: String,
+    participants: HashSet<String>,
+    transcript: Vec<RoomMessage>,
+    invites: HashMap<String, InviteRecord>,
+    created_at: u64,
+    last_activity_at: u64,
+}
+
+#[derive(Debug, Clone)]
+pub enum RoomError {
+    NotFound(String),
+    AlreadyExists(String),
+    Forbidden(String),
+    Invalid(String),
+}
+
+impl fmt::Display for RoomError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RoomError::NotFound(msg)
+            | RoomError::AlreadyExists(msg)
+            | RoomError::Forbidden(msg)
+            | RoomError::Invalid(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl std::error::Error for RoomError {}
+
+pub struct RoomRegistry {
+    rooms: RwLock<HashMap<u32, HashMap<String, Room>>>,
+    omar_dir: PathBuf,
+    transcript_cap: usize,
+}
+
+impl RoomRegistry {
+    pub fn new(omar_dir: PathBuf) -> Self {
+        Self {
+            rooms: RwLock::new(HashMap::new()),
+            omar_dir,
+            transcript_cap: 2_000,
+        }
+    }
+
+    pub fn create_room(
+        &self,
+        ea_id: u32,
+        name: &str,
+        created_by: &str,
+    ) -> Result<RoomSummary, RoomError> {
+        validate_room_name(name)?;
+        let mut guard = self.rooms.write().unwrap();
+        let per_ea = guard.entry(ea_id).or_default();
+        if per_ea.contains_key(name) {
+            return Err(RoomError::AlreadyExists(format!(
+                "Room '{}' already exists",
+                name
+            )));
+        }
+
+        let now = now_ns();
+        let mut participants = HashSet::new();
+        if !created_by.trim().is_empty() {
+            participants.insert(created_by.trim().to_string());
+        }
+        let room = Room {
+            name: name.to_string(),
+            created_by: created_by.to_string(),
+            participants,
+            transcript: Vec::new(),
+            invites: HashMap::new(),
+            created_at: now,
+            last_activity_at: now,
+        };
+        per_ea.insert(name.to_string(), room);
+        Ok(self
+            .room_summary_from_map(per_ea, name)
+            .expect("just inserted"))
+    }
+
+    pub fn list_rooms(&self, ea_id: u32) -> Vec<RoomSummary> {
+        let guard = self.rooms.read().unwrap();
+        let Some(per_ea) = guard.get(&ea_id) else {
+            return Vec::new();
+        };
+        let mut rooms: Vec<RoomSummary> = per_ea
+            .values()
+            .map(|room| RoomSummary {
+                name: room.name.clone(),
+                created_by: room.created_by.clone(),
+                participant_count: room.participants.len(),
+                message_count: room.transcript.len(),
+                last_activity_at: room.last_activity_at,
+            })
+            .collect();
+        rooms.sort_by(|a, b| b.last_activity_at.cmp(&a.last_activity_at));
+        rooms
+    }
+
+    pub fn get_room(&self, ea_id: u32, name: &str) -> Option<RoomSnapshot> {
+        let guard = self.rooms.read().unwrap();
+        let room = guard.get(&ea_id)?.get(name)?;
+        Some(room_snapshot(room))
+    }
+
+    pub fn close_room(
+        &self,
+        ea_id: u32,
+        name: &str,
+        reason: &str,
+    ) -> Result<RoomSummary, RoomError> {
+        let mut guard = self.rooms.write().unwrap();
+        let per_ea = guard
+            .get_mut(&ea_id)
+            .ok_or_else(|| RoomError::NotFound(format!("Room '{}' not found", name)))?;
+        let room = per_ea
+            .remove(name)
+            .ok_or_else(|| RoomError::NotFound(format!("Room '{}' not found", name)))?;
+        let summary = RoomSummary {
+            name: room.name.clone(),
+            created_by: room.created_by.clone(),
+            participant_count: room.participants.len(),
+            message_count: room.transcript.len(),
+            last_activity_at: room.last_activity_at,
+        };
+        self.write_minutes(ea_id, &room, reason);
+        Ok(summary)
+    }
+
+    pub fn close_inactive(&self, ea_id: u32, idle_ns: u64) -> Vec<String> {
+        let mut guard = self.rooms.write().unwrap();
+        let Some(per_ea) = guard.get_mut(&ea_id) else {
+            return Vec::new();
+        };
+        let now = now_ns();
+        let to_close: Vec<String> = per_ea
+            .iter()
+            .filter_map(|(name, room)| {
+                if now.saturating_sub(room.last_activity_at) >= idle_ns {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for name in &to_close {
+            if let Some(room) = per_ea.remove(name) {
+                self.write_minutes(ea_id, &room, "inactive timeout");
+            }
+        }
+        to_close
+    }
+
+    pub fn create_invite(
+        &self,
+        ea_id: u32,
+        room_name: &str,
+        invited_by: &str,
+        invited_agent: &str,
+        message: Option<String>,
+        expires_at: Option<u64>,
+    ) -> Result<InviteRecord, RoomError> {
+        let mut guard = self.rooms.write().unwrap();
+        let room = get_room_mut(&mut guard, ea_id, room_name)?;
+        if !room.participants.contains(invited_by) {
+            return Err(RoomError::Forbidden(format!(
+                "'{}' is not a participant in room '{}'",
+                invited_by, room_name
+            )));
+        }
+        if room.participants.contains(invited_agent) {
+            return Err(RoomError::Invalid(format!(
+                "'{}' is already in room '{}'",
+                invited_agent, room_name
+            )));
+        }
+
+        let now = now_ns();
+        let invite = InviteRecord {
+            id: uuid::Uuid::new_v4().to_string(),
+            invited_agent: invited_agent.to_string(),
+            invited_by: invited_by.to_string(),
+            message,
+            created_at: now,
+            expires_at,
+            status: InviteStatus::Pending,
+            responded_at: None,
+            reason: None,
+        };
+        let invite_id = invite.id.clone();
+        room.invites.insert(invite_id, invite.clone());
+        room.last_activity_at = now;
+        append_system_message(
+            room,
+            format!("{} invited {}", invited_by, invited_agent),
+            now,
+            self.transcript_cap,
+        );
+        Ok(invite)
+    }
+
+    pub fn list_invites(
+        &self,
+        ea_id: u32,
+        room_name: &str,
+    ) -> Result<Vec<InviteRecord>, RoomError> {
+        let mut invites = {
+            let guard = self.rooms.read().unwrap();
+            let room = guard
+                .get(&ea_id)
+                .and_then(|m| m.get(room_name))
+                .ok_or_else(|| RoomError::NotFound(format!("Room '{}' not found", room_name)))?;
+            room.invites.values().cloned().collect::<Vec<_>>()
+        };
+        let now = now_ns();
+        for inv in &mut invites {
+            if inv.status == InviteStatus::Pending && inv.expires_at.is_some_and(|t| t <= now) {
+                inv.status = InviteStatus::Expired;
+            }
+        }
+        invites.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(invites)
+    }
+
+    pub fn cancel_invite(
+        &self,
+        ea_id: u32,
+        room_name: &str,
+        invite_id: &str,
+        cancelled_by: &str,
+    ) -> Result<InviteRecord, RoomError> {
+        let mut guard = self.rooms.write().unwrap();
+        let room = get_room_mut(&mut guard, ea_id, room_name)?;
+        if !room.participants.contains(cancelled_by) {
+            return Err(RoomError::Forbidden(format!(
+                "'{}' is not a participant in room '{}'",
+                cancelled_by, room_name
+            )));
+        }
+
+        let now = now_ns();
+        let cancelled_agent = {
+            let invite = room
+                .invites
+                .get_mut(invite_id)
+                .ok_or_else(|| RoomError::NotFound(format!("Invite '{}' not found", invite_id)))?;
+            if invite.status != InviteStatus::Pending {
+                return Err(RoomError::Invalid(format!(
+                    "Invite '{}' is not pending",
+                    invite_id
+                )));
+            }
+            if invite.expires_at.is_some_and(|t| t <= now) {
+                invite.status = InviteStatus::Expired;
+                return Err(RoomError::Invalid(format!(
+                    "Invite '{}' has expired",
+                    invite_id
+                )));
+            }
+            invite.status = InviteStatus::Cancelled;
+            invite.responded_at = Some(now);
+            invite.invited_agent.clone()
+        };
+        room.last_activity_at = now;
+        append_system_message(
+            room,
+            format!("{} cancelled invite for {}", cancelled_by, cancelled_agent),
+            now,
+            self.transcript_cap,
+        );
+        let invite = room
+            .invites
+            .get(invite_id)
+            .cloned()
+            .ok_or_else(|| RoomError::NotFound(format!("Invite '{}' not found", invite_id)))?;
+        Ok(invite)
+    }
+
+    pub fn respond_invite(
+        &self,
+        ea_id: u32,
+        room_name: &str,
+        invite_id: &str,
+        agent: &str,
+        decision: InviteDecision,
+        reason: Option<String>,
+    ) -> Result<InviteRecord, RoomError> {
+        let mut guard = self.rooms.write().unwrap();
+        let room = get_room_mut(&mut guard, ea_id, room_name)?;
+        let now = now_ns();
+        {
+            let invite = room
+                .invites
+                .get_mut(invite_id)
+                .ok_or_else(|| RoomError::NotFound(format!("Invite '{}' not found", invite_id)))?;
+            if invite.invited_agent != agent {
+                return Err(RoomError::Forbidden(format!(
+                    "Invite '{}' is not addressed to '{}'",
+                    invite_id, agent
+                )));
+            }
+            if invite.status != InviteStatus::Pending {
+                return Err(RoomError::Invalid(format!(
+                    "Invite '{}' is not pending",
+                    invite_id
+                )));
+            }
+            if invite.expires_at.is_some_and(|t| t <= now) {
+                invite.status = InviteStatus::Expired;
+                return Err(RoomError::Invalid(format!(
+                    "Invite '{}' has expired",
+                    invite_id
+                )));
+            }
+
+            invite.responded_at = Some(now);
+            invite.reason = reason;
+            match decision {
+                InviteDecision::Accept => {
+                    invite.status = InviteStatus::Accepted;
+                }
+                InviteDecision::Decline => {
+                    invite.status = InviteStatus::Declined;
+                }
+            }
+        }
+        match decision {
+            InviteDecision::Accept => {
+                room.participants.insert(agent.to_string());
+                append_system_message(
+                    room,
+                    format!("{} accepted invite", agent),
+                    now,
+                    self.transcript_cap,
+                );
+            }
+            InviteDecision::Decline => {
+                append_system_message(
+                    room,
+                    format!("{} declined invite", agent),
+                    now,
+                    self.transcript_cap,
+                );
+            }
+        }
+        room.last_activity_at = now;
+        let invite = room
+            .invites
+            .get(invite_id)
+            .cloned()
+            .ok_or_else(|| RoomError::NotFound(format!("Invite '{}' not found", invite_id)))?;
+        Ok(invite)
+    }
+
+    pub fn post_message(
+        &self,
+        ea_id: u32,
+        room_name: &str,
+        sender: &str,
+        payload: &str,
+    ) -> Result<(RoomMessage, Vec<String>), RoomError> {
+        if payload.trim().is_empty() {
+            return Err(RoomError::Invalid(
+                "Message payload cannot be empty".to_string(),
+            ));
+        }
+        let mut guard = self.rooms.write().unwrap();
+        let room = get_room_mut(&mut guard, ea_id, room_name)?;
+        if !room.participants.contains(sender) {
+            return Err(RoomError::Forbidden(format!(
+                "'{}' is not a participant in room '{}'",
+                sender, room_name
+            )));
+        }
+        let now = now_ns();
+        let mut delivered_to: Vec<String> = room
+            .participants
+            .iter()
+            .filter(|name| name.as_str() != sender)
+            .cloned()
+            .collect();
+        delivered_to.sort();
+        let msg = RoomMessage {
+            id: uuid::Uuid::new_v4().to_string(),
+            sender: sender.to_string(),
+            payload: payload.to_string(),
+            created_at: now,
+            delivered_to: delivered_to.clone(),
+            system: false,
+        };
+        room.transcript.push(msg.clone());
+        cap_transcript(&mut room.transcript, self.transcript_cap);
+        room.last_activity_at = now;
+        Ok((msg, delivered_to))
+    }
+
+    fn room_summary_from_map(
+        &self,
+        per_ea: &HashMap<String, Room>,
+        room_name: &str,
+    ) -> Option<RoomSummary> {
+        let room = per_ea.get(room_name)?;
+        Some(RoomSummary {
+            name: room.name.clone(),
+            created_by: room.created_by.clone(),
+            participant_count: room.participants.len(),
+            message_count: room.transcript.len(),
+            last_activity_at: room.last_activity_at,
+        })
+    }
+
+    fn write_minutes(&self, ea_id: u32, room: &Room, reason: &str) {
+        let meetings_dir = self.omar_dir.join("meetings");
+        if fs::create_dir_all(&meetings_dir).is_err() {
+            return;
+        }
+        let ts = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
+        let filename = format!("ea{}-{}-{}.md", ea_id, sanitize_name(&room.name), ts);
+        let path = meetings_dir.join(filename);
+
+        let mut participants: Vec<String> = room.participants.iter().cloned().collect();
+        participants.sort();
+        let mut transcript = String::new();
+        for msg in &room.transcript {
+            let local =
+                chrono::DateTime::<chrono::Utc>::from_timestamp_nanos(msg.created_at as i64)
+                    .with_timezone(&chrono::Local);
+            let prefix = if msg.system { "[system]" } else { "" };
+            transcript.push_str(&format!(
+                "- {} {} **{}**: {}\n",
+                local.format("%Y-%m-%d %H:%M:%S"),
+                prefix,
+                msg.sender,
+                msg.payload.replace('\n', " ")
+            ));
+        }
+
+        let content = format!(
+            "# Meeting Minutes: {}\n\n- EA: {}\n- Created by: {}\n- Created at: {}\n- Closed at: {}\n- Closed reason: {}\n- Participants: {}\n\n## Transcript\n{}\n",
+            room.name,
+            ea_id,
+            room.created_by,
+            fmt_ns(room.created_at),
+            fmt_ns(now_ns()),
+            reason,
+            participants.join(", "),
+            transcript
+        );
+        let _ = fs::write(path, content);
+    }
+}
+
+fn room_snapshot(room: &Room) -> RoomSnapshot {
+    let mut participants: Vec<String> = room.participants.iter().cloned().collect();
+    participants.sort();
+    let mut invites: Vec<InviteRecord> = room.invites.values().cloned().collect();
+    let now = now_ns();
+    for inv in &mut invites {
+        if inv.status == InviteStatus::Pending && inv.expires_at.is_some_and(|t| t <= now) {
+            inv.status = InviteStatus::Expired;
+        }
+    }
+    invites.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+    RoomSnapshot {
+        name: room.name.clone(),
+        created_by: room.created_by.clone(),
+        participants,
+        transcript: room.transcript.clone(),
+        invites,
+        created_at: room.created_at,
+        last_activity_at: room.last_activity_at,
+    }
+}
+
+fn get_room_mut<'a>(
+    all: &'a mut HashMap<u32, HashMap<String, Room>>,
+    ea_id: u32,
+    room_name: &str,
+) -> Result<&'a mut Room, RoomError> {
+    all.get_mut(&ea_id)
+        .and_then(|m| m.get_mut(room_name))
+        .ok_or_else(|| RoomError::NotFound(format!("Room '{}' not found", room_name)))
+}
+
+fn append_system_message(room: &mut Room, text: String, now: u64, cap: usize) {
+    room.transcript.push(RoomMessage {
+        id: uuid::Uuid::new_v4().to_string(),
+        sender: "system".to_string(),
+        payload: text,
+        created_at: now,
+        delivered_to: Vec::new(),
+        system: true,
+    });
+    cap_transcript(&mut room.transcript, cap);
+}
+
+fn cap_transcript(transcript: &mut Vec<RoomMessage>, cap: usize) {
+    if transcript.len() > cap {
+        let drop_n = transcript.len() - cap;
+        transcript.drain(0..drop_n);
+    }
+}
+
+fn validate_room_name(name: &str) -> Result<(), RoomError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(RoomError::Invalid("Room name cannot be empty".to_string()));
+    }
+    if trimmed.len() < 2 || trimmed.len() > 64 {
+        return Err(RoomError::Invalid(
+            "Room name must be 2..64 characters".to_string(),
+        ));
+    }
+    let mut chars = trimmed.chars();
+    let first = chars.next().unwrap();
+    if !first.is_ascii_alphanumeric() {
+        return Err(RoomError::Invalid(
+            "Room name must start with an alphanumeric character".to_string(),
+        ));
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(RoomError::Invalid(
+            "Room name supports only alphanumeric, '-' and '_'".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn sanitize_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn now_ns() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(std::time::Duration::ZERO)
+        .as_nanos() as u64
+}
+
+fn fmt_ns(ns: u64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_nanos(ns as i64)
+        .with_timezone(&chrono::Local)
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_registry() -> RoomRegistry {
+        let dir = std::env::temp_dir().join(format!("omar-rooms-test-{}", uuid::Uuid::new_v4()));
+        RoomRegistry::new(dir)
+    }
+
+    #[test]
+    fn invite_accept_adds_participant() {
+        let rooms = test_registry();
+        let _ = rooms.create_room(1, "audit", "firm-head").unwrap();
+        let inv = rooms
+            .create_invite(1, "audit", "firm-head", "auditor", None, None)
+            .unwrap();
+        let accepted = rooms
+            .respond_invite(1, "audit", &inv.id, "auditor", InviteDecision::Accept, None)
+            .unwrap();
+        assert_eq!(accepted.status, InviteStatus::Accepted);
+        let room = rooms.get_room(1, "audit").unwrap();
+        assert!(room.participants.contains(&"auditor".to_string()));
+    }
+
+    #[test]
+    fn room_message_fanout_excludes_sender() {
+        let rooms = test_registry();
+        let _ = rooms.create_room(1, "audit", "firm-head").unwrap();
+        let inv = rooms
+            .create_invite(1, "audit", "firm-head", "auditor", None, None)
+            .unwrap();
+        let _ = rooms
+            .respond_invite(1, "audit", &inv.id, "auditor", InviteDecision::Accept, None)
+            .unwrap();
+
+        let (_msg, recipients) = rooms
+            .post_message(1, "audit", "firm-head", "hello")
+            .unwrap();
+        assert_eq!(recipients, vec!["auditor".to_string()]);
+    }
+}

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -536,7 +536,12 @@ fn render_status_row(frame: &mut Frame, app: &App, status_spans: &[Span], area: 
 }
 
 fn render_projects_panel(frame: &mut Frame, app: &App, area: Rect) {
-    let border_color = Color::Gray;
+    let panel_active = app.sidebar_focused && app.sidebar_panel == SidebarPanel::Projects;
+    let border_color = if panel_active {
+        Color::Magenta
+    } else {
+        Color::Gray
+    };
     let block = Block::default()
         .title(" Projects ")
         .borders(Borders::ALL)
@@ -664,7 +669,7 @@ fn render_focus_parent(frame: &mut Frame, app: &App, area: Rect) {
 
         let (border_color, title_line) = if is_selected {
             (
-                Color::Gray,
+                Color::Magenta,
                 Line::from(vec![
                     Span::styled(" [", Style::default().fg(Color::Magenta)),
                     Span::styled(status_icon, Style::default().fg(Color::Magenta)),
@@ -798,7 +803,12 @@ fn render_focus_parent(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_command_tree(frame: &mut Frame, app: &App, area: Rect) {
-    let border_color = Color::Gray;
+    let panel_active = app.sidebar_focused && app.sidebar_panel == SidebarPanel::ChainOfCommand;
+    let border_color = if panel_active {
+        Color::Magenta
+    } else {
+        Color::Gray
+    };
     let block = Block::default()
         .title(" Chain of Command ")
         .borders(Borders::ALL)
@@ -891,7 +901,12 @@ fn render_command_tree(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_event_queue(frame: &mut Frame, app: &App, area: Rect) {
-    let border_color = Color::Gray;
+    let panel_active = app.sidebar_focused && app.sidebar_panel == SidebarPanel::Events;
+    let border_color = if panel_active {
+        Color::Magenta
+    } else {
+        Color::Gray
+    };
     let block = Block::default()
         .title(" Event Queue ")
         .borders(Borders::ALL)
@@ -937,7 +952,12 @@ fn render_event_queue(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_meeting_rooms_panel(frame: &mut Frame, app: &App, area: Rect) {
-    let border_color = Color::Gray;
+    let panel_active = app.sidebar_focused && app.sidebar_panel == SidebarPanel::Rooms;
+    let border_color = if panel_active {
+        Color::LightMagenta
+    } else {
+        Color::DarkGray
+    };
     let block = Block::default()
         .title(" Meeting Rooms ")
         .borders(Borders::ALL)
@@ -992,7 +1012,11 @@ fn render_summary_card(
         HealthState::Idle => (Color::Yellow, "○"),
     };
 
-    let border_color = Color::Gray;
+    let border_color = if selected {
+        Color::Magenta
+    } else {
+        Color::Gray
+    };
 
     let border_style = Style::default().fg(border_color).add_modifier(if selected {
         Modifier::BOLD
@@ -1310,7 +1334,7 @@ fn render_help_popup(frame: &mut Frame) {
     let block = Block::default()
         .title(" Help ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Gray));
+        .border_style(Style::default().fg(Color::Cyan));
 
     let paragraph = Paragraph::new(help_content).block(block);
 
@@ -1379,7 +1403,7 @@ fn render_confirm_dialog(frame: &mut Frame, app: &App, action: ConfirmAction) {
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Gray));
+        .border_style(Style::default().fg(Color::Red));
 
     let paragraph = Paragraph::new(content)
         .block(block)
@@ -1413,7 +1437,7 @@ fn render_project_input(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" New Project ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Gray));
+        .border_style(Style::default().fg(Color::Cyan));
 
     let paragraph = Paragraph::new(content)
         .block(block)
@@ -1447,7 +1471,7 @@ fn render_ea_input(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" New EA ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Gray));
+        .border_style(Style::default().fg(Color::Cyan));
 
     let paragraph = Paragraph::new(content)
         .block(block)
@@ -1580,7 +1604,7 @@ fn render_events_popup(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" Event Queue ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Gray));
+        .border_style(Style::default().fg(Color::Cyan));
 
     let paragraph = Paragraph::new(lines).block(block);
 
@@ -1624,7 +1648,7 @@ fn render_debug_console(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" Debug Console ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Gray));
+        .border_style(Style::default().fg(Color::Yellow));
 
     let paragraph = Paragraph::new(lines).block(block);
 
@@ -1678,7 +1702,7 @@ fn render_settings_popup(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" Settings ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Gray));
+        .border_style(Style::default().fg(Color::Cyan));
 
     let paragraph = Paragraph::new(lines).block(block);
 
@@ -1752,7 +1776,7 @@ fn render_meeting_room_popup(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" Live Meeting Room ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Gray))
+        .border_style(Style::default().fg(Color::Cyan))
         .padding(Padding::horizontal(1));
     let paragraph = Paragraph::new(lines)
         .block(block)
@@ -1883,7 +1907,7 @@ fn render_sidebar_popup(frame: &mut Frame, app: &App, panel: SidebarPanel) {
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Gray))
+        .border_style(Style::default().fg(Color::Magenta))
         .padding(Padding::horizontal(1));
 
     let paragraph = Paragraph::new(all_lines).block(block);

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1735,11 +1735,9 @@ fn render_meeting_room_popup(frame: &mut Frame, app: &App) {
         lines.push(Line::from(""));
 
         let body_height = area.height.saturating_sub(8) as usize;
-        let max_offset = room.transcript.len().saturating_sub(body_height);
-        let offset = app.meeting_popup_offset_from_end.min(max_offset);
-        let end = room.transcript.len().saturating_sub(offset);
-        let start = end.saturating_sub(body_height);
-        let messages = room.transcript[start..end].to_vec();
+        let msg_width = area.width.saturating_sub(6) as usize;
+        let start = room.transcript.len().saturating_sub(body_height);
+        let messages = room.transcript[start..].to_vec();
 
         for msg in messages {
             let ts = chrono::DateTime::<chrono::Utc>::from_timestamp_nanos(msg.created_at as i64)
@@ -1757,7 +1755,10 @@ fn render_meeting_room_popup(frame: &mut Frame, app: &App) {
                     format!("{}: ", msg.sender),
                     Style::default().fg(Color::Yellow),
                 ),
-                Span::styled(msg.payload, Style::default().fg(color)),
+                Span::styled(
+                    truncate_str(&msg.payload, msg_width),
+                    Style::default().fg(color),
+                ),
             ]));
         }
     } else {
@@ -1769,7 +1770,7 @@ fn render_meeting_room_popup(frame: &mut Frame, app: &App) {
 
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
-        "↑/k:Older  ↓/j:Newer  PgUp/PgDn:Fast  Esc/Enter:Close",
+        "Sliding window: newest messages shown at bottom. Esc/Enter:Close",
         Style::default().fg(Color::Gray),
     )));
 

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1079,22 +1079,6 @@ fn render_summary_card(
         ]));
     }
 
-    // Status line (from in-memory cache populated by refresh(), fallback to last_output)
-    let status_text = app
-        .agent_status(&agent.session.name)
-        .cloned()
-        .unwrap_or_else(|| {
-            if agent.health_info.last_output.is_empty() {
-                "waiting for the agent to report status".to_string()
-            } else {
-                agent.health_info.last_output.clone()
-            }
-        });
-    lines.push(Line::from(vec![
-        Span::styled("Status: ", Style::default().fg(Color::Reset)),
-        Span::styled(status_text, Style::default().fg(Color::Reset)),
-    ]));
-
     // Task (multi-line word wrap to fill available card space)
     let task = app
         .worker_tasks()

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -536,12 +536,7 @@ fn render_status_row(frame: &mut Frame, app: &App, status_spans: &[Span], area: 
 }
 
 fn render_projects_panel(frame: &mut Frame, app: &App, area: Rect) {
-    let panel_active = app.sidebar_focused && app.sidebar_panel == SidebarPanel::Projects;
-    let border_color = if panel_active {
-        Color::Magenta
-    } else {
-        Color::Gray
-    };
+    let border_color = Color::Gray;
     let block = Block::default()
         .title(" Projects ")
         .borders(Borders::ALL)
@@ -669,7 +664,7 @@ fn render_focus_parent(frame: &mut Frame, app: &App, area: Rect) {
 
         let (border_color, title_line) = if is_selected {
             (
-                Color::Magenta,
+                Color::Gray,
                 Line::from(vec![
                     Span::styled(" [", Style::default().fg(Color::Magenta)),
                     Span::styled(status_icon, Style::default().fg(Color::Magenta)),
@@ -803,12 +798,7 @@ fn render_focus_parent(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_command_tree(frame: &mut Frame, app: &App, area: Rect) {
-    let panel_active = app.sidebar_focused && app.sidebar_panel == SidebarPanel::ChainOfCommand;
-    let border_color = if panel_active {
-        Color::Magenta
-    } else {
-        Color::Gray
-    };
+    let border_color = Color::Gray;
     let block = Block::default()
         .title(" Chain of Command ")
         .borders(Borders::ALL)
@@ -901,12 +891,7 @@ fn render_command_tree(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_event_queue(frame: &mut Frame, app: &App, area: Rect) {
-    let panel_active = app.sidebar_focused && app.sidebar_panel == SidebarPanel::Events;
-    let border_color = if panel_active {
-        Color::Magenta
-    } else {
-        Color::Gray
-    };
+    let border_color = Color::Gray;
     let block = Block::default()
         .title(" Event Queue ")
         .borders(Borders::ALL)
@@ -952,12 +937,7 @@ fn render_event_queue(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_meeting_rooms_panel(frame: &mut Frame, app: &App, area: Rect) {
-    let panel_active = app.sidebar_focused && app.sidebar_panel == SidebarPanel::Rooms;
-    let border_color = if panel_active {
-        Color::LightMagenta
-    } else {
-        Color::DarkGray
-    };
+    let border_color = Color::Gray;
     let block = Block::default()
         .title(" Meeting Rooms ")
         .borders(Borders::ALL)
@@ -1012,11 +992,7 @@ fn render_summary_card(
         HealthState::Idle => (Color::Yellow, "○"),
     };
 
-    let border_color = if selected {
-        Color::Magenta
-    } else {
-        Color::Gray
-    };
+    let border_color = Color::Gray;
 
     let border_style = Style::default().fg(border_color).add_modifier(if selected {
         Modifier::BOLD
@@ -1334,7 +1310,7 @@ fn render_help_popup(frame: &mut Frame) {
     let block = Block::default()
         .title(" Help ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Color::Gray));
 
     let paragraph = Paragraph::new(help_content).block(block);
 
@@ -1403,7 +1379,7 @@ fn render_confirm_dialog(frame: &mut Frame, app: &App, action: ConfirmAction) {
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Red));
+        .border_style(Style::default().fg(Color::Gray));
 
     let paragraph = Paragraph::new(content)
         .block(block)
@@ -1437,7 +1413,7 @@ fn render_project_input(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" New Project ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Color::Gray));
 
     let paragraph = Paragraph::new(content)
         .block(block)
@@ -1471,7 +1447,7 @@ fn render_ea_input(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" New EA ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Color::Gray));
 
     let paragraph = Paragraph::new(content)
         .block(block)
@@ -1604,7 +1580,7 @@ fn render_events_popup(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" Event Queue ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Color::Gray));
 
     let paragraph = Paragraph::new(lines).block(block);
 
@@ -1648,7 +1624,7 @@ fn render_debug_console(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" Debug Console ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Yellow));
+        .border_style(Style::default().fg(Color::Gray));
 
     let paragraph = Paragraph::new(lines).block(block);
 
@@ -1702,7 +1678,7 @@ fn render_settings_popup(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" Settings ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Color::Gray));
 
     let paragraph = Paragraph::new(lines).block(block);
 
@@ -1776,7 +1752,7 @@ fn render_meeting_room_popup(frame: &mut Frame, app: &App) {
     let block = Block::default()
         .title(" Live Meeting Room ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan))
+        .border_style(Style::default().fg(Color::Gray))
         .padding(Padding::horizontal(1));
     let paragraph = Paragraph::new(lines)
         .block(block)
@@ -1907,7 +1883,7 @@ fn render_sidebar_popup(frame: &mut Frame, app: &App, panel: SidebarPanel) {
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Magenta))
+        .border_style(Style::default().fg(Color::Gray))
         .padding(Padding::horizontal(1));
 
     let paragraph = Paragraph::new(all_lines).block(block);

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1735,11 +1735,11 @@ fn render_meeting_room_popup(frame: &mut Frame, app: &App) {
         lines.push(Line::from(""));
 
         let body_height = area.height.saturating_sub(8) as usize;
-        let messages = if room.transcript.len() > body_height {
-            room.transcript[room.transcript.len() - body_height..].to_vec()
-        } else {
-            room.transcript.clone()
-        };
+        let max_offset = room.transcript.len().saturating_sub(body_height);
+        let offset = app.meeting_popup_offset_from_end.min(max_offset);
+        let end = room.transcript.len().saturating_sub(offset);
+        let start = end.saturating_sub(body_height);
+        let messages = room.transcript[start..end].to_vec();
 
         for msg in messages {
             let ts = chrono::DateTime::<chrono::Utc>::from_timestamp_nanos(msg.created_at as i64)
@@ -1769,7 +1769,7 @@ fn render_meeting_room_popup(frame: &mut Frame, app: &App) {
 
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
-        "Press Esc or Enter to close",
+        "↑/k:Older  ↓/j:Newer  PgUp/PgDn:Fast  Esc/Enter:Close",
         Style::default().fg(Color::Gray),
     )));
 

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -352,8 +352,23 @@ pub fn render(frame: &mut Frame, app: &App) {
     };
     let (sidebar_area, main_area) = columns;
 
-    // Sidebar: projects, (optional) event queue, chain of command
+    // Sidebar: projects, (optional) event queue, meeting rooms, chain of command
     if app.config.dashboard.show_event_queue {
+        let sidebar = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Ratio(1, 4),
+                Constraint::Ratio(1, 4),
+                Constraint::Ratio(1, 4),
+                Constraint::Ratio(1, 4),
+            ])
+            .split(sidebar_area);
+
+        render_projects_panel(frame, app, sidebar[0]);
+        render_event_queue(frame, app, sidebar[1]);
+        render_meeting_rooms_panel(frame, app, sidebar[2]);
+        render_command_tree(frame, app, sidebar[3]);
+    } else {
         let sidebar = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -364,16 +379,8 @@ pub fn render(frame: &mut Frame, app: &App) {
             .split(sidebar_area);
 
         render_projects_panel(frame, app, sidebar[0]);
-        render_event_queue(frame, app, sidebar[1]);
+        render_meeting_rooms_panel(frame, app, sidebar[1]);
         render_command_tree(frame, app, sidebar[2]);
-    } else {
-        let sidebar = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-            .split(sidebar_area);
-
-        render_projects_panel(frame, app, sidebar[0]);
-        render_command_tree(frame, app, sidebar[1]);
     }
 
     // Main area: agent grid on top (~2/3), focus parent on bottom (~1/3)
@@ -414,6 +421,10 @@ pub fn render(frame: &mut Frame, app: &App) {
 
     if app.show_settings {
         render_settings_popup(frame, app);
+    }
+
+    if app.active_meeting_room_name.is_some() {
+        render_meeting_room_popup(frame, app);
     }
 
     if let Some(panel) = app.sidebar_popup {
@@ -933,6 +944,47 @@ fn render_event_queue(frame: &mut Frame, app: &App, area: Rect) {
                 format!("+{} more", remaining),
                 Style::default().fg(Color::Gray),
             )));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_meeting_rooms_panel(frame: &mut Frame, app: &App, area: Rect) {
+    let panel_active = app.sidebar_focused && app.sidebar_panel == SidebarPanel::Rooms;
+    let border_color = if panel_active {
+        Color::LightMagenta
+    } else {
+        Color::DarkGray
+    };
+    let block = Block::default()
+        .title(" Meeting Rooms ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Thick)
+        .border_style(Style::default().fg(border_color))
+        .padding(Padding::horizontal(1));
+
+    let mut lines: Vec<Line> = Vec::new();
+    if app.meeting_rooms.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No active meetings",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        let visible = area.height.saturating_sub(2) as usize;
+        for room in app.meeting_rooms.iter().take(visible) {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    truncate_str(&room.name, 16),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::raw(" "),
+                Span::styled(
+                    format!("({})", room.participant_count),
+                    Style::default().fg(Color::Yellow),
+                ),
+            ]));
         }
     }
 
@@ -1658,6 +1710,81 @@ fn render_settings_popup(frame: &mut Frame, app: &App) {
     frame.render_widget(paragraph, area);
 }
 
+fn render_meeting_room_popup(frame: &mut Frame, app: &App) {
+    let area = centered_rect(78, 72, frame.area());
+    let mut lines: Vec<Line> = Vec::new();
+
+    if let Some(ref room) = app.active_meeting_room {
+        lines.push(Line::from(Span::styled(
+            format!("Room: {}", room.name),
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(Span::styled(
+            format!("Participants: {}", room.participants.join(", ")),
+            Style::default().fg(Color::Cyan),
+        )));
+        let pending = room
+            .invites
+            .iter()
+            .filter(|i| i.status.as_str() == "pending")
+            .count();
+        lines.push(Line::from(Span::styled(
+            format!("Pending invites: {}", pending),
+            Style::default().fg(Color::Gray),
+        )));
+        lines.push(Line::from(""));
+
+        let body_height = area.height.saturating_sub(8) as usize;
+        let messages = if room.transcript.len() > body_height {
+            room.transcript[room.transcript.len() - body_height..].to_vec()
+        } else {
+            room.transcript.clone()
+        };
+
+        for msg in messages {
+            let ts = chrono::DateTime::<chrono::Utc>::from_timestamp_nanos(msg.created_at as i64)
+                .with_timezone(&chrono::Local)
+                .format("%H:%M:%S")
+                .to_string();
+            let color = if msg.system {
+                Color::DarkGray
+            } else {
+                Color::White
+            };
+            lines.push(Line::from(vec![
+                Span::styled(format!("[{}] ", ts), Style::default().fg(Color::Gray)),
+                Span::styled(
+                    format!("{}: ", msg.sender),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(msg.payload, Style::default().fg(color)),
+            ]));
+        }
+    } else {
+        lines.push(Line::from(Span::styled(
+            "Meeting ended",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Press Esc or Enter to close",
+        Style::default().fg(Color::Gray),
+    )));
+
+    let block = Block::default()
+        .title(" Live Meeting Room ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .padding(Padding::horizontal(1));
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(Clear, area);
+    frame.render_widget(paragraph, area);
+}
+
 fn render_sidebar_popup(frame: &mut Frame, app: &App, panel: SidebarPanel) {
     let area = centered_rect(70, 60, frame.area());
 
@@ -1682,6 +1809,35 @@ fn render_sidebar_popup(frame: &mut Frame, app: &App, panel: SidebarPanel) {
         SidebarPanel::Events => {
             // Events popup is handled by the existing show_events popup
             unreachable!()
+        }
+        SidebarPanel::Rooms => {
+            let mut lines: Vec<Line> = Vec::new();
+            if app.meeting_rooms.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    "No active meeting rooms.",
+                    Style::default().fg(Color::Gray),
+                )));
+            } else {
+                for (idx, room) in app.meeting_rooms.iter().enumerate() {
+                    let selected = idx == app.room_list_selected;
+                    let marker = if selected { "► " } else { "  " };
+                    let style = if selected {
+                        Style::default().fg(Color::Magenta)
+                    } else {
+                        Style::default().fg(Color::Reset)
+                    };
+                    lines.push(Line::from(vec![
+                        Span::styled(marker, Style::default().fg(Color::Magenta)),
+                        Span::styled(truncate_str(&room.name, 30), style),
+                        Span::raw(" "),
+                        Span::styled(
+                            format!("({} participants)", room.participant_count),
+                            Style::default().fg(Color::Yellow),
+                        ),
+                    ]));
+                }
+            }
+            (" Meeting Rooms ", lines)
         }
         SidebarPanel::ChainOfCommand => {
             let mut lines: Vec<Line> = Vec::new();
@@ -1736,10 +1892,17 @@ fn render_sidebar_popup(frame: &mut Frame, app: &App, panel: SidebarPanel) {
 
     let mut all_lines = lines;
     all_lines.push(Line::from(""));
-    all_lines.push(Line::from(Span::styled(
-        "Press Esc or Enter to close",
-        Style::default().fg(Color::Gray),
-    )));
+    if panel == SidebarPanel::Rooms {
+        all_lines.push(Line::from(Span::styled(
+            "↑↓:Select  Enter:Open live room  Esc:Close",
+            Style::default().fg(Color::Gray),
+        )));
+    } else {
+        all_lines.push(Line::from(Span::styled(
+            "Press Esc or Enter to close",
+            Style::default().fg(Color::Gray),
+        )));
+    }
 
     let block = Block::default()
         .title(title)

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1735,7 +1735,6 @@ fn render_meeting_room_popup(frame: &mut Frame, app: &App) {
         lines.push(Line::from(""));
 
         let body_height = area.height.saturating_sub(8) as usize;
-        let msg_width = area.width.saturating_sub(6) as usize;
         let start = room.transcript.len().saturating_sub(body_height);
         let messages = room.transcript[start..].to_vec();
 
@@ -1755,10 +1754,7 @@ fn render_meeting_room_popup(frame: &mut Frame, app: &App) {
                     format!("{}: ", msg.sender),
                     Style::default().fg(Color::Yellow),
                 ),
-                Span::styled(
-                    truncate_str(&msg.payload, msg_width),
-                    Style::default().fg(color),
-                ),
+                Span::styled(msg.payload, Style::default().fg(color)),
             ]));
         }
     } else {


### PR DESCRIPTION
## Summary
- add EA-scoped meeting room registry with transcript and invite handshake (accept/decline/cancel)
- add room APIs under `/api/ea/:ea_id/rooms/*` including message fan-out via scheduler
- add dashboard Meeting Rooms panel, selectable enlarged room list, and live room popup
- auto-close inactive rooms and write meeting minutes to `~/.omar/meetings/`

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test rooms::tests:: -- --nocapture`

## Notes
- full `cargo test --all-targets` still has existing tmux-delivery test flakiness in this environment (`tmux::client::tests::test_deliver_prompt_*`).
