### PR TITLE
fix(tmux): preserve LF in paste-buffer for raw-mode TUIs

### DIFF
--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -227,6 +227,15 @@ impl TmuxClient {
     /// cannot clobber each other's payload via the shared unnamed buffer.
     /// `-d` on paste-buffer deletes the buffer after pasting, so buffers
     /// do not accumulate on error paths either.
+    ///
+    /// `-r` disables tmux's default LF→CR replacement inside the paste.
+    /// Without it, every `\n` in the payload is delivered to the target pane
+    /// as `\r`. TUI backends like Claude Code run the terminal in raw mode
+    /// (ICRNL off), so those CRs are not translated back to LF and each one
+    /// reads as an Enter keypress inside the input widget — turning a single
+    /// multi-line prompt into a cascade of blank submissions. Reproduced on
+    /// tmux 3.2a (Ubuntu 22.04); newer tmux builds on macOS appear to mask
+    /// this but `-r` makes behavior identical across versions.
     pub fn paste_text(&self, target: &str, text: &str) -> Result<()> {
         let buffer_name = format!("omar-paste-{}", uuid::Uuid::new_v4());
 
@@ -254,8 +263,18 @@ impl TmuxClient {
         }
         // Paste from the named buffer using bracketed paste mode so the
         // target pane treats it as a single paste operation. `-d` deletes
-        // the buffer after pasting.
-        self.run(&["paste-buffer", "-b", &buffer_name, "-t", target, "-d", "-p"])?;
+        // the buffer after pasting. `-r` preserves LFs verbatim — see the
+        // doc comment above for why this matters for raw-mode TUIs.
+        self.run(&[
+            "paste-buffer",
+            "-b",
+            &buffer_name,
+            "-t",
+            target,
+            "-d",
+            "-p",
+            "-r",
+        ])?;
         Ok(())
     }
 
@@ -906,5 +925,111 @@ mod tests {
         // but small enough to catch the ~1-3 KB tasks that silently fail
         const { assert!(TmuxClient::LARGE_PAYLOAD_THRESHOLD >= 512) };
         const { assert!(TmuxClient::LARGE_PAYLOAD_THRESHOLD <= 8192) };
+    }
+
+    /// Regression: on tmux 3.2a (Ubuntu 22.04), `paste-buffer` without `-r`
+    /// replaces every LF in the buffer with CR by default. TUI backends like
+    /// Claude Code run the terminal in raw mode (ICRNL off), so those CRs
+    /// arrive unchanged and each reads as an Enter keypress in the input
+    /// widget — turning a multi-line prompt into a cascade of blank
+    /// submissions. `paste_text` must use `-r` so LFs survive verbatim.
+    ///
+    /// This test reproduces the raw-mode environment that exposes the bug:
+    /// without `stty -icrnl` the TTY driver translates CR→LF on input and
+    /// the test would pass trivially regardless of the flag, masking
+    /// regressions. A naive `cat > file` + `C-d` reader also won't work
+    /// because `-icanon` disables EOF interpretation; we use
+    /// `dd bs=1 count=N` instead so the reader exits deterministically
+    /// after the expected number of bytes.
+    #[test]
+    fn test_paste_text_preserves_lf_in_raw_mode() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let session = "omar-test-paste-preserves-lf";
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", session])
+            .output();
+        let _guard = SessionGuard(session.to_string());
+
+        let tmp_path =
+            std::env::temp_dir().join(format!("omar-paste-lf-{}.txt", uuid::Uuid::new_v4()));
+        let tmp_str = tmp_path.to_str().unwrap();
+
+        // Start with an rc-less, non-login shell so users' rc files can't
+        // break session startup on CI runners with unusual setups.
+        let shell_cmd = "/bin/bash --norc --noprofile -i";
+        let ok = Command::new("tmux")
+            .args(["new-session", "-d", "-s", session, shell_cmd])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            eprintln!("Skipping test: failed to create tmux session");
+            return;
+        }
+
+        // Give the shell a moment to draw, then put the pane into the raw-mode
+        // conditions that expose the bug (ICRNL off, non-canonical input) and
+        // start a deterministic N-byte reader.
+        thread::sleep(Duration::from_millis(200));
+        let payload = "line1\nline2\nline3";
+        let reader_cmd = format!(
+            "stty -icrnl -icanon; dd bs=1 count={} of={} 2>/dev/null",
+            payload.len(),
+            tmp_str,
+        );
+
+        let client = TmuxClient::new("omar-test-");
+        if client.send_keys_literal(session, &reader_cmd).is_err() {
+            eprintln!("Skipping test: send_keys_literal failed (sandbox?)");
+            return;
+        }
+        if client.send_keys(session, "Enter").is_err() {
+            eprintln!("Skipping test: send_keys Enter failed (sandbox?)");
+            return;
+        }
+        thread::sleep(Duration::from_millis(200));
+
+        if client.paste_text(session, payload).is_err() {
+            eprintln!("Skipping test: paste_text failed (sandbox?)");
+            return;
+        }
+
+        // Wait for dd to finish collecting the payload and flush the file.
+        // Poll briefly instead of sleeping blindly so slow runners still pass.
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline {
+            if let Ok(meta) = std::fs::metadata(&tmp_path) {
+                if meta.len() as usize >= payload.len() {
+                    break;
+                }
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+
+        let got = match std::fs::read(&tmp_path) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("Skipping test: tmp file not produced: {}", e);
+                let _ = std::fs::remove_file(&tmp_path);
+                return;
+            }
+        };
+        let _ = std::fs::remove_file(&tmp_path);
+
+        // The core assertion: LFs must survive. With the bug, every \n in
+        // the payload arrives as \r, so the file would be "line1\rline2\rline3".
+        assert_eq!(
+            got,
+            payload.as_bytes(),
+            "paste_text must preserve LF (got {:?}, expected {:?}) — \
+             tmux is likely mangling \\n → \\r because `-r` is missing from \
+             the paste-buffer call in paste_text",
+            String::from_utf8_lossy(&got),
+            payload,
+        );
     }
 }

--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -529,6 +529,15 @@ mod tests {
         }
     }
 
+    /// Cleanup guard: remove a path on drop (even on panic or early return).
+    /// Best-effort — missing files are fine.
+    struct TempPathGuard(std::path::PathBuf);
+    impl Drop for TempPathGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
     /// Deliver a prompt to a shell session and verify the command actually ran.
     #[test]
     fn test_deliver_prompt_to_shell_session() {
@@ -956,7 +965,22 @@ mod tests {
 
         let tmp_path =
             std::env::temp_dir().join(format!("omar-paste-lf-{}.txt", uuid::Uuid::new_v4()));
-        let tmp_str = tmp_path.to_str().unwrap();
+        let tmp_str = match tmp_path.to_str() {
+            Some(s) => s,
+            None => {
+                eprintln!(
+                    "Skipping test: temp path is not valid UTF-8: {:?}",
+                    tmp_path
+                );
+                return;
+            }
+        };
+        // Single-quote-escape the path for the shell command below so a
+        // TMPDIR containing spaces or metacharacters doesn't break the test
+        // (which would mask the regression by spuriously skipping).
+        let quoted_tmp_path = format!("'{}'", tmp_str.replace('\'', r"'\''"));
+        // Clean up the tmp file on every exit path (skip, assert fail, panic).
+        let _tmp_guard = TempPathGuard(tmp_path.clone());
 
         // Start with an rc-less, non-login shell so users' rc files can't
         // break session startup on CI runners with unusual setups.
@@ -979,7 +1003,7 @@ mod tests {
         let reader_cmd = format!(
             "stty -icrnl -icanon; dd bs=1 count={} of={} 2>/dev/null",
             payload.len(),
-            tmp_str,
+            quoted_tmp_path,
         );
 
         let client = TmuxClient::new("omar-test-");
@@ -1014,11 +1038,9 @@ mod tests {
             Ok(b) => b,
             Err(e) => {
                 eprintln!("Skipping test: tmp file not produced: {}", e);
-                let _ = std::fs::remove_file(&tmp_path);
                 return;
             }
         };
-        let _ = std::fs::remove_file(&tmp_path);
 
         // The core assertion: LFs must survive. With the bug, every \n in
         // the payload arrives as \r, so the file would be "line1\rline2\rline3".


### PR DESCRIPTION
## Summary

- Root cause: `tmux paste-buffer` defaults to replacing every LF in the buffer with CR. TUI backends like Claude Code run the terminal in raw mode (ICRNL off), so those CRs arrive unchanged and each reads as an Enter keypress — turning a single multi-line prompt into a cascade of blank submissions.
- Fix: pass `-r` to the `paste-buffer` call in `paste_text` so LFs survive verbatim. Behavior is now consistent across tmux versions.
- Regression test reproduces the raw-mode conditions on the pane and asserts multi-line payloads land with intact LFs.

## Why this only showed up on Ubuntu

Reproduced on tmux 3.2a (Ubuntu 22.04); newer tmux builds (e.g. homebrew on macOS) appear to mask this, so injection worked locally but `"input window filled with blank newlines"` on the Ubuntu server. Diagnostic on the affected box confirmed — without `-r` the paste delivered `line1\rline2\rline3`; with `-r` it delivered `line1\nline2\nline3`.

## Notes on the regression test

Two non-obvious things about reproducing this in a test:

- `stty -icrnl` is essential. Without it the TTY driver translates CR→LF on input and the test would pass regardless of the flag (an initial manual test fell for exactly this).
- `stty raw` disables `ICANON`, so `cat > file` + `C-d` never terminates. The test uses `stty -icrnl -icanon` + `dd bs=1 count=N of=…` so the reader exits deterministically after the expected number of bytes.

The session is started with `/bin/bash --norc --noprofile -i` to avoid flakiness from user rc files on unusual CI runners.

## Commits

- **`fix(tmux): preserve LF in paste-buffer for raw-mode TUIs`** — the one-flag production fix, doc-comment rationale, and the regression test.
- **`test(tmux): address Copilot review comments on paste-lf regression test`** — test-only hardening:
  - Skip (don't panic) when the temp path isn't valid UTF-8.
  - Single-quote-escape the temp path when interpolating it into the shell `dd` command so a TMPDIR with spaces/metacharacters can't silently skip the test.
  - New `TempPathGuard` (mirroring `SessionGuard`) so the temp file is removed on every exit path, including skip branches after the reader starts and any future panics.

## Manual validation

Confirmed on the affected Ubuntu 22.04 server (tmux 3.2a): with the `-r` flag, multi-line Claude prompt injection now lands as a single coherent prompt instead of a cascade of blank submissions.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --bin omar tmux::client::tests` (11 passed including the new test)
- [x] CI green on `ubuntu-latest` (prior commit; re-running for the review-response commit)
- [x] Manual validation on Ubuntu 22.04 / tmux 3.2a with real Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)