### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "bridges/slack", "bridges/computer"]
 
 [package]
 name = "omar"
-version = "0.1.2"
+version = "0.2.1"
 edition = "2021"
 description = "Agent dashboard for tmux"
 license = "MIT"


### PR DESCRIPTION
## Summary

Version bump in preparation for the `v0.2.1` release tag.

Includes everything merged since `v0.1.2`:
- #97 — backend readiness gating + tmux CI stabilization; fixes prompt delivery to Claude workers (issue #84) and several regressions re-introduced by the multi-EA PR (#61)
- #98 — restore v0.1.2 dashboard border palette and centralize it into `COLOR_ACTIVE` / `COLOR_INACTIVE` constants

## Release flow

After this PR is squash-merged, tag `v0.2.1` on main and push — that triggers `release.yml`, which builds cross-platform binaries, creates the GitHub release, and updates the `homebrew-omar` formula.