### PR TITLE
release: v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "bridges/slack", "bridges/computer"]
 
 [package]
 name = "omar"
-version = "0.2.7"
+version = "0.3.1"
 edition = "2021"
 description = "Agent dashboard for tmux"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bump OMAR version from 0.2.7 to 0.3.1 for release.

## Changes since v0.2.7

- **feat: migrate agent orchestration from REST API to MCP stdio (#113)**
  - Replace `:9876` axum REST API with an MCP stdio server (~30 typed tools).
  - Slack bridge rewritten as an MCP stdio client; gains `[slack_bridge].active_ea` in `config.toml`, a text-edit row in the dashboard settings panel, and live re-pinning when the toml changes (no bridge restart needed).
  - `--ea <name>` auto-creates a missing EA when given a non-numeric name. Numeric IDs still error (server-assigned, monotonic).
  - `schedule_event` renamed to `schedule_omar_event` so it doesn't collide with same-named tools published by other MCP servers.
  - Backend-native `ScheduleWakeup` / `TaskReminder` / `scheduled_tasks` blocked via `--disallowedTools` at every spawn — argv-level enforcement that follows the agent regardless of cwd.
  - Many regression fixes bundled — full detail in #113.

## Why 0.3.1 (skipping 0.3.0)

Bumping the minor (0.2 → 0.3) because removing the `:9876` REST endpoints is a caller-visible breaking change for any out-of-tree integration that talked to `api/`. v0.3.0 was never published.

## Test plan
- [ ] CI green (build matrix + clippy + tmux integration scripts)
- [ ] Tag `v0.3.1` on the merged commit so `.github/workflows/release.yml` builds and publishes the cross-platform binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)