### PR TITLE
release: v0.2.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "bridges/slack", "bridges/computer"]
 
 [package]
 name = "omar"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 description = "Agent dashboard for tmux"
 license = "MIT"


### PR DESCRIPTION
Bump OMAR version from 0.2.4 to 0.2.5 for release.

## Changes since v0.2.4

- feat: install panic hook that persists stacks to `~/.omar/logs/panics/` (#121)
- fix(slack-bridge): use `/api/ea/{id}/` prefix for all OMAR API calls (#119)
- fix: defer events by 30s while agent popup is open (#120)
- fix(tmux): preserve LF in paste-buffer for raw-mode TUIs (#117)

## Release steps after merge

1. Squash-merge this PR.
2. Tag the merged commit: `git tag v0.2.5 && git push origin v0.2.5`.
3. The `release.yml` workflow fires on the `v*` tag push and builds artifacts + creates the GitHub release.

## Test plan

- [x] `cargo check --workspace` succeeds with the new version
- [ ] CI green on this PR
- [ ] Tag pushed post-merge, release workflow produces artifacts for linux-amd64, linux-arm64, macos

🤖 Generated with [Claude Code](https://claude.com/claude-code)