### PR TITLE
Fix dashboard launch handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,35 @@ jobs:
       - name: Run EA zero-selector integration
         run: bash tests/ci/tmux_ea_selector_zero.sh
 
+  dashboard-relaunch-handoff-integration:
+    name: Dashboard Relaunch Handoff Integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install tmux
+        run: sudo apt-get update && sudo apt-get install -y tmux
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build omar
+        run: cargo build --bin omar
+
+      - name: Run dashboard relaunch handoff integration
+        run: bash tests/ci/dashboard_relaunch_handoff.sh
+
   opencode-compat:
     name: Opencode Compatibility
     runs-on: ubuntu-latest
@@ -323,7 +352,7 @@ jobs:
   # Ensure all jobs pass before allowing merge
   ci-success:
     name: CI Success
-    needs: [check, fmt, clippy, test, popup-quote-integration, exit-behavior-integration, unresolved-session-integration, codex-yolo-integration, ea-zero-selector-integration, opencode-compat, build]
+    needs: [check, fmt, clippy, test, popup-quote-integration, exit-behavior-integration, unresolved-session-integration, codex-yolo-integration, ea-zero-selector-integration, dashboard-relaunch-handoff-integration, opencode-compat, build]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -338,6 +367,7 @@ jobs:
              [[ "${{ needs.unresolved-session-integration.result }}" != "success" ]] || \
              [[ "${{ needs.codex-yolo-integration.result }}" != "success" ]] || \
              [[ "${{ needs.ea-zero-selector-integration.result }}" != "success" ]] || \
+             [[ "${{ needs.dashboard-relaunch-handoff-integration.result }}" != "success" ]] || \
              [[ "${{ needs.opencode-compat.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]]; then
             echo "One or more jobs failed"

--- a/src/app.rs
+++ b/src/app.rs
@@ -282,6 +282,7 @@ impl App {
 
     /// Refresh the list of agents (scoped to active EA)
     pub fn refresh(&mut self) -> Result<()> {
+        self.apply_dashboard_launch_handoff();
         self.registered_eas = ea::load_registry(&self.omar_dir);
 
         // Pick up out-of-band EA switches (e.g. via the MCP `switch_ea` tool)
@@ -518,6 +519,18 @@ impl App {
         Ok(())
     }
 
+    fn apply_dashboard_launch_handoff(&mut self) {
+        let Some(handoff) = ea::take_dashboard_launch_handoff(&self.omar_dir) else {
+            return;
+        };
+
+        self.config.agent.default_command = handoff.default_command.clone();
+        self.config.agent.default_workdir = handoff.default_workdir.clone();
+        self.default_command = handoff.default_command;
+        self.default_workdir = handoff.default_workdir;
+        let _ = ea::save_active_ea(&self.omar_dir, handoff.active_ea);
+    }
+
     /// Build the startup command attempts for the manager.
     ///
     /// In strict mode we issue exactly one launch command so behavior matches
@@ -549,9 +562,7 @@ impl App {
             .map(|ea| ea.name.as_str())
             .unwrap_or("Default");
 
-        let workdir = std::env::current_dir()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| ".".to_string());
+        let workdir = self.default_workdir.clone();
 
         let (default_command, inject_prompt) = self
             .manager_startup_attempts()
@@ -2068,6 +2079,30 @@ mod tests {
             assert_eq!(&attempts[0].0, cmd);
             assert!(attempts[0].1);
         }
+    }
+
+    #[test]
+    fn dashboard_launch_handoff_updates_runtime_command_and_workdir() {
+        let _guard = env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let _home = HomeEnvGuard::set(dir.path());
+        let config = test_config_with_prefix(format!("omar-test-{}-", uuid::Uuid::new_v4()));
+        let scheduler = Arc::new(Scheduler::new());
+        let mut app = App::new(&config, TickerBuffer::new(), scheduler);
+        let handoff = ea::DashboardLaunchHandoff {
+            active_ea: 0,
+            default_command: "claude --dangerously-skip-permissions".to_string(),
+            default_workdir: "/tmp/omar-launch".to_string(),
+        };
+        ea::save_dashboard_launch_handoff(&app.omar_dir, &handoff).unwrap();
+
+        app.apply_dashboard_launch_handoff();
+
+        assert_eq!(app.default_command(), handoff.default_command);
+        assert_eq!(app.default_workdir, handoff.default_workdir);
+        assert_eq!(app.config.agent.default_command, handoff.default_command);
+        assert_eq!(app.config.agent.default_workdir, handoff.default_workdir);
+        assert!(ea::take_dashboard_launch_handoff(&app.omar_dir).is_none());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -526,6 +526,12 @@ impl App {
             return Ok(());
         };
 
+        // Capture the pre-handoff backend so we only restart the manager when
+        // the user actually switched backends. `omar -a claude` while already
+        // on claude shouldn't kill the running EA — that throws away the
+        // backend's in-memory conversation for nothing.
+        let backend_changed = self.default_command != handoff.default_command;
+
         self.config.agent.default_command = handoff.default_command.clone();
         self.config.agent.default_workdir = handoff.default_workdir.clone();
         self.default_command = handoff.default_command;
@@ -533,7 +539,7 @@ impl App {
         self.activate_ea_local(handoff.active_ea)?;
         ea::save_active_ea(&self.omar_dir, handoff.active_ea)?;
 
-        if handoff.restart_manager {
+        if handoff.restart_manager && backend_changed {
             let manager_session = ea::ea_manager_session(handoff.active_ea, &self.base_prefix);
             if self.client.has_session(&manager_session)? {
                 self.client.kill_session(&manager_session)?;
@@ -2113,6 +2119,147 @@ mod tests {
         assert_eq!(app.config.agent.default_command, handoff.default_command);
         assert_eq!(app.config.agent.default_workdir, handoff.default_workdir);
         assert!(ea::take_dashboard_launch_handoff(&app.omar_dir).is_none());
+    }
+
+    #[test]
+    fn dashboard_launch_handoff_preserves_manager_when_backend_unchanged() {
+        // Regression guard for the no-op case: `omar -a claude` typed while
+        // the EA is already running under claude must NOT kill the manager
+        // tmux session, since that throws away the backend's in-memory
+        // conversation for no behavioral change.
+        if !std::process::Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+        {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let _guard = env_lock();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let _home = HomeEnvGuard::set(dir.path());
+        let tmux_server = format!("omar-handoff-noop-{}", uuid::Uuid::new_v4());
+        let _tmux = TmuxServerEnvGuard::set(&tmux_server);
+        let prefix = format!("omar-test-{}-", uuid::Uuid::new_v4());
+        let config = test_config_with_prefix(prefix.clone());
+        let mut app = App::new(&config, TickerBuffer::new(), Arc::new(Scheduler::new()));
+
+        let claude = crate::config::resolve_backend("claude").unwrap();
+        app.default_command = claude.clone();
+        app.config.agent.default_command = claude.clone();
+
+        let manager_session = ea::ea_manager_session(0, &prefix);
+        let spawned = std::process::Command::new("tmux")
+            .args([
+                "-L",
+                &tmux_server,
+                "new-session",
+                "-d",
+                "-s",
+                &manager_session,
+                "sleep 600",
+            ])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !spawned {
+            eprintln!("Skipping test: failed to create tmux session");
+            return;
+        }
+        assert!(app.client.has_session(&manager_session).unwrap());
+
+        let handoff = ea::DashboardLaunchHandoff {
+            active_ea: 0,
+            default_command: claude.clone(),
+            default_workdir: "/tmp/omar-noop".to_string(),
+            restart_manager: true,
+        };
+        ea::save_dashboard_launch_handoff(&app.omar_dir, &handoff).unwrap();
+
+        app.apply_dashboard_launch_handoff().unwrap();
+
+        assert!(
+            app.client.has_session(&manager_session).unwrap(),
+            "no-op handoff (same backend) must not kill the manager session"
+        );
+
+        let _ = std::process::Command::new("tmux")
+            .args(["-L", &tmux_server, "kill-session", "-t", &manager_session])
+            .status();
+    }
+
+    #[test]
+    fn dashboard_launch_handoff_kills_manager_when_backend_changes() {
+        // Positive case: a real backend swap (claude -> opencode) must kill
+        // the manager session so it respawns under the new backend.
+        if !std::process::Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false)
+        {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let _guard = env_lock();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let _home = HomeEnvGuard::set(dir.path());
+        let tmux_server = format!("omar-handoff-swap-{}", uuid::Uuid::new_v4());
+        let _tmux = TmuxServerEnvGuard::set(&tmux_server);
+        let prefix = format!("omar-test-{}-", uuid::Uuid::new_v4());
+        let config = test_config_with_prefix(prefix.clone());
+        let mut app = App::new(&config, TickerBuffer::new(), Arc::new(Scheduler::new()));
+
+        let claude = crate::config::resolve_backend("claude").unwrap();
+        let opencode = crate::config::resolve_backend("opencode").unwrap();
+        assert_ne!(
+            claude, opencode,
+            "backends must resolve to distinct commands"
+        );
+        app.default_command = claude.clone();
+        app.config.agent.default_command = claude.clone();
+
+        let manager_session = ea::ea_manager_session(0, &prefix);
+        let spawned = std::process::Command::new("tmux")
+            .args([
+                "-L",
+                &tmux_server,
+                "new-session",
+                "-d",
+                "-s",
+                &manager_session,
+                "sleep 600",
+            ])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !spawned {
+            eprintln!("Skipping test: failed to create tmux session");
+            return;
+        }
+        assert!(app.client.has_session(&manager_session).unwrap());
+
+        let handoff = ea::DashboardLaunchHandoff {
+            active_ea: 0,
+            default_command: opencode.clone(),
+            default_workdir: "/tmp/omar-swap".to_string(),
+            restart_manager: true,
+        };
+        ea::save_dashboard_launch_handoff(&app.omar_dir, &handoff).unwrap();
+
+        app.apply_dashboard_launch_handoff().unwrap();
+
+        assert!(
+            !app.client.has_session(&manager_session).unwrap(),
+            "real backend swap must kill the manager session so it respawns under the new backend"
+        );
+        assert!(
+            app.manager.is_none(),
+            "App::manager must be cleared after kill"
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -282,7 +282,7 @@ impl App {
 
     /// Refresh the list of agents (scoped to active EA)
     pub fn refresh(&mut self) -> Result<()> {
-        self.apply_dashboard_launch_handoff();
+        self.apply_dashboard_launch_handoff()?;
         self.registered_eas = ea::load_registry(&self.omar_dir);
 
         // Pick up out-of-band EA switches (e.g. via the MCP `switch_ea` tool)
@@ -519,16 +519,26 @@ impl App {
         Ok(())
     }
 
-    fn apply_dashboard_launch_handoff(&mut self) {
+    fn apply_dashboard_launch_handoff(&mut self) -> Result<()> {
         let Some(handoff) = ea::take_dashboard_launch_handoff(&self.omar_dir) else {
-            return;
+            return Ok(());
         };
 
         self.config.agent.default_command = handoff.default_command.clone();
         self.config.agent.default_workdir = handoff.default_workdir.clone();
         self.default_command = handoff.default_command;
         self.default_workdir = handoff.default_workdir;
-        let _ = ea::save_active_ea(&self.omar_dir, handoff.active_ea);
+        self.activate_ea_local(handoff.active_ea)?;
+        ea::save_active_ea(&self.omar_dir, handoff.active_ea)?;
+
+        if handoff.restart_manager {
+            let manager_session = ea::ea_manager_session(handoff.active_ea, &self.base_prefix);
+            if self.client.has_session(&manager_session)? {
+                self.client.kill_session(&manager_session)?;
+                self.manager = None;
+            }
+        }
+        Ok(())
     }
 
     /// Build the startup command attempts for the manager.
@@ -1351,30 +1361,8 @@ Use the OMAR MCP tools for inspection/control. To post to Slack, call the `slack
 
     /// Switch the dashboard to a different EA. Full reload of all state.
     pub fn switch_ea(&mut self, ea_id: EaId) -> Result<()> {
-        // Reload registry and validate that the target EA exists
-        self.registered_eas = ea::load_registry(&self.omar_dir);
-        if !self.registered_eas.iter().any(|e| e.id == ea_id) {
-            anyhow::bail!("EA {} not registered", ea_id);
-        }
-
-        self.active_ea = ea_id;
+        self.activate_ea_local(ea_id)?;
         ea::save_active_ea(&self.omar_dir, ea_id)?;
-
-        // Reconstruct tmux client with new EA's prefix
-        let new_prefix = ea::ea_prefix(ea_id, &self.base_prefix);
-        self.client = TmuxClient::new(&new_prefix);
-        self.health_checker = HealthChecker::new(self.client.clone(), self.health_threshold)
-            .with_auth_failure_patterns(self.config.watchdog.auth_failure_patterns.clone());
-
-        // Reset all view state
-        self.focus_parent = ea::ea_manager_session(ea_id, &self.base_prefix);
-        self.focus_stack.clear();
-        self.selected = 0;
-        self.manager_selected = true;
-
-        // Ensure EA state directory exists; refresh() will reload projects/parents/tasks
-        let state_dir = ea::ea_state_dir(ea_id, &self.omar_dir);
-        std::fs::create_dir_all(&state_dir).ok();
 
         // Refresh discovers agents via the new prefix and reloads all EA state
         self.refresh()?;
@@ -1395,6 +1383,27 @@ Use the OMAR MCP tools for inspection/control. To post to Slack, call the `slack
         self.settings_edit_buffer = None;
         self.sidebar_popup = None;
         self.pending_confirm = None;
+        Ok(())
+    }
+
+    fn activate_ea_local(&mut self, ea_id: EaId) -> Result<()> {
+        self.registered_eas = ea::load_registry(&self.omar_dir);
+        if !self.registered_eas.iter().any(|e| e.id == ea_id) {
+            anyhow::bail!("EA {} not registered", ea_id);
+        }
+
+        self.active_ea = ea_id;
+        let new_prefix = ea::ea_prefix(ea_id, &self.base_prefix);
+        self.client = TmuxClient::new(&new_prefix);
+        self.health_checker = HealthChecker::new(self.client.clone(), self.health_threshold)
+            .with_auth_failure_patterns(self.config.watchdog.auth_failure_patterns.clone());
+        self.focus_parent = ea::ea_manager_session(ea_id, &self.base_prefix);
+        self.focus_stack.clear();
+        self.selected = 0;
+        self.manager_selected = true;
+
+        let state_dir = ea::ea_state_dir(ea_id, &self.omar_dir);
+        std::fs::create_dir_all(&state_dir).ok();
         Ok(())
     }
 
@@ -2093,10 +2102,11 @@ mod tests {
             active_ea: 0,
             default_command: crate::config::resolve_backend("claude").unwrap(),
             default_workdir: "/tmp/omar-launch".to_string(),
+            restart_manager: false,
         };
         ea::save_dashboard_launch_handoff(&app.omar_dir, &handoff).unwrap();
 
-        app.apply_dashboard_launch_handoff();
+        app.apply_dashboard_launch_handoff().unwrap();
 
         assert_eq!(app.default_command(), handoff.default_command);
         assert_eq!(app.default_workdir, handoff.default_workdir);

--- a/src/app.rs
+++ b/src/app.rs
@@ -2091,7 +2091,7 @@ mod tests {
         let mut app = App::new(&config, TickerBuffer::new(), scheduler);
         let handoff = ea::DashboardLaunchHandoff {
             active_ea: 0,
-            default_command: "claude --dangerously-skip-permissions".to_string(),
+            default_command: crate::config::resolve_backend("claude").unwrap(),
             default_workdir: "/tmp/omar-launch".to_string(),
         };
         ea::save_dashboard_launch_handoff(&app.omar_dir, &handoff).unwrap();

--- a/src/ea.rs
+++ b/src/ea.rs
@@ -25,6 +25,8 @@ pub struct DashboardLaunchHandoff {
     pub active_ea: EaId,
     pub default_command: String,
     pub default_workdir: String,
+    #[serde(default)]
+    pub restart_manager: bool,
 }
 
 fn default_ea_info() -> EaInfo {
@@ -444,6 +446,7 @@ mod tests {
             active_ea: 4,
             default_command: crate::config::resolve_backend("claude").unwrap(),
             default_workdir: "/tmp/omar".to_string(),
+            restart_manager: true,
         };
 
         save_dashboard_launch_handoff(dir.path(), &handoff).unwrap();
@@ -452,6 +455,7 @@ mod tests {
         assert_eq!(loaded.active_ea, handoff.active_ea);
         assert_eq!(loaded.default_command, handoff.default_command);
         assert_eq!(loaded.default_workdir, handoff.default_workdir);
+        assert_eq!(loaded.restart_manager, handoff.restart_manager);
         assert!(take_dashboard_launch_handoff(dir.path()).is_none());
     }
 

--- a/src/ea.rs
+++ b/src/ea.rs
@@ -20,6 +20,13 @@ pub struct EaInfo {
     pub created_at: u64, // Unix timestamp
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DashboardLaunchHandoff {
+    pub active_ea: EaId,
+    pub default_command: String,
+    pub default_workdir: String,
+}
+
 fn default_ea_info() -> EaInfo {
     EaInfo {
         id: 0,
@@ -60,6 +67,10 @@ fn active_ea_path(base_dir: &Path) -> PathBuf {
     base_dir.join("active_ea")
 }
 
+fn dashboard_handoff_path(base_dir: &Path) -> PathBuf {
+    base_dir.join("dashboard_handoff.json")
+}
+
 /// Load all registered EAs from ~/.omar/eas.json.
 pub fn load_registry(base_dir: &Path) -> Vec<EaInfo> {
     let path = base_dir.join("eas.json");
@@ -92,6 +103,23 @@ pub fn save_active_ea(base_dir: &Path, ea_id: EaId) -> anyhow::Result<()> {
     fs::create_dir_all(base_dir)?;
     fs::write(&path, ea_id.to_string())?;
     Ok(())
+}
+
+pub fn save_dashboard_launch_handoff(
+    base_dir: &Path,
+    handoff: &DashboardLaunchHandoff,
+) -> anyhow::Result<()> {
+    let path = dashboard_handoff_path(base_dir);
+    fs::create_dir_all(base_dir)?;
+    fs::write(&path, serde_json::to_vec(handoff)?)?;
+    Ok(())
+}
+
+pub fn take_dashboard_launch_handoff(base_dir: &Path) -> Option<DashboardLaunchHandoff> {
+    let path = dashboard_handoff_path(base_dir);
+    let content = fs::read_to_string(&path).ok()?;
+    let _ = fs::remove_file(&path);
+    serde_json::from_str(&content).ok()
 }
 
 /// Resolve the active EA, falling back to the lowest registered EA when needed.
@@ -407,6 +435,24 @@ mod tests {
 
         assert_eq!(resolve_active_ea(dir.path(), &eas), 0);
         assert_eq!(load_active_ea(dir.path()), Some(0));
+    }
+
+    #[test]
+    fn dashboard_launch_handoff_round_trips_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let handoff = DashboardLaunchHandoff {
+            active_ea: 4,
+            default_command: "claude --dangerously-skip-permissions".to_string(),
+            default_workdir: "/tmp/omar".to_string(),
+        };
+
+        save_dashboard_launch_handoff(dir.path(), &handoff).unwrap();
+
+        let loaded = take_dashboard_launch_handoff(dir.path()).unwrap();
+        assert_eq!(loaded.active_ea, handoff.active_ea);
+        assert_eq!(loaded.default_command, handoff.default_command);
+        assert_eq!(loaded.default_workdir, handoff.default_workdir);
+        assert!(take_dashboard_launch_handoff(dir.path()).is_none());
     }
 
     #[test]

--- a/src/ea.rs
+++ b/src/ea.rs
@@ -442,7 +442,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let handoff = DashboardLaunchHandoff {
             active_ea: 4,
-            default_command: "claude --dangerously-skip-permissions".to_string(),
+            default_command: crate::config::resolve_backend("claude").unwrap(),
             default_workdir: "/tmp/omar".to_string(),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,7 @@ async fn async_main() -> Result<()> {
         None => {
             if std::env::var("TMUX").is_err() {
                 let target = resolve_cli_ea(&omar_dir, cli.ea.as_deref())?;
-                relaunch_in_tmux(&config, &omar_dir, target.id)
+                relaunch_in_tmux(&config, &omar_dir, target.id, cli.agent.is_some())
             } else {
                 run_dashboard(config).await
             }
@@ -550,6 +550,7 @@ fn relaunch_in_tmux(
     config: &Config,
     omar_dir: &std::path::Path,
     active_ea: ea::EaId,
+    restart_manager: bool,
 ) -> Result<()> {
     use std::os::unix::process::CommandExt;
 
@@ -563,6 +564,7 @@ fn relaunch_in_tmux(
             active_ea,
             default_command: config.agent.default_command.clone(),
             default_workdir: current_dir.to_string_lossy().into_owned(),
+            restart_manager,
         };
         ea::save_dashboard_launch_handoff(omar_dir, &handoff)?;
         let target = format!("={}", DASHBOARD_SESSION);

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,7 +321,8 @@ async fn async_main() -> Result<()> {
         },
         None => {
             if std::env::var("TMUX").is_err() {
-                relaunch_in_tmux()
+                let target = resolve_cli_ea(&omar_dir, cli.ea.as_deref())?;
+                relaunch_in_tmux(&config, &omar_dir, target.id)
             } else {
                 run_dashboard(config).await
             }
@@ -541,20 +542,32 @@ fn cancel_cli_event(
 /// Called when the dashboard is started outside of tmux so that popups,
 /// attach, and other tmux-dependent features work correctly.
 ///
-/// If an existing dashboard session exists, tries to attach to it.
-/// This preserves the in-memory scheduler (cron jobs, pending events)
-/// across detach/reattach cycles. If attach fails (stale session),
-/// kills the session and creates a fresh one.
-fn relaunch_in_tmux() -> Result<()> {
+/// If the dashboard is already running, hands this invocation's EA/backend/cwd
+/// to it and attaches. This preserves the in-memory scheduler (cron jobs,
+/// pending events) across detach/reattach cycles. If attach fails (stale
+/// session), kills the stale session and creates a fresh one.
+fn relaunch_in_tmux(
+    config: &Config,
+    omar_dir: &std::path::Path,
+    active_ea: ea::EaId,
+) -> Result<()> {
     use std::os::unix::process::CommandExt;
 
     let client = TmuxClient::new("");
+    let exe = std::env::current_exe()?;
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
-    // Preserve a live dashboard across detach/reattach cycles.
-    // Only kill the session if attach fails, which indicates a stale tmux session.
     if client.has_session(DASHBOARD_SESSION)? {
+        let handoff = ea::DashboardLaunchHandoff {
+            active_ea,
+            default_command: config.agent.default_command.clone(),
+            default_workdir: current_dir.to_string_lossy().into_owned(),
+        };
+        ea::save_dashboard_launch_handoff(omar_dir, &handoff)?;
+        let target = format!("={}", DASHBOARD_SESSION);
         let status = tmux_command()
-            .args(["-2", "attach-session", "-t", DASHBOARD_SESSION])
+            .args(["-2", "attach-session", "-t", &target])
             .status();
 
         match status {
@@ -565,13 +578,11 @@ fn relaunch_in_tmux() -> Result<()> {
         }
     }
 
-    let exe = std::env::current_exe()?;
-    let args: Vec<String> = std::env::args().skip(1).collect();
-
     let mut cmd = tmux_command();
     // Force 256-color mode when launching the dashboard session.
     cmd.arg("-2");
-    cmd.args(["new-session", "-s", DASHBOARD_SESSION]);
+    cmd.args(["new-session", "-s", DASHBOARD_SESSION, "-c"]);
+    cmd.arg(&current_dir);
     cmd.arg(&exe);
     cmd.args(&args);
 

--- a/tests/ci/dashboard_relaunch_handoff.sh
+++ b/tests/ci/dashboard_relaunch_handoff.sh
@@ -107,7 +107,7 @@ rm -f "$handoff_file"
 )
 
 if [ ! -f "$handoff_file" ]; then
-  fail "dashboard_handoff.json was not written by omar -a bash"
+  fail "dashboard_handoff.json was not written by omar -a claude"
 fi
 
 python3 - "$handoff_file" "$work_dir" <<'PY'

--- a/tests/ci/dashboard_relaunch_handoff.sh
+++ b/tests/ci/dashboard_relaunch_handoff.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end check for the dashboard relaunch handoff wired up in
+# `relaunch_in_tmux` (src/main.rs). The unit tests cover the serde
+# round-trip and the App-side apply; this test runs the real `omar` binary
+# against a fake "already running" dashboard tmux session and asserts the
+# handoff JSON written to ~/.omar/dashboard_handoff.json carries the cwd,
+# backend, active EA, and restart_manager flag taken from the second
+# invocation's arguments.
+#
+# Why this works without a TTY: relaunch_in_tmux writes the handoff
+# *before* it calls `tmux attach-session`. The attach fails in a
+# non-interactive subshell, after which omar tries to spawn a fresh
+# dashboard which also fails — both side effects we don't care about. The
+# handoff file is what we inspect.
+
+OMAR_BIN="${OMAR_BIN:-target/debug/omar}"
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux is required" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
+  exit 1
+fi
+
+if [ ! -x "$OMAR_BIN" ]; then
+  echo "OMAR binary not found or not executable: $OMAR_BIN" >&2
+  exit 1
+fi
+
+# Absolutize OMAR_BIN so the subshells that `cd` into $work_dir can still find it.
+OMAR_BIN="$(cd "$(dirname "$OMAR_BIN")" && pwd)/$(basename "$OMAR_BIN")"
+
+server="omar-handoff-${RANDOM}-$$"
+home_dir="$(mktemp -d)"
+work_dir="$(mktemp -d)"
+
+# Canonicalize $work_dir because std::env::current_dir() returns the
+# resolved path (e.g. /var/folders/... -> /private/var/folders/... on macOS),
+# and we compare it verbatim against the handoff's default_workdir.
+work_dir="$(cd "$work_dir" && pwd -P)"
+
+cleanup() {
+  tmux -L "$server" kill-server >/dev/null 2>&1 || true
+  rm -rf "$home_dir" "$work_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$home_dir/.omar"
+cat >"$home_dir/.omar/config.toml" <<'EOF'
+[dashboard]
+refresh_interval = 1
+session_prefix = "omar-agent-"
+
+[agent]
+default_command = "bash"
+default_workdir = "."
+EOF
+
+# Pre-register a single EA so resolve_cli_ea has an unambiguous answer
+# without falling back to interactive bootstrap.
+cat >"$home_dir/.omar/eas.json" <<'EOF'
+[
+  { "id": 0, "name": "Default", "description": null, "created_at": 1700000000 }
+]
+EOF
+printf '0' >"$home_dir/.omar/active_ea"
+
+tmux_cmd() {
+  HOME="$home_dir" OMAR_TMUX_SERVER="$server" tmux -L "$server" "$@"
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+handoff_file="$home_dir/.omar/dashboard_handoff.json"
+
+start_fake_dashboard() {
+  tmux_cmd kill-session -t "omar-dashboard" 2>/dev/null || true
+  tmux_cmd new-session -d -s "omar-dashboard" "sleep 9999"
+  for _ in $(seq 1 50); do
+    if tmux_cmd has-session -t "omar-dashboard" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  fail "fake dashboard session did not come up"
+}
+
+# Case 1: `omar -a claude` from $work_dir should write a handoff with the
+# new cwd, the claude backend command, and restart_manager=true (because
+# -a was passed). We don't need claude actually installed — relaunch_in_tmux
+# only writes the handoff and tries to attach; the attach is expected to fail
+# in this non-interactive subshell, which is fine.
+start_fake_dashboard
+rm -f "$handoff_file"
+
+(
+  cd "$work_dir"
+  HOME="$home_dir" OMAR_TMUX_SERVER="$server" "$OMAR_BIN" -a claude >/dev/null 2>&1 || true
+)
+
+if [ ! -f "$handoff_file" ]; then
+  fail "dashboard_handoff.json was not written by omar -a bash"
+fi
+
+python3 - "$handoff_file" "$work_dir" <<'PY'
+import json, sys
+path, work_dir = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    h = json.load(fh)
+errs = []
+if h.get("active_ea") != 0:
+    errs.append(f"active_ea: expected 0, got {h.get('active_ea')!r}")
+if "claude" not in str(h.get("default_command", "")):
+    errs.append(f"default_command: expected to mention 'claude', got {h.get('default_command')!r}")
+if h.get("default_workdir") != work_dir:
+    errs.append(f"default_workdir: expected {work_dir!r}, got {h.get('default_workdir')!r}")
+if h.get("restart_manager") is not True:
+    errs.append(f"restart_manager: expected True (because -a was passed), got {h.get('restart_manager')!r}")
+if errs:
+    raise SystemExit("handoff field mismatch (case: -a claude from new cwd):\n  " + "\n  ".join(errs))
+PY
+
+# Case 2: bare `omar` (no -a) should still hand off cwd, but
+# restart_manager must be false so the live manager isn't kicked.
+start_fake_dashboard
+rm -f "$handoff_file"
+
+(
+  cd "$work_dir"
+  HOME="$home_dir" OMAR_TMUX_SERVER="$server" "$OMAR_BIN" >/dev/null 2>&1 || true
+)
+
+if [ ! -f "$handoff_file" ]; then
+  fail "dashboard_handoff.json was not written by bare omar relaunch"
+fi
+
+python3 - "$handoff_file" "$work_dir" <<'PY'
+import json, sys
+path, work_dir = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    h = json.load(fh)
+errs = []
+if h.get("default_workdir") != work_dir:
+    errs.append(f"default_workdir: expected {work_dir!r}, got {h.get('default_workdir')!r}")
+if h.get("restart_manager") is not False:
+    errs.append(f"restart_manager: expected False (no -a), got {h.get('restart_manager')!r}")
+if errs:
+    raise SystemExit("handoff field mismatch (case: bare omar from new cwd):\n  " + "\n  ".join(errs))
+PY
+
+# Case 3: no existing dashboard => no handoff file should be written.
+# (relaunch_in_tmux only saves the handoff inside the has_session branch.)
+tmux_cmd kill-session -t "omar-dashboard" 2>/dev/null || true
+rm -f "$handoff_file"
+
+(
+  cd "$work_dir"
+  HOME="$home_dir" OMAR_TMUX_SERVER="$server" "$OMAR_BIN" -a claude >/dev/null 2>&1 || true
+)
+
+if [ -f "$handoff_file" ]; then
+  fail "dashboard_handoff.json was written on cold start (no existing dashboard)"
+fi
+
+echo "PASS: dashboard relaunch writes handoff with correct fields (and skips it on cold start)"

--- a/tests/ci/opencode_binary_tree.sh
+++ b/tests/ci/opencode_binary_tree.sh
@@ -161,11 +161,13 @@ for s in "$leaf1_session" "$leaf2_session"; do
 done
 
 # Positive assertion: each leaf pane should show that opencode came up.
-# We look for the opencode TUI banner; if the model name renders we accept
-# either signal. Both indicate the worker is alive and not crashed.
+# We look for the opencode TUI banner, normal prompt/status text, or the
+# opencode-owned update modal. Any of these indicates the worker is alive
+# and not crashed; the wizard-regression check above remains the behavioral
+# failure signal this test exists to catch.
 for s in "$leaf1_session" "$leaf2_session"; do
   text="$(pane_text "$s")"
-  if ! grep -qE 'opencode|chat|prompt' <<<"$text"; then
+  if ! grep -qiE 'opencode|chat|prompt|update available|new release' <<<"$text"; then
     fail "$s pane does not show opencode UI markers"
   fi
 done


### PR DESCRIPTION
## Summary
- hand off EA/backend/cwd from repeated `omar` launches to the existing single dashboard
- consume the one-shot dashboard handoff before manager startup so `-a claude` and launch cwd are honored
- skip the manager restart when the handoff backend equals the one already running, so re-typing `omar -a <same-backend>` doesn't throw away the EA's in-memory conversation
- make the opencode e2e UI marker tolerant of opencode's update modal while preserving the wizard-regression assertion

## Tests
- `cargo fmt --check`
- `cargo test dashboard_launch_handoff --bin omar` (4 tests: serde round-trip, runtime apply, no-op-preserves-manager, real-swap-kills-manager)
- `cargo test test_manager_notes_shell_write_persists_across_ea_restart --test integration_test`
- `bash -n tests/ci/opencode_binary_tree.sh`
- `OMAR_OPENCODE_E2E=1 OMAR_BIN=target/debug/omar tests/ci/opencode_binary_tree.sh`

## CI

Added `tests/ci/dashboard_relaunch_handoff.sh` and a matching GHA job (`dashboard-relaunch-handoff-integration`) wired into the all-pass aggregator. The unit tests cover serde round-trip, the App-side apply, and the no-op-restart guard with a real tmux server; this end-to-end script runs the real `omar` binary against a fake "already running" dashboard tmux session in an isolated `$HOME` and inspects the resulting `~/.omar/dashboard_handoff.json`. Three cases:

- `omar -a claude` from a new cwd → handoff carries the new cwd, the claude backend command, and `restart_manager=true`.
- bare `omar` from a new cwd → handoff carries the cwd, `restart_manager=false` so the live manager isn't kicked.
- no existing dashboard → `relaunch_in_tmux` must not write the handoff (it only saves it inside the `has_session` branch).

The writer runs `save_dashboard_launch_handoff` before `tmux attach-session`, so attach failing in a non-interactive subshell doesn't matter — the file lands on disk first and we read it from there. Verified the script fails closed against an `origin/main` binary that lacks the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)