### PR TITLE
release: v0.2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "bridges/slack", "bridges/computer"]
 
 [package]
 name = "omar"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "Agent dashboard for tmux"
 license = "MIT"


### PR DESCRIPTION
Bump OMAR version from 0.2.6 to 0.2.7 for release.

`v0.2.6` lives only as an orphan tag on `fix/tmux-extended-keys-on` that never merged to main — this is the first shipped bump since v0.2.5.

## Changes since v0.2.5

- fix(tmux): deterministic `deliver_prompt` with sentinel + placeholder (#127)
- fix: deliver `YOUR PARENT` via initial user message; remove dead `{{PARENT_NAME}}` (#125)
- fix: tmux `extended-keys` `always` → `on` so Shift+Tab reaches the dashboard (#124)
- fix: wait for Claude v2.1.116 input widget readiness before pressing Enter (#123)

## Test plan

- [x] `cargo build`
- [ ] CI passes
- [ ] Tag `v0.2.7` + trigger release workflow post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
