### PR TITLE
fix: restore 'n' manual-spawn shortcut for multi-EA

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -902,18 +902,24 @@ impl App {
         self.client
             .new_session(&name, &self.config.agent.default_command, Some(&workdir))?;
 
+        let state_dir = self.state_dir();
+        memory::save_agent_parent_in(&state_dir, &name, &self.focus_parent);
+
         let short_name = name
             .strip_prefix(&self.config.dashboard.session_prefix)
             .unwrap_or(&name);
         self.set_status(format!("Spawned agent: {}", short_name));
         self.refresh()?;
 
-        // Select the new agent
-        if let Some(pos) = self.agents.iter().position(|a| a.session.name == name) {
+        if let Some(pos) = self
+            .focus_child_indices
+            .iter()
+            .position(|&i| self.agents.get(i).is_some_and(|a| a.session.name == name))
+        {
             self.selected = pos;
+            self.manager_selected = false;
         }
 
-        let state_dir = self.state_dir();
         let manager_session = self.manager_session_name();
         let events = self.scheduler.list_by_ea(self.active_ea);
         memory::write_memory_to(
@@ -1899,6 +1905,52 @@ mod tests {
             "omar-agent-api-worker"
         );
         assert_eq!(agents[child_indices[1]].session.name, "omar-agent-auth");
+    }
+
+    #[test]
+    fn test_spawn_agent_parents_child_to_current_focus() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path();
+
+        let focus_parent = "omar-agent-api";
+        let new_child = "omar-agent-api-helper";
+
+        crate::memory::save_agent_parent_in(state_dir, new_child, focus_parent);
+
+        let parents = crate::memory::load_agent_parents_from(state_dir);
+        assert_eq!(
+            parents.get(new_child).map(String::as_str),
+            Some(focus_parent)
+        );
+
+        let agents = [
+            make_agent(focus_parent, HealthState::Running),
+            make_agent(new_child, HealthState::Running),
+        ];
+
+        let mut under_focus = Vec::new();
+        for (i, agent) in agents.iter().enumerate() {
+            if parents
+                .get(&agent.session.name)
+                .is_some_and(|p| p == focus_parent)
+            {
+                under_focus.push(i);
+            }
+        }
+        assert_eq!(under_focus.len(), 1);
+        assert_eq!(agents[under_focus[0]].session.name, new_child);
+
+        let mut at_root = Vec::new();
+        for (i, agent) in agents.iter().enumerate() {
+            let parent = parents.get(&agent.session.name);
+            match parent {
+                Some(p) if *p == TEST_MANAGER => at_root.push(i),
+                Some(p) if agents.iter().any(|a| a.session.name == *p) => {}
+                _ => at_root.push(i),
+            }
+        }
+        assert_eq!(at_root.len(), 1);
+        assert_eq!(agents[at_root[0]].session.name, focus_parent);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -861,28 +861,14 @@ impl App {
         Ok(())
     }
 
-    /// Generate a unique agent name (within the active EA's namespace)
+    /// Generate a unique agent name (within the active EA's namespace).
     pub fn generate_agent_name(&self) -> String {
         let existing: std::collections::HashSet<_> = self
             .agents
             .iter()
             .map(|a| a.session.name.as_str())
             .collect();
-
-        for i in 1..1000 {
-            let name = format!("{}{}", self.config.dashboard.session_prefix, i);
-            if !existing.contains(name.as_str()) {
-                return name;
-            }
-        }
-        format!(
-            "{}{}",
-            self.config.dashboard.session_prefix,
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs()
-        )
+        next_agent_name(&self.session_prefix, &existing)
     }
 
     /// Spawn a new agent with default settings
@@ -1587,6 +1573,27 @@ fn focus_view_index(
         .position(|&i| agents.get(i).is_some_and(|a| a.session.name == name))
 }
 
+/// Build the next unique agent name for `prefix`, skipping names already in
+/// `existing`. Must use the EA-scoped prefix: `refresh()` filters
+/// `self.agents` by that prefix, so a name built from the base prefix is
+/// invisible to the dashboard.
+fn next_agent_name(prefix: &str, existing: &std::collections::HashSet<&str>) -> String {
+    for i in 1..1000 {
+        let candidate = format!("{}{}", prefix, i);
+        if !existing.contains(candidate.as_str()) {
+            return candidate;
+        }
+    }
+    format!(
+        "{}{}",
+        prefix,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1914,6 +1921,35 @@ mod tests {
             "omar-agent-api-worker"
         );
         assert_eq!(agents[child_indices[1]].session.name, "omar-agent-auth");
+    }
+
+    #[test]
+    fn next_agent_name_uses_ea_scoped_prefix_so_refresh_keeps_the_agent() {
+        // Simulates EA 0: refresh() filters agents by the EA-scoped prefix
+        // "omar-agent-0-". A name built from the base prefix ("omar-agent-")
+        // would be stripped out, which is exactly the bug this guards against.
+        let ea_prefix = "omar-agent-0-";
+        let existing: std::collections::HashSet<&str> = std::collections::HashSet::new();
+
+        let name = next_agent_name(ea_prefix, &existing);
+
+        assert!(
+            name.starts_with(ea_prefix),
+            "generated name {:?} must start with EA-scoped prefix {:?}",
+            name,
+            ea_prefix
+        );
+        assert_eq!(name, "omar-agent-0-1");
+    }
+
+    #[test]
+    fn next_agent_name_skips_names_already_in_the_ea() {
+        let ea_prefix = "omar-agent-0-";
+        let mut existing: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        existing.insert("omar-agent-0-1");
+        existing.insert("omar-agent-0-2");
+
+        assert_eq!(next_agent_name(ea_prefix, &existing), "omar-agent-0-3");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -911,11 +911,7 @@ impl App {
         self.set_status(format!("Spawned agent: {}", short_name));
         self.refresh()?;
 
-        if let Some(pos) = self
-            .focus_child_indices
-            .iter()
-            .position(|&i| self.agents.get(i).is_some_and(|a| a.session.name == name))
-        {
+        if let Some(pos) = focus_view_index(&self.agents, &self.focus_child_indices, &name) {
             self.selected = pos;
             self.manager_selected = false;
         }
@@ -1578,6 +1574,19 @@ pub fn build_tree(
     nodes
 }
 
+/// Position of the agent named `name` within `focus_child_indices`, so the
+/// dashboard can land its cursor on a newly spawned worker that has just
+/// been re-refreshed into the current view.
+fn focus_view_index(
+    agents: &[AgentInfo],
+    focus_child_indices: &[usize],
+    name: &str,
+) -> Option<usize> {
+    focus_child_indices
+        .iter()
+        .position(|&i| agents.get(i).is_some_and(|a| a.session.name == name))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1908,49 +1917,49 @@ mod tests {
     }
 
     #[test]
-    fn test_spawn_agent_parents_child_to_current_focus() {
+    fn spawn_bookkeeping_persists_parent_under_focus_and_selects_in_view() {
+        use crate::memory;
+
         let dir = tempfile::tempdir().unwrap();
         let state_dir = dir.path();
 
         let focus_parent = "omar-agent-api";
         let new_child = "omar-agent-api-helper";
 
-        crate::memory::save_agent_parent_in(state_dir, new_child, focus_parent);
+        memory::save_agent_parent_in(state_dir, focus_parent, TEST_MANAGER);
+        memory::save_agent_parent_in(state_dir, new_child, focus_parent);
 
-        let parents = crate::memory::load_agent_parents_from(state_dir);
+        let parents = memory::load_agent_parents_from(state_dir);
         assert_eq!(
             parents.get(new_child).map(String::as_str),
-            Some(focus_parent)
+            Some(focus_parent),
+            "the post-spawn mapping must survive a refresh-style reload"
         );
 
-        let agents = [
+        let agents = vec![
             make_agent(focus_parent, HealthState::Running),
             make_agent(new_child, HealthState::Running),
         ];
 
-        let mut under_focus = Vec::new();
-        for (i, agent) in agents.iter().enumerate() {
-            if parents
-                .get(&agent.session.name)
-                .is_some_and(|p| p == focus_parent)
-            {
-                under_focus.push(i);
-            }
-        }
-        assert_eq!(under_focus.len(), 1);
-        assert_eq!(agents[under_focus[0]].session.name, new_child);
+        let focus_child_indices: Vec<usize> = agents
+            .iter()
+            .enumerate()
+            .filter_map(|(i, a)| {
+                parents
+                    .get(&a.session.name)
+                    .filter(|p| *p == focus_parent)
+                    .map(|_| i)
+            })
+            .collect();
 
-        let mut at_root = Vec::new();
-        for (i, agent) in agents.iter().enumerate() {
-            let parent = parents.get(&agent.session.name);
-            match parent {
-                Some(p) if *p == TEST_MANAGER => at_root.push(i),
-                Some(p) if agents.iter().any(|a| a.session.name == *p) => {}
-                _ => at_root.push(i),
-            }
-        }
-        assert_eq!(at_root.len(), 1);
-        assert_eq!(agents[at_root[0]].session.name, focus_parent);
+        let pos = focus_view_index(&agents, &focus_child_indices, new_child)
+            .expect("spawned child must resolve to a focus-view index");
+        assert_eq!(agents[focus_child_indices[pos]].session.name, new_child);
+
+        assert!(
+            focus_view_index(&agents, &focus_child_indices, "omar-agent-ghost").is_none(),
+            "unrelated sessions must not appear in the current view"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes `generate_agent_name` to use the EA-scoped prefix (`session_prefix`) instead of the base prefix (`config.dashboard.session_prefix`) — without this, spawned sessions fell outside the active EA's namespace and were dropped on every refresh
- Saves the child→parent mapping before refreshing so agents spawned while drilled into a sub-view appear at the correct level, not as orphans at root
- Extracts `next_agent_name` and `focus_view_index` helpers; adds unit tests covering both bugs

Reverses the intent of #103 — rather than removing the broken shortcut, this restores it correctly.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --bin omar --tests -- -D warnings`
- [x] `cargo test --bin omar -- --test-threads=1` — 131 passed
- [x] Manual: pressing `n` spawns a new agent in the active EA's namespace and it appears in the dashboard at the current view level