### PR TITLE
fix(slack-bridge): use /api/ea/{id}/ prefix for all OMAR API calls

### DIFF
--- a/bridges/slack/README.md
+++ b/bridges/slack/README.md
@@ -11,7 +11,7 @@ Slack (Socket Mode WS)                           OMAR (localhost:9876)
        │                                                │
        │ @mention event                                 │
        ▼                                                │
-  omar-slack bridge ──POST /api/events──────────►  Event Queue
+  omar-slack bridge ─POST /api/ea/{id}/events───►  Event Queue
        ▲            (receiver: "ea")                    │
        │                                                ▼
        │                                           EA (tmux)
@@ -108,7 +108,7 @@ cargo build --release
 2. Bridge starts an HTTP callback server on `SLACK_BRIDGE_PORT` (default 9877)
 3. When someone @mentions the bot in a channel:
    - Bridge formats the message as a `[SLACK MESSAGE]` event payload (includes channel, thread, user, reply curl command)
-   - Posts it to the OMAR event queue via `POST /api/events` with `receiver: "ea"`
+   - Posts it to the OMAR event queue via `POST /api/ea/{OMAR_EA_ID}/events` with `receiver: "ea"`
 4. OMAR's event scheduler delivers the event to the EA (deferred if popup is open)
 5. EA processes the request and replies by curling `POST /api/slack/reply` on the bridge
 6. Bridge posts the reply back to the correct Slack thread (auto-chunked if >3900 chars)
@@ -124,6 +124,7 @@ Agents are named `slack-<channel_suffix>-<thread_ts>` for traceability in OMAR's
 | `SLACK_BOT_TOKEN` | Yes | — | Bot OAuth token (`xoxb-...`) |
 | `SLACK_APP_TOKEN` | Yes | — | App-level token (`xapp-...`) |
 | `OMAR_URL` | No | `http://127.0.0.1:9876` | OMAR API endpoint |
+| `OMAR_EA_ID` | No | `0` | OMAR EA id for routing (`/api/ea/{id}/...`) |
 | `SLACK_BRIDGE_PORT` | No | `9877` | Bridge HTTP callback server port |
 | `MAX_MESSAGE_LENGTH` | No | `3900` | Max Slack message chunk size |
 | `RUST_LOG` | No | `info` | Log level (trace/debug/info/warn/error) |

--- a/bridges/slack/src/config.rs
+++ b/bridges/slack/src/config.rs
@@ -9,6 +9,9 @@ pub struct Config {
     pub app_token: String,
     /// OMAR API base URL (default: http://127.0.0.1:9876)
     pub omar_url: String,
+    /// OMAR EA id for routing agent/event/project calls under `/api/ea/{id}/...`
+    /// (default: 0 — the single-EA deployment id).
+    pub omar_ea_id: u32,
     /// Maximum Slack message length before chunking (Slack limit is 4000)
     pub max_message_length: usize,
     /// Port for the bridge's HTTP callback server (default: 9877)
@@ -37,6 +40,11 @@ impl Config {
         let omar_url =
             std::env::var("OMAR_URL").unwrap_or_else(|_| "http://127.0.0.1:9876".to_string());
 
+        let omar_ea_id: u32 = std::env::var("OMAR_EA_ID")
+            .unwrap_or_else(|_| "0".to_string())
+            .parse()
+            .unwrap_or(0);
+
         let max_message_length: usize = std::env::var("MAX_MESSAGE_LENGTH")
             .unwrap_or_else(|_| "3900".to_string())
             .parse()
@@ -51,6 +59,7 @@ impl Config {
             bot_token,
             app_token,
             omar_url,
+            omar_ea_id,
             max_message_length,
             bridge_port,
         })

--- a/bridges/slack/src/config.rs
+++ b/bridges/slack/src/config.rs
@@ -40,10 +40,22 @@ impl Config {
         let omar_url =
             std::env::var("OMAR_URL").unwrap_or_else(|_| "http://127.0.0.1:9876".to_string());
 
-        let omar_ea_id: u32 = std::env::var("OMAR_EA_ID")
-            .unwrap_or_else(|_| "0".to_string())
-            .parse()
-            .unwrap_or(0);
+        // OMAR_EA_ID is unusual: silently defaulting on parse errors would
+        // misroute every event to EA 0 with no signal. Default only when the
+        // var is unset; fail loudly on anything else.
+        let omar_ea_id: u32 = match std::env::var("OMAR_EA_ID") {
+            Ok(value) => value.parse().map_err(|err| {
+                anyhow::anyhow!(
+                    "OMAR_EA_ID must be a valid unsigned integer, got {:?}: {}",
+                    value,
+                    err
+                )
+            })?,
+            Err(std::env::VarError::NotPresent) => 0,
+            Err(std::env::VarError::NotUnicode(_)) => {
+                bail!("OMAR_EA_ID must contain valid Unicode")
+            }
+        };
 
         let max_message_length: usize = std::env::var("MAX_MESSAGE_LENGTH")
             .unwrap_or_else(|_| "3900".to_string())

--- a/bridges/slack/src/main.rs
+++ b/bridges/slack/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
 
     // Create clients
     let slack_client = SlackClient::new(&config.bot_token, &config.app_token);
-    let omar_client = OmarClient::new(&config.omar_url);
+    let omar_client = OmarClient::new(&config.omar_url, config.omar_ea_id);
 
     // Build the bridge (holds the shared SlackClient)
     let bridge = Bridge::new(config.clone(), slack_client, omar_client);

--- a/bridges/slack/src/omar.rs
+++ b/bridges/slack/src/omar.rs
@@ -6,10 +6,14 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
 /// Client for the OMAR HTTP API (localhost:9876).
+///
+/// All agent/event/project endpoints are EA-scoped under `/api/ea/{ea_id}/...`
+/// (see `src/api/mod.rs`). Global endpoints like `/api/health` are unscoped.
 #[derive(Clone)]
 pub struct OmarClient {
     client: Client,
     base_url: String,
+    ea_id: u32,
 }
 
 // -- Request/Response models matching OMAR's api/models.rs --
@@ -65,20 +69,42 @@ pub struct ErrorResponse {
 }
 
 impl OmarClient {
-    pub fn new(base_url: &str) -> Self {
+    /// Create a new client bound to a specific EA id. All agent/event/project
+    /// endpoints will be routed to `/api/ea/{ea_id}/...`.
+    pub fn new(base_url: &str, ea_id: u32) -> Self {
         Self {
             client: Client::new(),
             base_url: base_url.trim_end_matches('/').to_string(),
+            ea_id,
         }
+    }
+
+    /// Build an EA-scoped URL. `suffix` must start with `/` (e.g. `/events`,
+    /// `/agents/foo`). The result has the form
+    /// `{base}/api/ea/{ea_id}{suffix}`.
+    pub fn ea_url(&self, suffix: &str) -> String {
+        debug_assert!(
+            suffix.starts_with('/'),
+            "ea_url suffix must start with '/': {}",
+            suffix
+        );
+        format!("{}/api/ea/{}{}", self.base_url, self.ea_id, suffix)
+    }
+
+    /// Build a global (non-EA-scoped) API URL — used for `/api/health` and
+    /// similar manager-wide endpoints.
+    pub fn global_url(&self, suffix: &str) -> String {
+        debug_assert!(
+            suffix.starts_with('/'),
+            "global_url suffix must start with '/': {}",
+            suffix
+        );
+        format!("{}/api{}", self.base_url, suffix)
     }
 
     /// Check if OMAR API is reachable.
     pub async fn health_check(&self) -> Result<bool> {
-        let resp = self
-            .client
-            .get(format!("{}/api/health", self.base_url))
-            .send()
-            .await?;
+        let resp = self.client.get(self.global_url("/health")).send().await?;
         Ok(resp.status().is_success())
     }
 
@@ -86,7 +112,7 @@ impl OmarClient {
     pub async fn spawn_agent(&self, req: &SpawnAgentRequest) -> Result<SpawnAgentResponse> {
         let resp = self
             .client
-            .post(format!("{}/api/agents", self.base_url))
+            .post(self.ea_url("/agents"))
             .json(req)
             .send()
             .await
@@ -105,7 +131,7 @@ impl OmarClient {
     pub async fn get_agent(&self, name: &str) -> Result<Option<AgentDetail>> {
         let resp = self
             .client
-            .get(format!("{}/api/agents/{}", self.base_url, name))
+            .get(self.ea_url(&format!("/agents/{}", name)))
             .send()
             .await
             .context("Failed to get OMAR agent")?;
@@ -133,7 +159,7 @@ impl OmarClient {
 
         let resp = self
             .client
-            .post(format!("{}/api/agents/{}/send", self.base_url, name))
+            .post(self.ea_url(&format!("/agents/{}/send", name)))
             .json(&req)
             .send()
             .await
@@ -157,7 +183,7 @@ impl OmarClient {
     pub async fn list_agents(&self) -> Result<Vec<AgentListItem>> {
         let resp = self
             .client
-            .get(format!("{}/api/agents", self.base_url))
+            .get(self.ea_url("/agents"))
             .send()
             .await
             .context("Failed to list OMAR agents")?;
@@ -196,7 +222,7 @@ impl OmarClient {
 
         let resp = self
             .client
-            .post(format!("{}/api/events", self.base_url))
+            .post(self.ea_url("/events"))
             .json(&body)
             .send()
             .await
@@ -220,7 +246,7 @@ impl OmarClient {
     pub async fn kill_agent(&self, name: &str) -> Result<()> {
         let resp = self
             .client
-            .delete(format!("{}/api/agents/{}", self.base_url, name))
+            .delete(self.ea_url(&format!("/agents/{}", name)))
             .send()
             .await
             .context("Failed to kill OMAR agent")?;
@@ -232,5 +258,66 @@ impl OmarClient {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ea_url_uses_ea_prefix_by_default() {
+        let c = OmarClient::new("http://127.0.0.1:9876", 0);
+        assert_eq!(c.ea_url("/events"), "http://127.0.0.1:9876/api/ea/0/events");
+        assert_eq!(c.ea_url("/agents"), "http://127.0.0.1:9876/api/ea/0/agents");
+        assert_eq!(
+            c.ea_url("/agents/foo"),
+            "http://127.0.0.1:9876/api/ea/0/agents/foo"
+        );
+        assert_eq!(
+            c.ea_url("/agents/foo/send"),
+            "http://127.0.0.1:9876/api/ea/0/agents/foo/send"
+        );
+    }
+
+    #[test]
+    fn ea_url_respects_custom_ea_id() {
+        let c = OmarClient::new("http://127.0.0.1:9876", 3);
+        assert_eq!(c.ea_url("/events"), "http://127.0.0.1:9876/api/ea/3/events");
+    }
+
+    #[test]
+    fn ea_url_trims_trailing_slash_from_base() {
+        let c = OmarClient::new("http://127.0.0.1:9876/", 0);
+        // No double slash between base and /api
+        assert_eq!(c.ea_url("/events"), "http://127.0.0.1:9876/api/ea/0/events");
+    }
+
+    #[test]
+    fn global_url_is_not_ea_scoped() {
+        let c = OmarClient::new("http://127.0.0.1:9876", 0);
+        assert_eq!(c.global_url("/health"), "http://127.0.0.1:9876/api/health");
+    }
+
+    /// Regression guard: before PR #61 the client posted to `/api/events`
+    /// and `/api/agents`. The OMAR server now expects `/api/ea/{id}/...`.
+    /// If this invariant ever regresses, Slack @mentions silently 404 again.
+    #[test]
+    fn no_pre_multi_ea_endpoints_leak_through() {
+        let c = OmarClient::new("http://127.0.0.1:9876", 0);
+        for suffix in ["/events", "/agents", "/agents/some-name"] {
+            let url = c.ea_url(suffix);
+            assert!(
+                url.contains("/api/ea/"),
+                "URL should contain /api/ea/: {}",
+                url
+            );
+            // Make sure we didn't accidentally build `/api/events` etc.
+            assert!(
+                !url.contains("/api/events") && !url.contains("/api/agents"),
+                "URL must not use pre-multi-EA path: {}",
+                url
+            );
+        }
     }
 }

--- a/bridges/slack/src/omar.rs
+++ b/bridges/slack/src/omar.rs
@@ -83,7 +83,9 @@ impl OmarClient {
     /// `/agents/foo`). The result has the form
     /// `{base}/api/ea/{ea_id}{suffix}`.
     pub fn ea_url(&self, suffix: &str) -> String {
-        debug_assert!(
+        // Enforce the invariant in release builds too — a missing leading
+        // slash would produce `/api/ea/0agents` and 404 silently.
+        assert!(
             suffix.starts_with('/'),
             "ea_url suffix must start with '/': {}",
             suffix
@@ -94,7 +96,7 @@ impl OmarClient {
     /// Build a global (non-EA-scoped) API URL — used for `/api/health` and
     /// similar manager-wide endpoints.
     pub fn global_url(&self, suffix: &str) -> String {
-        debug_assert!(
+        assert!(
             suffix.starts_with('/'),
             "global_url suffix must start with '/': {}",
             suffix
@@ -266,7 +268,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ea_url_uses_ea_prefix_by_default() {
+    fn ea_url_uses_ea_prefix_for_zero_ea_id() {
         let c = OmarClient::new("http://127.0.0.1:9876", 0);
         assert_eq!(c.ea_url("/events"), "http://127.0.0.1:9876/api/ea/0/events");
         assert_eq!(c.ea_url("/agents"), "http://127.0.0.1:9876/api/ea/0/agents");


### PR DESCRIPTION
## Summary

The Slack bridge has been silently dropping every `@mention` since PR #61 landed on `main`. All OMAR agent/event endpoints were moved under `/api/ea/{ea_id}/...`, but `bridges/slack/src/omar.rs` still posts to the pre-#61 paths (`/api/events`, `/api/agents`, `/api/agents/{name}/send`, …) — every call returns 404.

The failures went unnoticed because the bridge's stdout/stderr is redirected to `/dev/null` when OMAR auto-launches it, so nothing surfaced in the dashboard or logs. Net effect: messages posted to Slack never reach the EA event queue.

- Verified: `curl http://localhost:9876/api/events` → 404
- Verified: `curl http://localhost:9876/api/ea/0/events` → 200

## Root cause

URL prefix mismatch. `bridges/slack/src/omar.rs` was never updated when PR #61 scoped the agent/event routes under `/api/ea/{ea_id}/`.

## What changed

- `OmarClient` now carries an `ea_id` (default `0`, overridable via the new `OMAR_EA_ID` env var).
- New `ea_url(suffix)` helper produces `{base}/api/ea/{ea_id}{suffix}` for all EA-scoped calls.
- All six EA-scoped endpoints are routed through the helper:
  - `POST /api/ea/{id}/agents` — spawn
  - `GET  /api/ea/{id}/agents` — list
  - `GET  /api/ea/{id}/agents/{name}` — detail
  - `POST /api/ea/{id}/agents/{name}/send` — input
  - `DELETE /api/ea/{id}/agents/{name}` — kill
  - `POST /api/ea/{id}/events` — event enqueue (the Slack @mention path)
- `/api/health` stays unscoped via a separate `global_url` helper.
- README updated: architecture diagram + a new `OMAR_EA_ID` config row.

## Tests

New unit tests in `bridges/slack/src/omar.rs`:

- `ea_url_uses_ea_prefix_by_default`
- `ea_url_respects_custom_ea_id`
- `ea_url_trims_trailing_slash_from_base`
- `global_url_is_not_ea_scoped`
- `no_pre_multi_ea_endpoints_leak_through` — regression guard; fails if any builder re-introduces a pre-#61 path.

Picked up automatically by the workspace `cargo test` job in `.github/workflows/ci.yml`.

## Reinstall + restart (operator)

The bridge binary is `target/release/omar-slack`, currently installed to `/usr/local/bin/omar-slack`. The running bridge holds the file, so you must stop it first:

```bash
# 1. Build
cargo build --release

# 2. Stop the running bridge (whichever applies)
pkill -f omar-slack
# or: systemctl --user stop omar-slack
# or: just restart `omar` — it auto-launches the bridge from $PATH

# 3. Install
sudo cp target/release/omar-slack /usr/local/bin/omar-slack

# 4. Restart OMAR (auto-launches the bridge) or run the bridge directly
```

No config change is required for the default single-EA deployment (`OMAR_EA_ID` defaults to 0). Set `OMAR_EA_ID` if you ever point the bridge at a non-zero EA.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` in `bridges/slack/` — 11 passed, 0 failed
- [x] `cargo build --release` succeeds
- [ ] Operator reinstalls + restarts bridge
- [ ] Confirm a Slack `@mention` now appears as an `ea` event in the OMAR queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)