### PR TITLE
fix: deliver YOUR PARENT via initial user message; remove dead {{PARENT_NAME}}

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -692,7 +692,6 @@ pub async fn spawn_agent(
             &base_command,
             &prompt_file,
             &[
-                ("{{PARENT_NAME}}", &prompt_parent_name),
                 ("{{TASK}}", task),
                 ("{{EA_ID}}", &ea_id.to_string()),
             ],
@@ -741,7 +740,10 @@ pub async fn spawn_agent(
     if let Some(ref task) = req.task {
         memory::save_worker_task_in(&state_dir, &session_name, task);
 
-        let user_msg = format!("YOUR NAME: {}\nYOUR TASK: {}", short_name, task);
+        let user_msg = format!(
+            "YOUR NAME: {}\nYOUR PARENT: {}\nYOUR TASK: {}",
+            short_name, prompt_parent_name, task
+        );
         let client2 = client.clone();
         let session2 = session_name.clone();
         let readiness_markers: Vec<&'static str> = backend_name

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -691,10 +691,7 @@ pub async fn spawn_agent(
         build_agent_command(
             &base_command,
             &prompt_file,
-            &[
-                ("{{TASK}}", task),
-                ("{{EA_ID}}", &ea_id.to_string()),
-            ],
+            &[("{{TASK}}", task), ("{{EA_ID}}", &ea_id.to_string())],
         )
     } else {
         base_command.clone()

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -527,7 +527,6 @@ fn spawn_worker(
         command,
         &prompt_file,
         &[
-            ("{{PARENT_NAME}}", parent_name),
             ("{{TASK}}", &agent.task),
             ("{{EA_ID}}", &ea_id.to_string()),
         ],
@@ -568,7 +567,10 @@ fn spawn_worker(
         false
     };
 
-    let initial_msg = format!("YOUR NAME: {}\nYOUR TASK: {}", agent.name, agent.task);
+    let initial_msg = format!(
+        "YOUR NAME: {}\nYOUR PARENT: {}\nYOUR TASK: {}",
+        agent.name, parent_name, agent.task
+    );
     let opts = DeliveryOptions {
         startup_timeout: Duration::from_secs(45),
         stable_quiet: Duration::from_millis(800),

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -526,10 +526,7 @@ fn spawn_worker(
     let cmd = build_agent_command(
         command,
         &prompt_file,
-        &[
-            ("{{TASK}}", &agent.task),
-            ("{{EA_ID}}", &ea_id.to_string()),
-        ],
+        &[("{{TASK}}", &agent.task), ("{{EA_ID}}", &ea_id.to_string())],
     );
 
     // Create worker session — system prompt set at process start
@@ -724,11 +721,11 @@ mod tests {
         let cmd = build_agent_command(
             "claude",
             Path::new("/prompts/worker.md"),
-            &[("{{PARENT_NAME}}", "pm-api"), ("{{TASK}}", "build it")],
+            &[("{{TASK}}", "build it"), ("{{EA_ID}}", "0")],
         );
         assert_eq!(
             cmd,
-            "claude --system-prompt \"$(sed 's|{{PARENT_NAME}}|pm-api|g; s|{{TASK}}|build it|g' '/prompts/worker.md')\""
+            "claude --system-prompt \"$(sed 's|{{TASK}}|build it|g; s|{{EA_ID}}|0|g' '/prompts/worker.md')\""
         );
     }
 
@@ -737,11 +734,7 @@ mod tests {
         let cmd = build_agent_command(
             "claude",
             Path::new("/prompts/agent.md"),
-            &[
-                ("{{PARENT_NAME}}", "ea"),
-                ("{{TASK}}", "do stuff"),
-                ("{{EA_ID}}", "2"),
-            ],
+            &[("{{TASK}}", "do stuff"), ("{{EA_ID}}", "2")],
         );
         assert!(cmd.contains("s|{{EA_ID}}|2|g"));
     }


### PR DESCRIPTION
## Summary
- Child agents now receive `YOUR PARENT:` in their initial user message alongside `YOUR NAME` and `YOUR TASK`, fixing silently-dropped `[TASK COMPLETE]` events from children to their EA.
- Removed the `{{PARENT_NAME}}` system-prompt substitution — audit confirmed it was dead across all 5 backends (claude, codex, cursor, gemini, opencode) and every prompt/skill/test/demo/bridge file.

## Why
An agent posting to `/api/ea/0/events` with `receiver: "ea_0"` (guessed from the URL) falls through the `"ea" || "omar"` branch in `scheduler/mod.rs:195` and is routed to a nonexistent tmux session — parent never sees the notification.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test --bin omar -- build_agent_command` (13/13 pass)
- [ ] Spawn a child agent, let it complete, confirm the EA receives a `[EVENT]` line for the `[TASK COMPLETE]` notification (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)