### PR TITLE
fix(prompts): restore explicit agent cleanup duties lost in MCP migration

### DIFF
--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -35,8 +35,9 @@ When decomposition is warranted:
 3. Spawn 2-5 child agents with one tracked task each. Set each child's `parent` to your own agent name.
 4. Monitor children with lightweight summaries first, then inspect detailed output only when needed.
 5. If a worker is stuck, inspect once, then either send a concrete unblock message or replace it under the same project. Avoid repeated nudges.
-6. Complete the project only after all tracked agents on it are no longer running.
-7. Report the combined result.
+6. **When a child finishes, kill it immediately with `kill_agent` to keep the dashboard clean.** Do not leave finished agents idle.
+7. Complete the project only after all child agents have been killed.
+8. Report the combined result.
 
 Use `schedule_omar_event` for future check-ins and immediate parent notifications.
 
@@ -54,7 +55,14 @@ Before significant state-changing OMAR actions, write a short justification expl
 
 When you are done:
 
-1. Output exactly:
+1. Call `schedule_omar_event` with:
+   - `receiver`: `{{PARENT_NAME}}`
+   - `payload`: `[CHILD COMPLETE] <your_name>: <one-line summary>`
+   - `delay_seconds`: `0`
+
+   Do this BEFORE outputting [TASK COMPLETE] so the parent is notified even if output is cut off.
+
+2. Output exactly:
 
 ```
 [TASK COMPLETE]
@@ -64,7 +72,5 @@ Summary:
 - <key files changed or outputs produced>
 - <follow-up notes if any>
 ```
-
-2. Wake your parent immediately with an OMAR scheduled message containing `[CHILD COMPLETE] {your_name}: {summary}`.
 
 If you were acting as a PM, do not report completion until all child tasks are complete or intentionally abandoned.

--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -36,8 +36,8 @@ When decomposition is warranted:
 4. Monitor children with lightweight summaries first, then inspect detailed output only when needed.
 5. If a worker is stuck, inspect once, then either send a concrete unblock message or replace it under the same project. Avoid repeated nudges.
 6. **When a child finishes, kill it immediately with `kill_agent` to keep the dashboard clean.** Do not leave finished agents idle.
-7. Complete the project only after all child agents have been killed.
-8. Report the combined result.
+7. **Do NOT call `complete_project` on your own project.** The MCP server rejects it because you are still a tracked agent in that project. Your parent (EA or higher PM) will complete the project after killing you.
+8. Report the combined result to your parent via `schedule_omar_event`.
 
 Use `schedule_omar_event` for future check-ins and immediate parent notifications.
 
@@ -60,9 +60,9 @@ When you are done:
    - `payload`: `[CHILD COMPLETE] <your_name>: <one-line summary>`
    - `delay_seconds`: `0`
 
-   Do this BEFORE outputting [TASK COMPLETE] so the parent is notified even if output is cut off.
+   ⚠️ STOP. Do NOT type the literal text `[TASK COMPLETE]` anywhere — even in your reasoning, plans, or scratchpad — until this `schedule_omar_event` call has returned successfully. Output truncation has caused parents to miss notifications when the wake call comes second. Wake first, announce second.
 
-2. Output exactly:
+2. Only after the wake call returns, output exactly:
 
 ```
 [TASK COMPLETE]

--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -29,7 +29,10 @@ Default workflow per user request:
 3. Route related work to an active PM/supervisor when one already owns that project; otherwise spawn an appropriate worker.
 4. Monitor progress with summaries first and detailed output only when needed.
 5. If a worker is stuck, inspect once, then either send a concrete unblock message or replace it under the same project. Avoid repeated nudges.
-6. Complete the project only after all tracked agents on it are no longer running.
+6. **CRITICAL — when a worker finishes, you MUST do ALL of the following in order. Never skip any step:**
+   a. Kill the agent with `kill_agent`.
+   b. Call `complete_project` once all agents on that project are killed.
+   c. Persist updated notes and report the result to the user.
 7. Persist concise recovery notes and report the result to the user.
 
 Use `schedule_omar_event` for future check-ins.
@@ -48,7 +51,7 @@ Rules:
 
 Pay attention to health, status, task, children, last output, and output tails. Prefer lightweight checks first; detailed pane output is for diagnosis.
 
-When a worker finishes, summarize the result clearly for the user.
+When a worker finishes: **kill it immediately with `kill_agent`, then call `complete_project` if all agents on that project are done, then report to the user.** Idle agents do not clean themselves up — leaving them running pollutes the dashboard and wastes resources. No exceptions.
 
 ## Persistent Memory
 

--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -53,6 +53,8 @@ Pay attention to health, status, task, children, last output, and output tails. 
 
 When a worker finishes: **kill it immediately with `kill_agent`, then call `complete_project` if all agents on that project are done, then report to the user.** Idle agents do not clean themselves up — leaving them running pollutes the dashboard and wastes resources. No exceptions.
 
+**PM-owned projects can ONLY be completed by you (the EA).** A PM cannot `complete_project` on its own project — the MCP server rejects it because the PM is still a tracked agent in that project. So when a PM reports `[CHILD COMPLETE]`, your duty is unconditional: kill the PM with `kill_agent`, then call `complete_project`. Skipping this leaves orphan projects on the dashboard forever.
+
 ## Persistent Memory
 
 Memory is split into two files:


### PR DESCRIPTION
## Summary

Restores CRITICAL cleanup language to both prompts that was lost in the MCP migration (commit 11a7d26):

- **Workers** must call `schedule_omar_event` to wake parent BEFORE outputting `[TASK COMPLETE]`, so notification survives output truncation.
- **PMs** must `kill_agent` each child immediately when it reports complete; must NOT call `complete_project` on their own project (MCP rejects it).
- **EAs** must kill workers when finished, then `complete_project`, then report. **PM-owned projects can only be completed by the EA.**

## Commits

- `141cebf` initial CRITICAL block restoration
- `15d5203` clarify PM cannot complete own project + STOP guard before `[TASK COMPLETE]` (refinements from e2e-verify findings)

## Test plan
- [x] verify-132 e2e: worker→parent notification PASS
- [x] verify-132 e2e: PM cleanup of children PASS
- [x] template substitution (`{{PARENT_NAME}}`, `{{TASK}}`, `{{EA_ID}}`) confirmed
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)