### PR TITLE
fix(test): close heredoc-vs-readback race in manager_notes integration test

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1881,22 +1881,28 @@ NOTES";
     let _ = tmux(&["send-keys", "-t", &manager_session, "-l", heredoc]);
     let _ = tmux(&["send-keys", "-t", &manager_session, "Enter"]);
 
-    // Wait for the file to land (heredoc runs asynchronously inside tmux).
+    // Wait for the heredoc body to land. `cat > file` opens (and creates)
+    // the target file immediately, before reading stdin — so a bare
+    // `path.exists()` check would race ahead of the heredoc and read an
+    // empty file. Poll for the actual content marker instead.
+    let mut written = String::new();
     let mut wrote = false;
     for _ in 0..50 {
-        if notes_path.exists() {
-            wrote = true;
-            break;
+        if let Ok(content) = fs::read_to_string(&notes_path) {
+            if content.contains("User prefers TypeScript") {
+                written = content;
+                wrote = true;
+                break;
+            }
         }
         thread::sleep(Duration::from_millis(100));
     }
     assert!(
         wrote,
-        "EA never wrote {} via shell heredoc",
+        "EA never wrote expected content into {} via shell heredoc",
         notes_path.display(),
     );
 
-    let written = fs::read_to_string(&notes_path).expect("read notes");
     assert!(
         written.contains("User prefers TypeScript"),
         "notes body: {}",


### PR DESCRIPTION
## Summary

`test_manager_notes_shell_write_persists_across_ea_restart` polls for the file's *existence* before reading and asserting on its contents:

\`\`\`rust
for _ in 0..50 {
    if notes_path.exists() { wrote = true; break; }
    thread::sleep(Duration::from_millis(100));
}
let written = fs::read_to_string(&notes_path).expect("read notes");
assert!(written.contains("User prefers TypeScript"), "notes body: {}", written);
\`\`\`

`cat > file << NOTES` opens (creates) the target file *before* reading stdin, so the existence check returns true while the file is still empty. On a slow Ubuntu CI runner the read happens before bash has drained the heredoc, and the assertion fires with `notes body: <empty>`. Same test passed on the merge of #113 — that run was just lucky on timing.

Poll for the content marker (`"User prefers TypeScript"`) instead, so the loop only breaks once the heredoc body has actually landed.

Reproduction: PR #129 has hit this twice in a row (jobs `74706499968`, `74707158637`) on otherwise-pass CI.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --test integration_test test_manager_notes_shell_write_persists_across_ea_restart` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)