### PR TITLE
fix: only spawn computer bridge on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Lead a team of 100 agents to solve humanity's biggest problems.
 ## Features
 
 - **Deep hierarchies**: Agents managing agents, just like a company.
-- **Heterogeneity**: Let `claude`, `codex`, and more collaborate as a team.
+- **Heterogeneity**: Let `claude`, `codex`, and other agents collaborate as a team.
 - **Full control**: Talk to and control any subagent you want.
 - **Life span**: Long-running or ephemeral agents, your choice.
 - **Customization**: Support all `tmux` commands you love.

--- a/src/main.rs
+++ b/src/main.rs
@@ -556,8 +556,15 @@ fn find_computer_binary() -> Option<PathBuf> {
     Some(PathBuf::from("omar-computer"))
 }
 
-/// Spawn the computer-use bridge binary if DISPLAY is set (X11 available).
+/// Spawn the computer-use bridge binary on Linux when an X11 display is
+/// available. The bridge wraps xdotool / ImageMagick `import`, which are
+/// X11-only tools, so skip it entirely on non-Linux platforms — an
+/// XQuartz `DISPLAY` on macOS would otherwise trigger a noisy spawn of a
+/// bridge that cannot do anything useful there.
 fn spawn_computer_bridge() -> Option<std::process::Child> {
+    if !cfg!(target_os = "linux") {
+        return None;
+    }
     if std::env::var("DISPLAY").is_err() {
         return None;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -565,7 +565,13 @@ fn spawn_computer_bridge() -> Option<std::process::Child> {
     if !cfg!(target_os = "linux") {
         return None;
     }
-    if std::env::var("DISPLAY").is_err() {
+    // Treat both unset and empty DISPLAY as "no X11 session". A bare
+    // `export DISPLAY=` in a shell profile would otherwise satisfy
+    // `is_err() == false` and still trigger a useless bridge spawn.
+    let display_ok = std::env::var("DISPLAY")
+        .ok()
+        .is_some_and(|v| !v.trim().is_empty());
+    if !display_ok {
         return None;
     }
 


### PR DESCRIPTION
## Summary

The computer bridge wraps `xdotool` and ImageMagick's `import` — both are X11-only. The existing gate only checked `DISPLAY`, so a macOS user with XQuartz installed would trigger a spawn of a bridge that cannot do anything useful there. The visible symptom is the `[omar] Computer bridge started (pid N)` noise at dashboard startup on macOS, plus a dead child process hanging off omar.

Adds a `cfg!(target_os = "linux")` guard before the `DISPLAY` probe in `src/main.rs::spawn_computer_bridge`. The `DISPLAY` check stays as a second layer (headless Linux boxes still skip the bridge cleanly).

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --bin omar --tests -- -D warnings`
- [x] `cargo test --bin omar -- --test-threads=1` — 150 passed
- [ ] Manual on macOS: start omar, confirm no `[omar] Computer bridge started` line appears and no `omar-computer` child process is left around.
- [ ] Manual on Linux with `DISPLAY` set: bridge still starts as before.