### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "bridges/slack", "bridges/computer"]
 
 [package]
 name = "omar"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Agent dashboard for tmux"
 license = "MIT"


### PR DESCRIPTION
## Summary

Version bump in preparation for the `v0.2.2` release tag.

Includes everything merged since `v0.2.1`:
- #100 — feat: restore multi-EA action-reasoning logs + prompt audit
- #101 — README update

## Release flow

After this PR is squash-merged, tag `v0.2.2` on main and push — that triggers `release.yml` (cross-platform binaries, GitHub release, `homebrew-omar` formula update).