### PR TITLE
fix: use window_activity so check_task doesn't falsely report idle

### DIFF
--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -161,13 +161,23 @@ impl TmuxClient {
         ])
     }
 
-    /// Get the activity timestamp of a pane
+    /// Get the activity timestamp of a pane.
+    ///
+    /// Uses `#{window_activity}` — the per-pane `#{pane_activity}` format is
+    /// empty on tmux 3.6a (macOS Homebrew) unless `monitor-activity` is
+    /// enabled, which breaks every readiness check (empty string → parse
+    /// error → caller's `unwrap_or_default()` yields 0 → health always
+    /// reads as "idle", which makes EAs replace working agents). Window
+    /// activity is universally populated and tracks the most recent
+    /// input/output in the window. OMAR worker sessions always have
+    /// exactly one window and one pane, so window-level granularity is
+    /// equivalent to pane-level.
     pub fn get_pane_activity(&self, target: &str) -> Result<i64> {
-        let output = self.run(&["display-message", "-t", target, "-p", "#{pane_activity}"])?;
+        let output = self.run(&["display-message", "-t", target, "-p", "#{window_activity}"])?;
         output
             .trim()
             .parse()
-            .context("Failed to parse pane activity timestamp")
+            .context("Failed to parse window activity timestamp")
     }
 
     /// Send keys to a pane
@@ -731,6 +741,52 @@ mod tests {
         assert!(
             found,
             "wait_for_markers must match 'Claude Code' even when rendered with ANSI escapes between the words"
+        );
+    }
+
+    /// Regression: get_pane_activity must return a parseable timestamp on
+    /// every supported tmux. On tmux 3.6a (macOS Homebrew), `#{pane_activity}`
+    /// is empty unless `monitor-activity` is enabled, so parsing fails and
+    /// callers that `unwrap_or_default()` get 0 — which makes
+    /// `health_from_activity` always report "idle". This caused EAs to
+    /// replace working agents. `#{window_activity}` is populated universally.
+    #[test]
+    fn test_get_pane_activity_returns_recent_timestamp() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let session = "omar-client-test-pane-activity";
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", session])
+            .output();
+        let _guard = SessionGuard(session.to_string());
+
+        let ok = Command::new("tmux")
+            .args(["new-session", "-d", "-s", session])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            return;
+        }
+
+        let client = TmuxClient::new("omar-client-test-");
+        let activity = client
+            .get_pane_activity(session)
+            .expect("get_pane_activity must succeed on freshly created session");
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        // Activity should be within the last 10 minutes — if it's 0 or ancient,
+        // the underlying format string is empty on this tmux (regression).
+        assert!(
+            now - activity < 600,
+            "get_pane_activity returned a stale timestamp ({}s old) — format string is probably empty on this tmux version",
+            now - activity
         );
     }
 }


### PR DESCRIPTION
## Summary

`check_task` was returning `health: "idle"` for every agent on macOS Homebrew tmux 3.6a, regardless of actual pane state. That made the EA respawn agents that were working correctly — reproduced with codex as the EA backend (`omar -a codex`), where the EA consults `health` more aggressively than claude (which tends to wait for `notify_parent` / `[TASK COMPLETE]` signals).

### Root cause

`get_pane_activity` queries `#{pane_activity}`. On tmux 3.6a (macOS Homebrew), that format string is empty unless `monitor-activity` is enabled. Result:

1. `#{pane_activity}` → empty string
2. `.parse::<i64>()` → parse error
3. Caller's `.unwrap_or_default()` → `0`
4. `health_from_activity(0, 15)` → `now - 0` is ~1.7 billion seconds → always `"idle"`

The EA prompt says *"If a worker is idle or stuck, replace it instead of repeatedly nudging it,"* so the EA followed the false signal and cycled working agents.

### Fix

Switch to `#{window_activity}` — populated on all tmux versions, tracks most recent I/O in the window. OMAR worker sessions are always single-window/single-pane, so window-level granularity is equivalent to pane-level. This was the behavior before a silent regression; I restored the original comment explaining why.

### Why this only surfaced now

Claude workers finish via `notify_parent` / `[TASK COMPLETE]` before the EA ever consults `health`. Codex workers run longer through check_task polls, so the bogus "idle" signal gets acted on.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (135 omar tests, 174 total — all passing)
- [x] New regression test `test_get_pane_activity_returns_recent_timestamp`: fails on the buggy `#{pane_activity}` implementation with *"cannot parse integer from empty string"*, passes on the fix
- [ ] Manual end-to-end: `omar -a codex`, spawn a tracked worker, confirm EA no longer respawns it prematurely

🤖 Generated with [Claude Code](https://claude.com/claude-code)