### PR TITLE
fix: wait for Claude v2.1.116 input widget readiness before pressing Enter

### DIFF
--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -294,24 +294,41 @@ impl TmuxClient {
             opts.require_initial_change,
         )?;
 
-        for attempt in 1..=opts.max_retries {
-            // Snapshot pane state before delivery so we can detect changes.
-            let content_before = self.capture_pane(session, 50).unwrap_or_default();
-            let activity_before = self.get_pane_activity(session).unwrap_or(0);
+        // Phase 2: settle delay after markers/stability confirm readiness.
+        // Claude Code v2.1.116 paints its banner + input-widget frame
+        // several hundred ms before the widget is actually wired up to
+        // accept keystrokes; without this pause, the Enter presses fired
+        // by this function land before the widget is live and get
+        // swallowed, while the pasted payload (which hits the terminal
+        // input stream directly) has already bumped the activity
+        // timestamp — masking the failure from wait_for_change.
+        thread::sleep(Duration::from_millis(500));
 
+        for attempt in 1..=opts.max_retries {
             // Paste text via bracketed paste (no trailing newline — Enter
             // is sent separately below).
             self.paste_text(session, text)?;
 
-            // Send Enter 3 times with small gaps. Some backends need time
-            // to process the pasted text before accepting Enter, and a
-            // single Enter can be lost. Redundant Enters are harmless.
+            // Snapshot pane state AFTER paste but BEFORE the Enter keys,
+            // so wait_for_change below actually verifies that the Enter
+            // submitted the prompt — not merely that paste_text drew the
+            // payload into the input widget. Without this ordering, a
+            // swallowed Enter still appears "successful" because the
+            // paste itself counts as a pane change.
+            let content_before = self.capture_pane(session, 50).unwrap_or_default();
+            let activity_before = self.get_pane_activity(session).unwrap_or(0);
+
+            // Send Enter 3 times with 400 ms gaps. The wider gap gives
+            // Claude Code's input widget time to finish ingesting the
+            // paste (it runs a debounce before accepting submit) before
+            // we try to trigger submission. Redundant Enters are harmless
+            // on all supported backends.
             for _ in 0..3 {
-                thread::sleep(Duration::from_millis(150));
+                thread::sleep(Duration::from_millis(400));
                 let _ = self.send_keys(session, "Enter");
             }
 
-            // Verify the backend processed the input.
+            // Verify the backend processed the Enter (not just the paste).
             if self.wait_for_change(
                 session,
                 activity_before,
@@ -319,6 +336,14 @@ impl TmuxClient {
                 opts.verify_timeout,
                 opts.poll_interval,
             ) {
+                // Belt-and-suspenders: one more trailing Enter after
+                // verification. If the widget had only just become live
+                // during the retry window, the observed pane change may
+                // have been a caret blink or spinner rather than actual
+                // submission — this extra Enter guarantees submit in
+                // that edge case and is a no-op when the prompt has
+                // already been accepted.
+                let _ = self.send_keys(session, "Enter");
                 return Ok(());
             }
 
@@ -400,8 +425,14 @@ impl TmuxClient {
         false
     }
 
-    /// Wait until pane output contains any of the provided markers.
+    /// Wait until pane output contains ALL of the provided markers.
     /// Matching is case-insensitive; returns false on timeout.
+    ///
+    /// All-match (rather than any-match) semantics matter for backends like
+    /// Claude Code v2.1.116, where the product banner paints hundreds of
+    /// ms before the input widget is actually ready to accept keystrokes.
+    /// Matching on only one of several markers would let the caller fire
+    /// Enter into a pane that silently swallows it.
     pub fn wait_for_markers(
         &self,
         session: &str,
@@ -420,7 +451,7 @@ impl TmuxClient {
             // independently (Claude Code inserts a reset between them).
             if let Ok(content) = self.capture_pane_plain(session, 120) {
                 let hay = content.to_ascii_lowercase();
-                if needles.iter().any(|needle| hay.contains(needle)) {
+                if needles.iter().all(|needle| hay.contains(needle)) {
                     return true;
                 }
             }
@@ -925,6 +956,72 @@ mod tests {
             content.contains("DELIVERED_AFTER_MARKERS"),
             "Expected delivered command in pane: {:?}",
             content
+        );
+    }
+
+    /// Regression: `wait_for_markers` must require ALL markers to be
+    /// present, not any-of. Claude Code v2.1.116 paints "Claude Code" in
+    /// its banner several hundred ms before the input widget is actually
+    /// wired up to accept Enter; any-of matching returned true immediately
+    /// when only the banner was visible and let `deliver_prompt` fire
+    /// Enter into a pane that would silently swallow it. With all-of
+    /// semantics, we don't succeed until every marker (banner + input-
+    /// widget footer for claude) has rendered.
+    #[test]
+    fn test_wait_for_markers_requires_all_markers() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let session = "omar-test-wait-markers-all";
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", session])
+            .output();
+        let _guard = SessionGuard(session.to_string());
+
+        let ok = Command::new("tmux")
+            .args(["new-session", "-d", "-s", session])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            return;
+        }
+
+        let client = TmuxClient::new("omar-test-");
+
+        // Print only the first marker. With the old any-of semantics
+        // wait_for_markers would return true; with all-of it must not.
+        let _ = client.send_keys_literal(session, "echo FIRST_MARKER_ONLY");
+        let _ = client.send_keys(session, "Enter");
+        thread::sleep(Duration::from_millis(300));
+
+        let found = client.wait_for_markers(
+            session,
+            &["FIRST_MARKER_ONLY", "SECOND_MARKER_MISSING"],
+            Duration::from_millis(600),
+            Duration::from_millis(50),
+        );
+        assert!(
+            !found,
+            "wait_for_markers must require ALL markers; returning true \
+             when only one is present regresses the Claude Code v2.1.116 \
+             Enter-swallow fix"
+        );
+
+        // Now print the second marker too; both present -> must return true.
+        let _ = client.send_keys_literal(session, "echo SECOND_MARKER_MISSING");
+        let _ = client.send_keys(session, "Enter");
+        let found = client.wait_for_markers(
+            session,
+            &["FIRST_MARKER_ONLY", "SECOND_MARKER_MISSING"],
+            Duration::from_secs(3),
+            Duration::from_millis(50),
+        );
+        assert!(
+            found,
+            "wait_for_markers must return true once ALL markers are present"
         );
     }
 

--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -966,7 +966,7 @@ mod tests {
     /// when only the banner was visible and let `deliver_prompt` fire
     /// Enter into a pane that would silently swallow it. With all-of
     /// semantics, we don't succeed until every marker (banner + input-
-    /// widget footer for claude) has rendered.
+    /// widget prompt glyph "❯" for claude) has rendered.
     #[test]
     fn test_wait_for_markers_requires_all_markers() {
         if !tmux_available() {
@@ -1022,6 +1022,59 @@ mod tests {
         assert!(
             found,
             "wait_for_markers must return true once ALL markers are present"
+        );
+    }
+
+    /// Regression: the claude readiness marker set includes "❯" (U+276F),
+    /// the non-ASCII input-widget prompt glyph. `wait_for_markers` lowercases
+    /// the hay with `to_ascii_lowercase`, which leaves "❯" byte-identical,
+    /// so substring matching must still find it. This test locks in that
+    /// UTF-8 markers work, so nobody later "fixes" readiness matching with a
+    /// full-Unicode lowercase transform that would shift the bytes and break
+    /// the match. Also guards against a prior bug where `capture_pane` (with
+    /// `-e`, ANSI-inclusive) was used for marker matching, which inserts
+    /// escape sequences mid-string and breaks multi-byte char boundaries.
+    #[test]
+    fn test_wait_for_markers_matches_claude_prompt_glyph() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let session = "omar-test-claude-glyph-marker";
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", session])
+            .output();
+        let _guard = SessionGuard(session.to_string());
+
+        let ok = Command::new("tmux")
+            .args(["new-session", "-d", "-s", session])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            return;
+        }
+
+        let client = TmuxClient::new("omar-test-");
+
+        // Put "Claude Code" and "❯" directly into the pane as literal
+        // bytes via `send-keys -l`. Avoids running a shell command so
+        // the test is independent of the sandbox's default shell actually
+        // executing inputs.
+        let _ = client.send_keys_literal(session, "Claude Code ❯ ");
+
+        let found = client.wait_for_markers(
+            session,
+            &["Claude Code", "❯"],
+            Duration::from_secs(3),
+            Duration::from_millis(50),
+        );
+        assert!(
+            found,
+            "wait_for_markers must match the non-ASCII \"❯\" glyph used as \
+             Claude Code's input prompt — regresses the v2.1.116 Enter- \
+             swallow fix if missing"
         );
     }
 

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -12,19 +12,23 @@ pub use session::Session;
 /// `spawn_agent` path and the CLI `manager::spawn_worker` path.
 ///
 /// For Claude Code specifically we require both the product banner
-/// ("Claude Code") AND the input-widget footer ("? for shortcuts"): on
-/// v2.1.116 the banner renders several hundred ms before the input widget
-/// is actually wired up to accept keystrokes, so matching only on
-/// "Claude Code" lets `deliver_prompt` fire Enter into a pane that silently
-/// swallows it. The shortcuts footer is the last thing Claude Code draws
-/// once the input widget is live, so its presence is a reliable signal
-/// that Enter will actually submit.
+/// ("Claude Code") AND the input-widget prompt glyph ("❯"): on v2.1.116
+/// the banner renders several hundred ms before the input widget is
+/// actually wired up to accept keystrokes, so matching only on "Claude
+/// Code" lets `deliver_prompt` fire Enter into a pane that silently
+/// swallows it. "❯" is drawn by Claude Code as the leading character of
+/// the input line and only appears once the widget has been laid out,
+/// making it a reliable readiness signal that survives tmux config
+/// differences (unlike the "? for shortcuts" hint, which Claude Code
+/// replaces with a `tmux focus-events off` warning on stock Ubuntu tmux
+/// configs — rendering that marker absent on Linux and stalling
+/// `wait_for_markers` for its full timeout).
 pub fn backend_readiness_markers(backend: &str) -> &'static [&'static str] {
     match backend {
         "codex" => &["OpenAI Codex"],
         "cursor" => &["Cursor Agent"],
         "gemini" => &["Gemini CLI"],
-        "claude" => &["Claude Code", "? for shortcuts"],
+        "claude" => &["Claude Code", "❯"],
         "opencode" => &["tab agents", "ctrl+p commands"],
         _ => &[],
     }

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -6,16 +6,25 @@ pub use client::{DeliveryOptions, TmuxClient};
 pub use health::{HealthChecker, HealthInfo, HealthState};
 pub use session::Session;
 
-/// Readiness markers for each supported backend — strings that appear in a
-/// backend's startup banner once its TUI has finished drawing and is ready
+/// Readiness markers for each supported backend — strings that must ALL
+/// appear in a backend's rendered TUI before the pane is considered ready
 /// to accept input. Single source of truth used by both the API's
 /// `spawn_agent` path and the CLI `manager::spawn_worker` path.
+///
+/// For Claude Code specifically we require both the product banner
+/// ("Claude Code") AND the input-widget footer ("? for shortcuts"): on
+/// v2.1.116 the banner renders several hundred ms before the input widget
+/// is actually wired up to accept keystrokes, so matching only on
+/// "Claude Code" lets `deliver_prompt` fire Enter into a pane that silently
+/// swallows it. The shortcuts footer is the last thing Claude Code draws
+/// once the input widget is live, so its presence is a reliable signal
+/// that Enter will actually submit.
 pub fn backend_readiness_markers(backend: &str) -> &'static [&'static str] {
     match backend {
         "codex" => &["OpenAI Codex"],
         "cursor" => &["Cursor Agent"],
         "gemini" => &["Gemini CLI"],
-        "claude" => &["Claude Code"],
+        "claude" => &["Claude Code", "? for shortcuts"],
         "opencode" => &["tab agents", "ctrl+p commands"],
         _ => &[],
     }


### PR DESCRIPTION
## Summary

Fixes an Enter-swallow race in `deliver_prompt` against Claude Code v2.1.116. After a fresh spawn, the task text was pasted correctly, but the Enter keystrokes meant to submit it were being eaten by the not-yet-live input widget — leaving the prompt sitting in the textbox until the user manually pressed Enter inside the attached pane.

This is a separate bug from the `paste-buffer -r` issue fixed in #117; that fix is intact and is not what this PR changes.

## The bug

On `main`, `deliver_prompt`:
1. Waits for the backend's banner marker (`"Claude Code"`) via `wait_for_markers`.
2. Snapshots pane state.
3. `paste_text(session, text)`.
4. Sends `Enter` three times, 150 ms apart.
5. Calls `wait_for_change` with the pre-paste snapshot.

On Claude Code v2.1.116 the banner paints ~several hundred ms before the input widget is actually wired up to accept keystrokes. The three `Enter`s fire inside that window and are silently swallowed. But because `wait_for_change` was comparing against the *pre-paste* snapshot, the paste itself counted as a pane change and `wait_for_change` happily returned `Ok` — masking the failure. The pasted text just sat in the widget until the user manually hit Enter.

Repro: spawn any Claude Code v2.1.116 worker via OMAR. Task text appears in the Claude Code input but is not submitted. Typing Enter in the attached tmux pane submits it.

## The fix

Changes in `src/tmux/`:

1. **Stricter readiness signal** — `backend_readiness_markers("claude")` now requires both `"Claude Code"` (banner) AND `"❯"` (U+276F, the input-widget prompt glyph — drawn only once the widget has been laid out).
2. **All-of marker semantics** — `wait_for_markers` now requires every marker in the list to be present, not any-of. A partial banner render can no longer falsely signal readiness. Single-marker backends (codex/cursor/gemini) are unaffected; opencode's two markers both render at ready time already.
3. **Settle delay + verify-after-paste** — after `wait_for_stable` returns, `deliver_prompt` sleeps 500 ms before the first `paste_text`, then snapshots pane state **after** the paste and **before** the Enter keys. Now `wait_for_change` verifies actual submission rather than merely the paste drawing the payload into the widget.
4. **Wider Enter gap + trailing Enter** — paste→Enter gap bumped from 150 ms to 400 ms (gives the widget time to ingest the paste before accepting submit). After `wait_for_change` succeeds, one belt-and-suspenders trailing `Enter` covers the edge case where the observed pane change was a caret blink rather than real submission.

### Why `"❯"` instead of `"? for shortcuts"`?

The original revision of this PR used `"? for shortcuts"` as the second readiness marker — the input-widget footer hint. That worked on macOS, but **on stock Ubuntu tmux (3.2a) Claude Code v2.1.116 replaces that footer with a `tmux focus-events off` warning**, so the hint marker never appears. `wait_for_markers` then burned its full 60 s timeout, and the subsequent `wait_for_stable` with `require_initial_change: true` burned another up-to-45 s on an already-stable pane. End result on Ubuntu: delivery looked completely broken.

Switching to `"❯"` (the input prompt glyph) fixes this: Claude Code draws it as the first character of the input line as soon as the widget is live, so it's an equally reliable readiness signal that does not depend on tmux config. `to_ascii_lowercase` leaves non-ASCII bytes untouched, so the needle matches verbatim in `capture_pane_plain` output.

## Verification

- `cargo check` — clean.
- `cargo clippy --all-targets` — clean.
- `cargo fmt` applied.
- `cargo test --bin omar tmux::` — passes on all tests that pass on `main`. One pre-existing failing test (`test_wait_for_markers_handles_ansi_styled_multiword_banner`) also fails on `main` at `c3435c8` without these changes, so it is an unrelated environmental issue and not a regression.
- Live Ubuntu reproduction: spawned Claude Code v2.1.116 in tmux, verified the `"❯"` marker is present in `capture_pane_plain` output, and verified paste+Enter submits the prompt.

Added two regression tests:
- `test_wait_for_markers_requires_all_markers` locks in the all-of semantics.
- `test_wait_for_markers_matches_claude_prompt_glyph` locks in that the non-ASCII `"❯"` needle is matched correctly (guards against anyone "fixing" readiness matching with a full-Unicode lowercase transform that would shift the bytes).

## Test plan

- [ ] CI green.
- [ ] Spawn a Claude Code v2.1.116 worker via OMAR on Ubuntu and confirm the task submits automatically (no manual Enter needed).
- [ ] Spawn a Claude Code v2.1.116 worker via OMAR on macOS — confirm the stricter readiness signal still works there.
- [ ] Spawn a codex / opencode worker and confirm the stricter readiness signal does not regress their spawn times.

Generated with Claude Code.
