### PR TITLE
fix(test): align opencode binary-tree session names with multi-EA scheme

### DIFF
--- a/tests/ci/opencode_binary_tree.sh
+++ b/tests/ci/opencode_binary_tree.sh
@@ -127,7 +127,7 @@ fail() {
 
 # Spawn the EA (root). Uses the configured default_command (opencode + model_a).
 omar_cmd manager start >/dev/null 2>&1 &
-ea_session="omar-agent-0-default"
+ea_session="omar-agent-ea-0"
 wait_for_session "$ea_session" 60 || fail "EA session never came up"
 
 # Wait for the EA's opencode TUI to become interactive. We don't have a
@@ -142,8 +142,8 @@ omar_cmd spawn -n leaf1 -c "opencode -m $model_a" >/dev/null 2>&1 \
 omar_cmd spawn -n leaf2 -c "opencode -m $model_b" >/dev/null 2>&1 \
   || fail "failed to spawn leaf2"
 
-leaf1_session="omar-agent-leaf1"
-leaf2_session="omar-agent-leaf2"
+leaf1_session="omar-agent-0-leaf1"
+leaf2_session="omar-agent-0-leaf2"
 wait_for_session "$leaf1_session" 60 || fail "leaf1 session never came up"
 wait_for_session "$leaf2_session" 60 || fail "leaf2 session never came up"
 


### PR DESCRIPTION
## Summary
Fixes the nightly **Opencode Binary Tree** workflow, which has failed every run since it was added (2026-05-07, 2026-05-08, run [25543481362](https://github.com/lsk567/omar/actions/runs/25543481362)) at:

```
Timed out waiting for session: omar-agent-0-default
FAIL: EA session never came up
```

The test was authored with session-name expectations that never matched the code:

| Test expected | Actual code (since well before the test was added) |
|---|---|
| EA manager: `omar-agent-0-default` | `omar-agent-ea-0` (`ea_manager_session`) |
| Workers: `omar-agent-leaf{1,2}` | `omar-agent-0-leaf{1,2}` (worker `ea_prefix` includes the EA id for multi-EA isolation) |

The `omar-agent-ea-<id>` manager-session and `omar-agent-<id>-<name>` worker-session conventions are deliberate (multi-EA isolation) and are hard-coded across `src/app.rs`, `src/manager/mod.rs`, `src/tmux/client.rs`, the dashboard, scheduled-event routing, and many tests. The right fix is to align the new test with the established scheme rather than rename sessions across the codebase.

## Test plan
- [ ] Re-run the `Opencode Binary Tree (Nightly)` workflow via `workflow_dispatch` and confirm the EA + leaf sessions are detected.
- [ ] Confirm per-PR CI is unaffected (this test skip-passes when `OMAR_OPENCODE_E2E != 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)