### PR TITLE
fix: tmux extended-keys on (restore Shift+Tab in dashboard)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -377,8 +377,8 @@ const TMUX_RECOMMENDED: &[(&str, &str, &str)] = &[
     ),
     (
         "extended-keys",
-        "set -g extended-keys always",
-        "Shift+Enter in agents",
+        "set -g extended-keys on",
+        "Shift+Enter in agents (on, not always — always breaks Shift+Tab in omar)",
     ),
     (
         "set-clipboard",
@@ -1245,4 +1245,32 @@ async fn run_dashboard(config: Config) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: `extended-keys always` forces tmux to emit modify-other-keys
+    /// sequences to every client, including omar's dashboard, which doesn't
+    /// push the kitty flag. Crossterm can't parse those sequences and silently
+    /// collapses Shift+Tab to plain Tab — so `drill_up` never runs. `on`
+    /// emits extended sequences only for clients that opt in via DECSET 2017,
+    /// which keeps Shift+Enter working in Claude panes while leaving the
+    /// dashboard on legacy xterm encoding (where Shift+Tab → `\x1b[Z` →
+    /// `KeyCode::BackTab`). Do not flip back to `always`.
+    #[test]
+    fn tmux_extended_keys_recommendation_is_on_not_always() {
+        let entry = TMUX_RECOMMENDED
+            .iter()
+            .find(|(opt, _, _)| *opt == "extended-keys")
+            .expect("TMUX_RECOMMENDED must include an extended-keys entry");
+        let value = entry.1.split_whitespace().last().unwrap_or("");
+        assert_eq!(
+            value, "on",
+            "extended-keys must be `on`, not `{}` — `always` breaks Shift+Tab \
+             in the dashboard (see tests comment)",
+            value
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- `extended-keys always` (introduced in #54 to keep Shift+Enter working inside Claude panes) forces tmux to emit modify-other-keys escape sequences to every attached client — including omar's dashboard, which never pushes the kitty keyboard flag.
- crossterm can't parse those sequences without kitty being active, so Shift+Tab silently collapses to plain `Tab`. That calls `drill_down` (match in `main.rs:937-943` requires `SHIFT` for drill-up) → the keybinding appears dead.
- `on` emits extended sequences only when the client opts in via DECSET 2017. Claude panes still opt in → Shift+Enter keeps working. The dashboard stays on legacy xterm encoding where Shift+Tab → `\x1b[Z` → `KeyCode::BackTab` → `drill_up` runs.

Verified by key-event logging: before the fix, Shift+Tab was arriving as `Tab KeyModifiers(0x0)`; after, as `BackTab`.

## Test plan
- [x] New regression test `tmux_extended_keys_recommendation_is_on_not_always` asserts the constant never silently flips back to `always`.
- [x] `cargo build` + `cargo fmt --check` clean locally.
- [ ] Run `omar setup-tmux` and verify the recommendation shows `extended-keys on`.
- [ ] Launch omar inside tmux, drill in with `Tab`, press Shift+Tab, confirm drill-up.
- [ ] Inside a Claude agent pane, verify Shift+Enter still inserts a newline (the behavior #54 was protecting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)