### PR TITLE
feat: install panic hook that persists stacks to ~/.omar/logs/panics/

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod ea;
 mod event;
 mod manager;
 mod memory;
+mod panic_hook;
 mod projects;
 mod scheduler;
 mod tmux;
@@ -110,6 +111,14 @@ enum ManagerAction {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install the persisted-panic hook FIRST, before tokio workers or
+    // any other thread exists. If the tmux parent dies it takes the
+    // stderr pane with it (see issue #118), so panics need to be
+    // written to disk before unwind. The hook chains to whatever hook
+    // was previously installed, preserving RUST_BACKTRACE/default
+    // stderr behaviour for non-tmux runs.
+    panic_hook::install(omar_dir().join("logs").join("panics"));
+
     let cli = Cli::parse();
     let mut config = Config::load(cli.config.as_deref())?;
     if let Some(ref agent) = cli.agent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,16 +109,26 @@ enum ManagerAction {
     Orchestrate,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Install the persisted-panic hook FIRST, before tokio workers or
-    // any other thread exists. If the tmux parent dies it takes the
-    // stderr pane with it (see issue #118), so panics need to be
-    // written to disk before unwind. The hook chains to whatever hook
-    // was previously installed, preserving RUST_BACKTRACE/default
-    // stderr behaviour for non-tmux runs.
+fn main() -> Result<()> {
+    // Install the persisted-panic hook FIRST, before tokio builds its
+    // runtime (and spawns worker threads). If the tmux parent dies it
+    // takes the stderr pane with it (see issue #118), so panics need
+    // to be written to disk before unwind. The hook chains to whatever
+    // hook was previously installed, preserving RUST_BACKTRACE /
+    // default stderr behaviour for non-tmux runs.
+    //
+    // We deliberately don't use `#[tokio::main]`: that macro builds
+    // the runtime BEFORE the `async fn` body runs, so any panic on a
+    // worker spawned during runtime construction would miss the hook.
     panic_hook::install(omar_dir().join("logs").join("panics"));
 
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async_main())
+}
+
+async fn async_main() -> Result<()> {
     let cli = Cli::parse();
     let mut config = Config::load(cli.config.as_deref())?;
     if let Some(ref agent) = cli.agent {

--- a/src/panic_hook.rs
+++ b/src/panic_hook.rs
@@ -9,17 +9,27 @@
 //! normal runs and we have a durable on-disk record for post-mortems.
 //!
 //! Install this as the very first thing in `main()`, before the tokio
-//! runtime starts, so panics on any worker thread are also persisted.
+//! runtime is built, so panics on any worker thread are also
+//! persisted. Note that `#[tokio::main]` constructs the runtime
+//! *before* the `async fn main()` body runs, so callers that need the
+//! earliest-possible coverage should use a synchronous `fn main()`
+//! that installs the hook and then builds the runtime by hand.
 //!
 //! IO failures in the hook are swallowed (with a best-effort `eprintln!`)
 //! because panicking inside a panic hook aborts the process.
 
 use std::backtrace::Backtrace;
-use std::fs::{self, File};
-use std::io::Write;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
 use std::panic;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Maximum number of filename-collision retries in `write_entry`.
+/// `SystemTime::now()` has coarse resolution on some platforms; if two
+/// panics land in the same nanosecond bucket within the same pid we
+/// append an attempt counter instead of truncating an earlier log.
+const MAX_COLLISION_RETRIES: u32 = 16;
 
 /// Install a panic hook that persists panic details under `log_dir`.
 ///
@@ -91,27 +101,48 @@ pub fn format_panic_log_entry(
     )
 }
 
-/// Write `entry` to `<log_dir>/<ts>-pid<N>.log`.
-fn write_entry(log_dir: &Path, entry: &str) -> std::io::Result<()> {
+/// Write `entry` to `<log_dir>/<ts>-pid<N>.log`. Uses
+/// `OpenOptions::create_new` so an unexpected existing file is never
+/// truncated; on collision (coarse clock + same pid) we append an
+/// attempt counter and retry.
+fn write_entry(log_dir: &Path, entry: &str) -> io::Result<()> {
     fs::create_dir_all(log_dir)?;
-    let filename = panic_filename(SystemTime::now(), std::process::id());
-    let path = log_dir.join(filename);
-    let mut file = File::create(&path)?;
-    file.write_all(entry.as_bytes())?;
-    file.flush()?;
-    Ok(())
+    let pid = std::process::id();
+
+    for attempt in 0..MAX_COLLISION_RETRIES {
+        let filename = panic_filename(SystemTime::now(), pid, attempt);
+        let path = log_dir.join(&filename);
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(mut file) => {
+                file.write_all(entry.as_bytes())?;
+                file.flush()?;
+                return Ok(());
+            }
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "panic log filename collisions exceeded retry budget",
+    ))
 }
 
-/// Build a filesystem-safe filename of the form
-/// `<unix_nanos>-pid<N>.log`. Using unix nanoseconds keeps names
-/// monotonic-ish and trivially sortable; including the pid prevents
-/// collisions when two processes panic in the same nanosecond.
-fn panic_filename(now: SystemTime, pid: u32) -> String {
+/// Build a filesystem-safe filename. Base form is
+/// `<unix_nanos>-pid<N>.log`; on collision retries the form becomes
+/// `<unix_nanos>-pid<N>-<attempt>.log`. Unix-nanosecond prefix keeps
+/// names monotonic-ish and trivially sortable; pid prevents collisions
+/// between concurrent processes.
+fn panic_filename(now: SystemTime, pid: u32, attempt: u32) -> String {
     let nanos = now
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    format!("{nanos}-pid{pid}.log")
+    if attempt == 0 {
+        format!("{nanos}-pid{pid}.log")
+    } else {
+        format!("{nanos}-pid{pid}-{attempt}.log")
+    }
 }
 
 #[cfg(test)]
@@ -126,6 +157,32 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
+    type BoxedHook = Box<dyn Fn(&panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+    /// RAII guard that captures the current panic hook on
+    /// construction and restores it on drop — even if the test
+    /// unwinds through an assertion. Prevents leaking a test hook
+    /// into sibling tests.
+    struct PanicHookGuard {
+        previous: Option<BoxedHook>,
+    }
+
+    impl PanicHookGuard {
+        fn new() -> Self {
+            Self {
+                previous: Some(panic::take_hook()),
+            }
+        }
+    }
+
+    impl Drop for PanicHookGuard {
+        fn drop(&mut self) {
+            if let Some(hook) = self.previous.take() {
+                panic::set_hook(hook);
+            }
+        }
+    }
+
     #[test]
     fn format_contains_all_fields() {
         let bt = Backtrace::capture(); // empty unless RUST_BACKTRACE=1
@@ -138,7 +195,7 @@ mod tests {
 
     #[test]
     fn panic_filename_is_safe_and_contains_pid() {
-        let name = panic_filename(SystemTime::now(), 4242);
+        let name = panic_filename(SystemTime::now(), 4242, 0);
         assert!(name.ends_with("-pid4242.log"), "bad suffix: {name}");
         // No path separators, colons, or spaces — filesystem-safe.
         for bad in [':', '/', '\\', ' '] {
@@ -147,16 +204,22 @@ mod tests {
     }
 
     #[test]
+    fn panic_filename_disambiguates_on_retry() {
+        let a = panic_filename(SystemTime::now(), 4242, 0);
+        let b = panic_filename(SystemTime::now(), 4242, 1);
+        assert_ne!(a, b, "retry must produce a different filename");
+        assert!(b.contains("-1.log"), "attempt suffix missing: {b}");
+    }
+
+    #[test]
     fn install_writes_file_on_panic() {
-        let _guard = hook_lock().lock().unwrap();
+        let _serial = hook_lock().lock().unwrap();
+        // Restore whatever hook was previously installed on drop —
+        // even if an assertion below panics.
+        let _restore = PanicHookGuard::new();
 
         let tmp = tempfile::tempdir().unwrap();
         let log_dir = tmp.path().to_path_buf();
-
-        // Snapshot whatever hook was installed before this test so we
-        // can restore it and not leak our hook into sibling tests.
-        let previous_before = panic::take_hook();
-        panic::set_hook(previous_before);
 
         install(log_dir.clone());
 
@@ -165,9 +228,6 @@ mod tests {
             panic!("persisted-panic-test");
         });
         assert!(result.is_err(), "expected panic");
-
-        // Restore a no-op hook so this test doesn't affect later tests.
-        panic::set_hook(Box::new(|_| {}));
 
         let mut entries: Vec<_> = fs::read_dir(&log_dir)
             .unwrap()
@@ -178,9 +238,10 @@ mod tests {
         let path = entries.pop().unwrap().path();
         let filename = path.file_name().unwrap().to_string_lossy().into_owned();
         assert!(
-            filename.contains(&format!("-pid{}.log", std::process::id())),
+            filename.contains(&format!("-pid{}", std::process::id())),
             "unexpected filename: {filename}"
         );
+        assert!(filename.ends_with(".log"), "bad extension: {filename}");
 
         let contents = fs::read_to_string(&path).unwrap();
         assert!(
@@ -191,5 +252,43 @@ mod tests {
             contents.contains("stack backtrace:"),
             "backtrace header missing in file: {contents}"
         );
+    }
+
+    #[test]
+    fn write_entry_does_not_truncate_existing_file() {
+        // Even without a racing panic, verify `write_entry` creates a
+        // second file via the collision-retry path when a log with the
+        // primary name already exists.
+        let tmp = tempfile::tempdir().unwrap();
+        let log_dir = tmp.path().to_path_buf();
+
+        // First call writes one file.
+        write_entry(&log_dir, "first").unwrap();
+        let first_entries: Vec<_> = fs::read_dir(&log_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(first_entries.len(), 1);
+
+        // Second call in the (extremely unlikely) same nanosecond would
+        // collide on the primary filename. Simulate that by manually
+        // creating a file at the exact primary name, then confirming
+        // `write_entry` writes a disambiguated file instead of
+        // overwriting.
+        let now = SystemTime::now();
+        let primary = log_dir.join(panic_filename(now, std::process::id(), 0));
+        fs::write(&primary, b"DO-NOT-OVERWRITE").unwrap();
+
+        write_entry(&log_dir, "second").unwrap();
+        let after: Vec<_> = fs::read_dir(&log_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        // We expect 3+ files: the original first-call file, the
+        // planted primary, and the retry-disambiguated second-call
+        // file. Crucially, the planted file must still say
+        // DO-NOT-OVERWRITE.
+        assert!(after.len() >= 3, "expected retry file: {after:?}");
+        assert_eq!(fs::read(&primary).unwrap(), b"DO-NOT-OVERWRITE");
     }
 }

--- a/src/panic_hook.rs
+++ b/src/panic_hook.rs
@@ -1,0 +1,195 @@
+//! Persisted panic logging.
+//!
+//! When omar runs as a child of a tmux session, stderr is attached to a
+//! tmux pane. If the tmux server dies (see issue #118) it takes the pane
+//! with it and any Rust panic message printed there is lost. This module
+//! installs a panic hook that writes panic details to
+//! `~/.omar/logs/panics/<ts>-pid<N>.log` **before** chaining to the
+//! previous hook, so the default stderr backtrace still happens for
+//! normal runs and we have a durable on-disk record for post-mortems.
+//!
+//! Install this as the very first thing in `main()`, before the tokio
+//! runtime starts, so panics on any worker thread are also persisted.
+//!
+//! IO failures in the hook are swallowed (with a best-effort `eprintln!`)
+//! because panicking inside a panic hook aborts the process.
+
+use std::backtrace::Backtrace;
+use std::fs::{self, File};
+use std::io::Write;
+use std::panic;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Install a panic hook that persists panic details under `log_dir`.
+///
+/// The previous hook (captured via `panic::take_hook()`) is invoked
+/// *after* writing the file so existing stderr / `RUST_BACKTRACE`
+/// behaviour is preserved. We do not call `process::abort()` — unwind
+/// proceeds normally.
+pub fn install(log_dir: PathBuf) {
+    let previous = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        // Best-effort: build the log entry and write it. Any IO error
+        // must not cause a second panic inside the hook.
+        let thread = std::thread::current();
+        let thread_name = thread.name().unwrap_or("unnamed").to_string();
+        let payload = payload_as_str(info).to_string();
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let backtrace = Backtrace::force_capture();
+
+        let entry = format_panic_log_entry(&thread_name, &payload, &location, &backtrace);
+
+        if let Err(e) = write_entry(&log_dir, &entry) {
+            // Last-ditch: print to stderr. If stderr is gone (tmux
+            // pane died) this is a no-op, but at least we tried.
+            let _ = writeln!(std::io::stderr(), "[omar] panic-hook write failed: {e}");
+        }
+
+        // Chain to the previous hook so default stderr / RUST_BACKTRACE
+        // behaviour still fires.
+        previous(info);
+    }));
+}
+
+/// Extract the panic payload as a string.
+///
+/// `PanicHookInfo::payload()` is `&dyn Any`; rustc downcasts the common
+/// cases to `&str` or `String`. Anything else is reported as a
+/// placeholder so the log entry stays useful.
+fn payload_as_str<'a>(info: &'a panic::PanicHookInfo<'_>) -> &'a str {
+    let payload = info.payload();
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "<non-string panic payload>"
+    }
+}
+
+/// Render a panic log entry. Pure — easy to unit test.
+pub fn format_panic_log_entry(
+    thread_name: &str,
+    payload: &str,
+    location: &str,
+    backtrace: &Backtrace,
+) -> String {
+    format!(
+        "thread '{thread}' panicked at {location}:\n\
+         {payload}\n\
+         \n\
+         stack backtrace:\n\
+         {backtrace}\n",
+        thread = thread_name,
+        location = location,
+        payload = payload,
+        backtrace = backtrace,
+    )
+}
+
+/// Write `entry` to `<log_dir>/<ts>-pid<N>.log`.
+fn write_entry(log_dir: &Path, entry: &str) -> std::io::Result<()> {
+    fs::create_dir_all(log_dir)?;
+    let filename = panic_filename(SystemTime::now(), std::process::id());
+    let path = log_dir.join(filename);
+    let mut file = File::create(&path)?;
+    file.write_all(entry.as_bytes())?;
+    file.flush()?;
+    Ok(())
+}
+
+/// Build a filesystem-safe filename of the form
+/// `<unix_nanos>-pid<N>.log`. Using unix nanoseconds keeps names
+/// monotonic-ish and trivially sortable; including the pid prevents
+/// collisions when two processes panic in the same nanosecond.
+fn panic_filename(now: SystemTime, pid: u32) -> String {
+    let nanos = now
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{nanos}-pid{pid}.log")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serialise tests that swap the process-wide panic hook so they
+    /// don't race each other.
+    fn hook_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn format_contains_all_fields() {
+        let bt = Backtrace::capture(); // empty unless RUST_BACKTRACE=1
+        let out = format_panic_log_entry("worker-3", "boom!", "src/foo.rs:10:5", &bt);
+        assert!(out.contains("worker-3"), "thread name missing: {out}");
+        assert!(out.contains("boom!"), "payload missing: {out}");
+        assert!(out.contains("src/foo.rs:10:5"), "location missing: {out}");
+        assert!(out.contains("stack backtrace:"), "header missing: {out}");
+    }
+
+    #[test]
+    fn panic_filename_is_safe_and_contains_pid() {
+        let name = panic_filename(SystemTime::now(), 4242);
+        assert!(name.ends_with("-pid4242.log"), "bad suffix: {name}");
+        // No path separators, colons, or spaces — filesystem-safe.
+        for bad in [':', '/', '\\', ' '] {
+            assert!(!name.contains(bad), "unsafe char {bad:?} in {name}");
+        }
+    }
+
+    #[test]
+    fn install_writes_file_on_panic() {
+        let _guard = hook_lock().lock().unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let log_dir = tmp.path().to_path_buf();
+
+        // Snapshot whatever hook was installed before this test so we
+        // can restore it and not leak our hook into sibling tests.
+        let previous_before = panic::take_hook();
+        panic::set_hook(previous_before);
+
+        install(log_dir.clone());
+
+        // `catch_unwind` lets the hook fire without killing the test.
+        let result = std::panic::catch_unwind(|| {
+            panic!("persisted-panic-test");
+        });
+        assert!(result.is_err(), "expected panic");
+
+        // Restore a no-op hook so this test doesn't affect later tests.
+        panic::set_hook(Box::new(|_| {}));
+
+        let mut entries: Vec<_> = fs::read_dir(&log_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(entries.len(), 1, "expected exactly one log file");
+
+        let path = entries.pop().unwrap().path();
+        let filename = path.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(
+            filename.contains(&format!("-pid{}.log", std::process::id())),
+            "unexpected filename: {filename}"
+        );
+
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(
+            contents.contains("persisted-panic-test"),
+            "payload missing in file: {contents}"
+        );
+        assert!(
+            contents.contains("stack backtrace:"),
+            "backtrace header missing in file: {contents}"
+        );
+    }
+}


### PR DESCRIPTION
Addresses option 2 of #118.

## Why

When omar runs as a child of a tmux session (the default launch path) and the tmux server crashes, stderr is attached to a tmux pane that dies with the server. Any Rust panic printed by the default hook is lost, and #118's investigation notes we currently can't tell from disk whether omar itself panicked. This change makes every panic durable on disk before unwind.

## What

- New `src/panic_hook.rs` exposing `pub fn install(log_dir: PathBuf)`.
- `main()` calls `panic_hook::install(omar_dir().join(\"logs\").join(\"panics\"))` as its very first line — before the tokio runtime, CLI parse, config load, anything. That means panics on any tokio worker thread are also captured.
- The hook:
  - captures the previous hook via `panic::take_hook()` at install time and calls it **after** writing, so `RUST_BACKTRACE=1` / default stderr still fires.
  - writes `thread.name()` (falls back to `\"unnamed\"`), payload (downcast `&str` / `String`, else `\"<non-string panic payload>\"`), `file:line:col` (else `\"<unknown>\"`), and `std::backtrace::Backtrace::force_capture()`.
  - does **not** call `process::abort()`.
  - swallows IO errors with a best-effort `eprintln!` — never panic-in-panic-hook.

## File format

`~/.omar/logs/panics/<unix_nanos>-pid<N>.log`. Unix-nanosecond prefix keeps names sortable and monotonic-ish; `-pid<N>` suffix prevents collisions between concurrent processes panicking in the same nanosecond. `fs::create_dir_all` creates the directory if missing.

## Edge cases

- Tmux pane already dead when panic fires → stderr write is a no-op, but the disk log already landed.
- Disk write fails (e.g. permission / full disk) → best-effort `eprintln!`, no second panic.
- Previous hook preserved → default backtrace still goes to stderr under `RUST_BACKTRACE=1`.
- No `process::abort()` — unwind proceeds normally.

## Test plan

- [x] Unit: `format_panic_log_entry` renders thread/payload/location/`stack backtrace:` header.
- [x] Unit: `panic_filename` ends with `-pid<N>.log` and contains no `:` / `/` / `\\` / space.
- [x] Unit: `install(tempdir)` + `catch_unwind(|| panic!(\"persisted-panic-test\"))` writes exactly one file under the tempdir whose contents contain the payload and the `stack backtrace:` header.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Full `cargo test -- --test-threads=1`: 157 passed (1 pre-existing failure on `origin/main`, `test_wait_for_markers_handles_ansi_styled_multiword_banner`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)