### PR TITLE
release: v0.2.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             suffix: linux-amd64
           - os: ubuntu-24.04-arm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "bridges/slack", "bridges/computer"]
 
 [package]
 name = "omar"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "Agent dashboard for tmux"
 license = "MIT"


### PR DESCRIPTION
Bump to 0.2.4 and build linux-amd64 release artifacts on ubuntu-22.04 to avoid GLIBC_2.39 runtime failures on older Ubuntu.