### PR TITLE
[codex] Add Antigravity backend and reset quit cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Other features include messaging systems integration (e.g., Slack), computer use
 - tmux 3.0+
 - Rust 1.70+
 - GNU Make
-- One or more coding agents: [Claude](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [Codex](https://developers.openai.com/codex/cli), [Cursor](https://cursor.com/cli), [Gemini](https://geminicli.com), [Opencode](https://github.com/anomalyco/opencode)
+- One or more coding agents: [Claude](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [Codex](https://developers.openai.com/codex/cli), [Cursor](https://cursor.com/cli), [Opencode](https://github.com/anomalyco/opencode), or Google Antigravity CLI (`agy`)
 
 ### One-liner (recommended)
 
@@ -96,8 +96,16 @@ Shutdown the test project and its agents.
 | [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) | `omar -a claude` (default) |
 | [Codex CLI](https://developers.openai.com/codex/cli) | `omar -a codex` |
 | [Cursor CLI](https://cursor.com/cli) | `omar -a cursor` |
-| [Gemini CLI](https://geminicli.com) | `omar -a gemini` |
 | [Opencode](https://github.com/anomalyco/opencode) | `omar -a opencode` |
+| Google Antigravity CLI (`agy`) | `omar -a antigravity` |
+
+Antigravity CLI must be installed and authenticated separately. OMAR does not
+run the installer automatically; install `agy` with Google's installer and log
+in before launching `omar -a antigravity`. OMAR launches it with
+`--dangerously-skip-permissions`, the CLI's YOLO-style permission mode, and
+registers an EA-scoped OMAR MCP server in
+`~/.gemini/antigravity-cli/mcp_config.json`. OMAR creates that file when it
+does not already exist.
 
 When spawning Codex workers through OMAR's MCP `spawn_agent` tool, pass
 `backend: "codex"`, optional `model` (for example `gpt-5.5`), and optional

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,8 +22,10 @@ pub type SharedApp = App;
 pub enum ConfirmAction {
     /// Kill the selected agent
     Kill,
-    /// Quit the dashboard while leaving EA sessions and persisted state intact.
+    /// Quit the dashboard while leaving persisted state intact.
     Quit,
+    /// Quit and reset persisted OMAR runtime state.
+    ResetQuit,
     /// Delete the currently active EA (blocked only if it is the last one)
     DeleteEa,
 }
@@ -88,6 +90,7 @@ pub struct App {
     pub selected: usize,
     pub manager_selected: bool,
     pub should_quit: bool,
+    pub reset_on_quit: bool,
     pub show_help: bool,
     pub pending_confirm: Option<ConfirmAction>,
     pub filter: String,
@@ -186,6 +189,7 @@ impl App {
             selected: 0,
             manager_selected: true,
             should_quit: false,
+            reset_on_quit: false,
             show_help: false,
             pending_confirm: None,
             filter: String::new(),
@@ -585,7 +589,7 @@ impl App {
         };
 
         // For backends whose manager prompt is now loaded from an auto-
-        // discovered file (codex `AGENTS.md`, gemini `GEMINI.md`, opencode
+        // discovered file (codex `AGENTS.md`, antigravity shared MCP config, opencode
         // `AGENTS.md`), build_ea_command returns the workspace dir we must
         // launch in. Fall back to the user's workdir for claude/cursor.
         let launch_cwd = workspace_cwd
@@ -2055,7 +2059,7 @@ mod tests {
         let scheduler = Arc::new(Scheduler::new());
         let mut app = App::new(&config, TickerBuffer::new(), scheduler);
 
-        let mut commands: Vec<String> = ["claude", "codex", "cursor", "gemini", "opencode"]
+        let mut commands: Vec<String> = ["claude", "codex", "cursor", "opencode", "antigravity"]
             .iter()
             .map(|name| crate::config::resolve_backend(name).unwrap())
             .collect();

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,8 +148,8 @@ fn detect_agent_command() -> String {
             "codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox",
         ),
         ("cursor", "cursor agent --yolo"),
-        ("gemini", "gemini --yolo"),
         ("opencode", "opencode"),
+        ("agy", "agy --dangerously-skip-permissions"),
     ])
     .unwrap_or_else(|| "claude --dangerously-skip-permissions".to_string())
 }
@@ -170,8 +170,8 @@ fn default_command() -> String {
 /// - `"claude"` → `"claude --dangerously-skip-permissions"`
 /// - `"codex"` → `"codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox"`
 /// - `"cursor"` → `"cursor agent --yolo"`
-/// - `"gemini"` → `"gemini --yolo"`
 /// - `"opencode"` → `"opencode"` (opencode has no permission-skip flag)
+/// - `"antigravity"` → `"agy --dangerously-skip-permissions"`
 /// - anything else → error
 pub fn resolve_backend(name: &str) -> Result<String, String> {
     match name {
@@ -180,10 +180,10 @@ pub fn resolve_backend(name: &str) -> Result<String, String> {
             Ok("codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox".to_string())
         }
         "cursor" => Ok("cursor agent --yolo".to_string()),
-        "gemini" => Ok("gemini --yolo".to_string()),
         "opencode" => Ok("opencode".to_string()),
+        "antigravity" => Ok("agy --dangerously-skip-permissions".to_string()),
         other => Err(format!(
-            "Unknown backend '{}'. Supported: claude, codex, cursor, gemini, opencode",
+            "Unknown backend '{}'. Supported: claude, codex, cursor, opencode, antigravity",
             other
         )),
     }
@@ -484,8 +484,8 @@ sidebar_right = false
             cmd.contains("claude")
                 || cmd.contains("codex")
                 || cmd.contains("cursor")
-                || cmd.contains("gemini")
-                || cmd.contains("opencode"),
+                || cmd.contains("opencode")
+                || cmd.contains("agy"),
             "Unexpected default command: {}",
             cmd
         );
@@ -520,6 +520,27 @@ sidebar_right = false
             start.elapsed() < Duration::from_secs(2),
             "hanging probe should be skipped after the bounded timeout"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_detect_agent_command_can_select_antigravity() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let agy = temp.path().join("agy");
+        fs::write(&agy, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = fs::metadata(&agy).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&agy, perms).unwrap();
+
+        let cmd = detect_agent_command_from(&[(
+            agy.to_str().unwrap(),
+            "agy --dangerously-skip-permissions",
+        )]);
+
+        assert_eq!(cmd.as_deref(), Some("agy --dangerously-skip-permissions"));
     }
 
     #[test]
@@ -576,8 +597,11 @@ session_prefix = "omar-agent"
             "codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox"
         );
         assert_eq!(resolve_backend("cursor").unwrap(), "cursor agent --yolo");
-        assert_eq!(resolve_backend("gemini").unwrap(), "gemini --yolo");
         assert_eq!(resolve_backend("opencode").unwrap(), "opencode");
+        assert_eq!(
+            resolve_backend("antigravity").unwrap(),
+            "agy --dangerously-skip-permissions"
+        );
     }
 
     #[test]

--- a/src/ea.rs
+++ b/src/ea.rs
@@ -261,16 +261,6 @@ pub fn unregister_ea(base_dir: &Path, ea_id: EaId) -> anyhow::Result<()> {
     save_registry(base_dir, &eas)
 }
 
-/// Compact the ID counter on clean quit.
-/// Resets ea_next_id to max(registered_ids) so the next session starts
-/// numbering from a compact point rather than the old high-water mark.
-/// Safe to call only on graceful exit — not during crash recovery.
-pub fn compact_id_counter(base_dir: &Path) -> anyhow::Result<()> {
-    let eas = load_registry(base_dir);
-    let max_id = eas.iter().map(|e| e.id).max().unwrap_or(0);
-    save_next_id_counter(base_dir, max_id)
-}
-
 fn save_registry(base_dir: &Path, eas: &[EaInfo]) -> anyhow::Result<()> {
     let path = base_dir.join("eas.json");
     fs::create_dir_all(base_dir).ok();
@@ -573,25 +563,6 @@ mod tests {
         // Create another — should get ID 4, NOT 1 or 2
         let id4 = register_ea(dir.path(), "Delta", None).unwrap();
         assert_eq!(id4, 4, "ID should be 4 (monotonic), not a reused ID");
-    }
-
-    #[test]
-    fn test_compact_id_counter() {
-        let dir = tempfile::tempdir().unwrap();
-        // Create EAs 1, 2, 3; delete 2 and 3
-        let _id1 = register_ea(dir.path(), "Alpha", None).unwrap();
-        let id2 = register_ea(dir.path(), "Beta", None).unwrap();
-        let id3 = register_ea(dir.path(), "Gamma", None).unwrap();
-        unregister_ea(dir.path(), id2).unwrap();
-        unregister_ea(dir.path(), id3).unwrap();
-        // Counter is at 3 (high-water mark)
-        assert_eq!(load_next_id_counter(dir.path()), 3);
-        // Compact: counter should drop to max registered (which is 1)
-        compact_id_counter(dir.path()).unwrap();
-        assert_eq!(load_next_id_counter(dir.path()), 1);
-        // Next register should get ID 2, not 4
-        let id_next = register_ea(dir.path(), "Delta", None).unwrap();
-        assert_eq!(id_next, 2);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ struct Cli {
     #[arg(short, long)]
     config: Option<String>,
 
-    /// Agent backend to use: claude, codex, cursor, gemini, opencode
+    /// Agent backend to use: claude, codex, cursor, opencode, antigravity
     #[arg(short, long)]
     agent: Option<String>,
 
@@ -1045,6 +1045,11 @@ async fn run_dashboard(config: Config) -> Result<()> {
                                     }
                                 }
                                 app::ConfirmAction::Quit => {
+                                    app.reset_on_quit = false;
+                                    app.should_quit = true;
+                                }
+                                app::ConfirmAction::ResetQuit => {
+                                    app.reset_on_quit = true;
                                     app.should_quit = true;
                                 }
                                 app::ConfirmAction::DeleteEa => {
@@ -1172,7 +1177,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
                     // Normal key handling
                     match key.code {
                         KeyCode::Char('Q') => {
-                            app.pending_confirm = Some(app::ConfirmAction::Quit);
+                            app.pending_confirm = Some(app::ConfirmAction::ResetQuit);
                         }
                         KeyCode::Esc => {
                             app.drill_up();
@@ -1220,9 +1225,6 @@ async fn run_dashboard(config: Config) -> Result<()> {
                         }
                         KeyCode::Char('[') => {
                             app.cycle_previous_ea();
-                        }
-                        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.pending_confirm = Some(app::ConfirmAction::Quit);
                         }
                         KeyCode::Char('j') | KeyCode::Down => {
                             if app.sidebar_focused {
@@ -1473,17 +1475,9 @@ async fn run_dashboard(config: Config) -> Result<()> {
         // Check quit flag
         let should_quit = {
             let app = shared_app.lock().await;
-            if app.should_quit {
-                Some(app.omar_dir.clone())
-            } else {
-                None
-            }
+            app.should_quit
         };
-        if let Some(omar_dir) = should_quit {
-            // Compact EA ID counter on clean quit so next session starts from a compact point
-            if let Err(e) = ea::compact_id_counter(&omar_dir) {
-                eprintln!("compact_id_counter failed: {}", e);
-            }
+        if should_quit {
             break;
         }
     }
@@ -1521,7 +1515,128 @@ async fn run_dashboard(config: Config) -> Result<()> {
         kill_child_gracefully(child, Duration::from_secs(3));
     }
 
+    let reset_on_quit = {
+        let app = shared_app.lock().await;
+        app.reset_on_quit
+    };
+    if reset_on_quit {
+        purge_persisted_runtime_state_on_quit(&omar_dir)?;
+    }
+
     Ok(())
+}
+
+fn purge_persisted_runtime_state_on_quit(omar_dir: &std::path::Path) -> Result<()> {
+    let archive_timestamp = now_ns();
+    archive_action_logs(omar_dir, archive_timestamp)?;
+    archive_manager_notes(omar_dir, archive_timestamp)?;
+
+    for file in [
+        "active_ea",
+        "ea_next_id",
+        "eas.json",
+        "eas.json.tmp",
+        "scheduled_events.json",
+        "scheduled_events.lock",
+        "scheduled_events.tmp",
+    ] {
+        remove_file_if_exists(omar_dir.join(file))?;
+    }
+
+    remove_dir_if_exists(omar_dir.join("ea"))?;
+    remove_dir_if_exists(omar_dir.join("mcp"))?;
+
+    Ok(())
+}
+
+fn archive_action_logs(omar_dir: &std::path::Path, archive_timestamp: u64) -> Result<()> {
+    let ea_dir = omar_dir.join("ea");
+    let Ok(entries) = std::fs::read_dir(&ea_dir) else {
+        return Ok(());
+    };
+
+    let archive_dir = omar_dir.join("logs").join("action_logs");
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let action_log = path.join("action_log.jsonl");
+        if !action_log.exists() {
+            continue;
+        }
+
+        std::fs::create_dir_all(&archive_dir)?;
+        let ea_id = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("unknown");
+        let archive_path = unique_archive_path(
+            &archive_dir,
+            &format!("ea-{}-{}", ea_id, archive_timestamp),
+            "jsonl",
+        );
+        std::fs::rename(action_log, archive_path)?;
+    }
+
+    Ok(())
+}
+
+fn archive_manager_notes(omar_dir: &std::path::Path, archive_timestamp: u64) -> Result<()> {
+    let Ok(entries) = std::fs::read_dir(omar_dir) else {
+        return Ok(());
+    };
+
+    let archive_dir = omar_dir.join("logs").join("manager_notes");
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !file_name.starts_with("manager_notes_ea") || !file_name.ends_with(".md") {
+            continue;
+        }
+
+        std::fs::create_dir_all(&archive_dir)?;
+        let stem = file_name.strip_suffix(".md").unwrap_or(file_name);
+        let archive_path = unique_archive_path(
+            &archive_dir,
+            &format!("{}-{}", stem, archive_timestamp),
+            "md",
+        );
+        std::fs::rename(path, archive_path)?;
+    }
+
+    Ok(())
+}
+
+fn unique_archive_path(dir: &std::path::Path, stem: &str, extension: &str) -> PathBuf {
+    let mut path = dir.join(format!("{}.{}", stem, extension));
+    let mut suffix = 1;
+    while path.exists() {
+        path = dir.join(format!("{}-{}.{}", stem, suffix, extension));
+        suffix += 1;
+    }
+    path
+}
+
+fn remove_file_if_exists(path: PathBuf) -> Result<()> {
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn remove_dir_if_exists(path: PathBuf) -> Result<()> {
+    match std::fs::remove_dir_all(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
 }
 
 #[cfg(test)]
@@ -1548,6 +1663,59 @@ mod tests {
             "extended-keys must be `on`, not `{}` — `always` breaks Shift+Tab \
              in the dashboard (see tests comment)",
             value
+        );
+    }
+
+    #[test]
+    fn purge_persisted_runtime_state_archives_logs_and_notes() {
+        let dir = tempfile::tempdir().unwrap();
+        let omar_dir = dir.path();
+        std::fs::create_dir_all(omar_dir.join("ea/7/status")).unwrap();
+        std::fs::create_dir_all(omar_dir.join("mcp/ea-7")).unwrap();
+        std::fs::create_dir_all(omar_dir.join("slack_outbox")).unwrap();
+        std::fs::create_dir_all(omar_dir.join("logs/panics")).unwrap();
+        std::fs::write(omar_dir.join("config.toml"), "[dashboard]\n").unwrap();
+        std::fs::write(omar_dir.join("slack_outbox/keep"), "queued").unwrap();
+        std::fs::write(omar_dir.join("logs/panics/panic.log"), "panic").unwrap();
+        std::fs::write(omar_dir.join("eas.json"), "[]").unwrap();
+        std::fs::write(omar_dir.join("active_ea"), "7").unwrap();
+        std::fs::write(omar_dir.join("ea_next_id"), "7").unwrap();
+        std::fs::write(omar_dir.join("scheduled_events.json"), "[]").unwrap();
+        std::fs::write(omar_dir.join("ea/7/tasks.md"), "- [1] stale\n").unwrap();
+        std::fs::write(omar_dir.join("ea/7/action_log.jsonl"), "action log\n").unwrap();
+        std::fs::write(omar_dir.join("manager_notes_ea7.md"), "manager notes\n").unwrap();
+
+        purge_persisted_runtime_state_on_quit(omar_dir).unwrap();
+
+        assert!(omar_dir.join("config.toml").exists());
+        assert!(omar_dir.join("slack_outbox/keep").exists());
+        assert!(omar_dir.join("logs/panics/panic.log").exists());
+        assert!(!omar_dir.join("eas.json").exists());
+        assert!(!omar_dir.join("active_ea").exists());
+        assert!(!omar_dir.join("ea_next_id").exists());
+        assert!(!omar_dir.join("scheduled_events.json").exists());
+        assert!(!omar_dir.join("ea").exists());
+        assert!(!omar_dir.join("mcp").exists());
+        assert!(!omar_dir.join("manager_notes_ea7.md").exists());
+
+        let action_logs: Vec<_> = std::fs::read_dir(omar_dir.join("logs/action_logs"))
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        assert_eq!(action_logs.len(), 1);
+        assert_eq!(
+            std::fs::read_to_string(&action_logs[0]).unwrap(),
+            "action log\n"
+        );
+
+        let manager_notes: Vec<_> = std::fs::read_dir(omar_dir.join("logs/manager_notes"))
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        assert_eq!(manager_notes.len(), 1);
+        assert_eq!(
+            std::fs::read_to_string(&manager_notes[0]).unwrap(),
+            "manager notes\n"
         );
     }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -5,6 +5,8 @@ pub mod protocol;
 use anyhow::Result;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
@@ -121,22 +123,28 @@ fn current_tmux_server() -> Option<String> {
         .filter(|server| !server.is_empty())
 }
 
+#[cfg(test)]
+fn global_home_env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackendKind {
+    Antigravity,
     Claude,
     Codex,
     Cursor,
-    Gemini,
     Opencode,
 }
 
 impl BackendKind {
     fn canonical_name(self) -> &'static str {
         match self {
+            BackendKind::Antigravity => "antigravity",
             BackendKind::Claude => "claude",
             BackendKind::Codex => "codex",
             BackendKind::Cursor => "cursor",
-            BackendKind::Gemini => "gemini",
             BackendKind::Opencode => "opencode",
         }
     }
@@ -150,10 +158,10 @@ fn detect_backend_token(token: &str) -> Option<BackendKind> {
         .unwrap_or(token);
 
     match executable {
+        "agy" => Some(BackendKind::Antigravity),
         "claude" => Some(BackendKind::Claude),
         "codex" => Some(BackendKind::Codex),
         "cursor" => Some(BackendKind::Cursor),
-        "gemini" => Some(BackendKind::Gemini),
         "opencode" => Some(BackendKind::Opencode),
         _ => None,
     }
@@ -187,20 +195,6 @@ fn ensure_codex_runtime_flags(base_command: &str) -> String {
     }
 
     command
-}
-
-fn backend_token(base_command: &str, kind: BackendKind) -> Option<String> {
-    base_command.split_whitespace().find_map(|token| {
-        if detect_backend_token(token) == Some(kind) {
-            Some(
-                token
-                    .trim_matches(|c| matches!(c, '"' | '\'' | '(' | ')'))
-                    .to_string(),
-            )
-        } else {
-            None
-        }
-    })
 }
 
 fn materialize_prompt_file(prompt_file: &Path, substitutions: &[(&str, &str)]) -> PathBuf {
@@ -341,49 +335,6 @@ fn codex_mcp_overrides(context: &McpLaunchContext) -> Option<String> {
     ))
 }
 
-fn materialize_gemini_deny_policy(context: &McpLaunchContext) -> Option<PathBuf> {
-    let dir = mcp_ea_dir(context)?;
-    let path = dir.join("gemini-deny-native-tools.toml");
-    let mut policy = String::new();
-    let entries = BACKEND_NATIVE_WAKE_TOOLS
-        .iter()
-        .map(|t| (*t, "Use the OMAR MCP tool schedule_omar_event instead."))
-        .chain(
-            BACKEND_NATIVE_AGENT_TOOLS
-                .iter()
-                .map(|t| (*t, "Use the OMAR MCP tool spawn_agent instead.")),
-        );
-    for (tool, message) in entries {
-        policy.push_str(&format!(
-            r#"[[rule]]
-toolName = "{tool}"
-decision = "deny"
-priority = 999
-denyMessage = "{message}"
-
-"#
-        ));
-    }
-    write_private_file(&path, policy.as_bytes()).ok()?;
-    Some(path)
-}
-
-fn gemini_mcp_bootstrap(base_command: &str, context: &McpLaunchContext) -> Option<String> {
-    let server_exe = std::env::current_exe().ok()?;
-    let context_file = materialize_mcp_context_file(context)?;
-    let gemini_exec =
-        backend_token(base_command, BackendKind::Gemini).unwrap_or_else(|| "gemini".to_string());
-    let server_exe = shell_single_quote(&server_exe.display().to_string());
-    let context_file = shell_single_quote(&context_file.display().to_string());
-    Some(format!(
-        "({gemini} mcp remove omar >/dev/null 2>&1 || true; \
-         {gemini} mcp add -s user omar {server} mcp-server --context-file {context} >/dev/null 2>&1 || true)",
-        gemini = gemini_exec,
-        server = server_exe,
-        context = context_file
-    ))
-}
-
 fn opencode_config_env(context: &McpLaunchContext) -> Option<String> {
     let server_exe = std::env::current_exe().ok()?;
     let context_file = materialize_mcp_context_file(context)?;
@@ -508,6 +459,83 @@ fn ensure_cursor_mcp_config(context: &McpLaunchContext) -> Option<()> {
     Some(())
 }
 
+fn ensure_antigravity_mcp_config(context: &McpLaunchContext) -> Option<()> {
+    // Antigravity CLI discovers global MCP servers from its own sparse config.
+    // Keep OMAR's entry EA-scoped and preserve all user servers.
+    let server_exe = std::env::current_exe().ok()?;
+    let context_file = materialize_mcp_context_file(context)?;
+    let home = std::env::var("HOME").ok()?;
+    let config_dir = PathBuf::from(home).join(".gemini").join("antigravity-cli");
+    std::fs::create_dir_all(&config_dir).ok()?;
+    let path = config_dir.join("mcp_config.json");
+
+    let mut root = match std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+    {
+        Some(v) if v.is_object() => v,
+        _ => serde_json::json!({}),
+    };
+
+    if !root
+        .get("mcpServers")
+        .map(|v| v.is_object())
+        .unwrap_or(false)
+    {
+        root["mcpServers"] = serde_json::json!({});
+    }
+
+    if let Some(servers) = root["mcpServers"].as_object_mut() {
+        let stale_keys: Vec<String> = servers
+            .iter()
+            .filter_map(|(k, v)| {
+                if k.starts_with("omar-ea-") {
+                    let ctx_path = v
+                        .get("args")
+                        .and_then(|a| a.as_array())
+                        .and_then(|a| a.last())
+                        .and_then(|p| p.as_str())
+                        .map(PathBuf::from);
+                    if let Some(p) = ctx_path {
+                        if !p.exists() {
+                            return Some(k.clone());
+                        }
+                    }
+                }
+                None
+            })
+            .collect();
+        for k in stale_keys {
+            servers.remove(&k);
+        }
+    }
+
+    let key = format!("omar-ea-{}", context.ea_id);
+    root["mcpServers"][&key] = serde_json::json!({
+        "command": server_exe.display().to_string(),
+        "args": ["mcp-server", "--context-file", context_file.display().to_string()],
+    });
+
+    if let Ok(entries) = std::fs::read_dir(&config_dir) {
+        for entry in entries.flatten() {
+            if let Some(name) = entry.file_name().to_str() {
+                if name.starts_with("mcp_config.json.omar-") && name.ends_with(".tmp") {
+                    let _ = std::fs::remove_file(entry.path());
+                }
+            }
+        }
+    }
+
+    let payload = serde_json::to_vec_pretty(&root).ok()?;
+    let tmp = config_dir.join(format!("mcp_config.json.omar-{}.tmp", Uuid::new_v4()));
+    std::fs::write(&tmp, &payload).ok()?;
+    if std::fs::rename(&tmp, &path).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        return None;
+    }
+    Some(())
+}
+
 /// Build a CLI command with system prompt loaded from a file via native flag.
 ///
 /// - `prompt_file`: absolute path to the prompt .md file
@@ -517,7 +545,8 @@ fn ensure_cursor_mcp_config(context: &McpLaunchContext) -> Option<()> {
 ///   - claude  → `--system-prompt "$(cat '<path>')"` plus native wake-tool denylist
 ///   - codex   → `-c "developer_instructions='''$(cat '<path>')'''"` plus scheduled-task disable
 ///   - cursor  → positional arg `"Load the <path> file and follow the instructions."`
-///   - gemini  → `-i "$(cat '<path>')"` plus native wake-tool deny policy
+///   - antigravity → `-i "$(cat '<path>')"` with an EA-scoped MCP entry in
+///     `~/.gemini/antigravity-cli/mcp_config.json`
 ///   - opencode → MCP env only (no `--prompt`); the agent prompt is delivered
 ///     after spawn via tmux because opencode's `--prompt` is treated as the
 ///     first **user** message (not system role) and the LLM responds by
@@ -549,6 +578,10 @@ pub fn build_agent_command(
     // session can still come up and the human operator sees the problem
     // via a degraded but visible agent, rather than a launch failure.
     match detect_backend(&base_command) {
+        Some(BackendKind::Antigravity) => {
+            let _ = ensure_antigravity_mcp_config(mcp_context);
+            format!("TERM=xterm-256color {} -i \"{}\"", base_command, shell_expr)
+        }
         Some(BackendKind::Claude) => match materialize_claude_mcp_config(mcp_context) {
             Some(mcp_config) => format!(
                 "{} --system-prompt \"{}\" --mcp-config {} --disallowedTools {}",
@@ -582,23 +615,6 @@ pub fn build_agent_command(
                 rendered.display()
             )
         }
-        Some(BackendKind::Gemini) => {
-            let mut cmd = format!(
-                "TERM=xterm-256color {} --allowed-mcp-server-names omar -i \"{}\"",
-                base_command, shell_expr
-            );
-            if let Some(policy) = materialize_gemini_deny_policy(mcp_context) {
-                cmd = format!(
-                    "{} --policy {}",
-                    cmd,
-                    shell_single_quote(&policy.display().to_string())
-                );
-            }
-            if let Some(setup) = gemini_mcp_bootstrap(&base_command, mcp_context) {
-                cmd = format!("{}; {}", setup, cmd);
-            }
-            cmd
-        }
         Some(BackendKind::Opencode) => {
             // opencode has no `--system-prompt`; `--prompt` is treated as the
             // first user message, which makes the LLM read agent.md
@@ -630,13 +646,12 @@ pub fn build_agent_command(
 ///
 /// 1. **claude** uses the native `--system-prompt-file <path>` flag, so
 ///    the prompt never touches argv at all and is unbounded.
-/// 2. **codex / gemini / opencode** keep the legacy inline shell-expansion
-///    path because their auto-loaded prompt files (`AGENTS.md` /
-///    `GEMINI.md`) are anchored at the agent's *working root*, not at the
-///    process cwd. Setting cwd = a per-EA workspace dir would either
-///    silently load the wrong `AGENTS.md` (the one at the user's working
-///    root) or force the manager to operate in a dir that isn't the
-///    user's project. A bounded truncation cap in `memory.rs`
+/// 2. **codex / antigravity / opencode** keep the legacy inline shell-expansion
+///    path because their auto-loaded prompt/config files are anchored at the
+///    agent's *working root*, not at the process cwd. Setting cwd = a per-EA
+///    workspace dir would either silently load the wrong project context (the
+///    one at the user's working root) or force the manager to operate in a dir
+///    that isn't the user's project. A bounded truncation cap in `memory.rs`
 ///    (see `truncate_for_prompt`) keeps the inlined prompt comfortably
 ///    under `MAX_ARG_STRLEN`.
 ///
@@ -712,7 +727,7 @@ pub fn build_ea_command(
             (cmd, None)
         }
         _ => {
-            // Inline path for codex/gemini/opencode/cursor/unknown. The
+            // Inline path for codex/antigravity/opencode/cursor/unknown. The
             // truncation cap in memory.rs keeps the rendered prompt under
             // `MAX_ARG_STRLEN` even when notes/memory grow large.
             let cmd = build_agent_command(
@@ -750,7 +765,7 @@ pub fn start_manager(
     }
 
     // Build command with EA system prompt + memory baked in. For backends
-    // whose prompt is now loaded from a workspace file (codex/gemini/opencode)
+    // whose prompt is now loaded from a workspace file (codex/antigravity/opencode)
     // the build also returns the cwd that backend must be launched in for
     // auto-discovery to work.
     let (cmd, workspace_cwd) = build_ea_command(
@@ -1168,6 +1183,28 @@ mod tests {
         }
     }
 
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &Path) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.as_ref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn embedded_prompts_forbid_backend_native_wake_tools() {
         for prompt in [PROMPT_EA, PROMPT_AGENT] {
@@ -1270,30 +1307,32 @@ mod tests {
     }
 
     #[test]
-    fn test_build_agent_command_gemini() {
+    fn test_build_agent_command_antigravity() {
+        let _env_lock = global_home_env_lock();
         let dir = tempfile::tempdir().unwrap();
+        let _home = EnvVarGuard::set("HOME", dir.path());
         let cmd = build_agent_command(
-            "gemini --yolo",
+            "agy --dangerously-skip-permissions",
             Path::new("/tmp/prompts/ea.md"),
             &[],
             &test_mcp_context(dir.path()),
         );
-        assert!(cmd.contains("gemini mcp remove omar"));
-        assert!(cmd.contains("gemini mcp add -s user omar"));
-        assert!(cmd.contains("mcp-server --context-file"));
-        assert!(cmd.contains("--policy"));
         assert!(cmd.contains(
-            "TERM=xterm-256color gemini --yolo --allowed-mcp-server-names omar -i \"$(cat '/tmp/prompts/ea.md')\""
+            "TERM=xterm-256color agy --dangerously-skip-permissions -i \"$(cat '/tmp/prompts/ea.md')\""
         ));
-        let policy = dir.path().join("mcp/ea-0/gemini-deny-native-tools.toml");
-        let policy = std::fs::read_to_string(policy).unwrap();
-        // Wake/timer overlap rules.
-        assert!(policy.contains("toolName = \"ScheduleWakeup\""));
-        assert!(policy.contains("Use the OMAR MCP tool schedule_omar_event instead."));
-        // Subagent-dispatcher overlap rules.
-        assert!(policy.contains("toolName = \"Task\""));
-        assert!(policy.contains("Use the OMAR MCP tool spawn_agent instead."));
-        assert!(policy.contains("decision = \"deny\""));
+        let config = dir.path().join(".gemini/antigravity-cli/mcp_config.json");
+        let config = std::fs::read_to_string(config).unwrap();
+        assert!(config.contains("\"omar-ea-0\""));
+        assert!(config.contains("\"mcp-server\""));
+        assert!(config.contains("\"--context-file\""));
+        assert!(
+            !cmd.contains("--allowed-mcp-server-names"),
+            "agy does not advertise MCP config CLI flags"
+        );
+        assert!(
+            !cmd.contains("--policy"),
+            "agy does not advertise policy CLI flags"
+        );
     }
 
     #[test]
@@ -1347,8 +1386,8 @@ mod tests {
         for backend in [
             "claude",
             "codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox",
-            "gemini --yolo",
             "opencode",
+            "agy --dangerously-skip-permissions",
         ] {
             let dir = tempfile::tempdir().unwrap();
             let omar_dir = dir.path();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -218,7 +218,7 @@ fn infer_backend_name(explicit_backend: Option<&str>, command: &str) -> String {
         match s.trim().to_ascii_lowercase().as_str() {
             "codex" => Some("codex"),
             "cursor" => Some("cursor"),
-            "gemini" => Some("gemini"),
+            "antigravity" | "agy" => Some("antigravity"),
             "claude" | "claude-code" | "claude_code" => Some("claude"),
             "opencode" => Some("opencode"),
             _ => None,
@@ -736,7 +736,7 @@ impl OmarMcpServer {
     }
 
     fn list_backends(&self) -> Result<Value> {
-        let backends = ["claude", "codex", "cursor", "gemini", "opencode"];
+        let backends = ["claude", "codex", "cursor", "opencode", "antigravity"];
         let infos: Vec<Value> = backends
             .iter()
             .filter_map(|name| {
@@ -881,8 +881,8 @@ impl OmarMcpServer {
             fs::remove_file(&notes_path)
                 .map_err(|e| anyhow!("Failed to remove notes {:?}: {}", notes_path, e))?;
         }
-        // Per-EA MCP scratch dir (context.json, claude-mcp.json,
-        // gemini-deny-native-tools.toml). These were silently leaking on
+        // Per-EA MCP scratch dir (context.json, claude-mcp.json, backend
+        // policy/config files). These were silently leaking on
         // EA delete before and could grow unbounded across re-creates.
         let mcp_dir = self
             .context
@@ -2118,7 +2118,7 @@ fn tool_definitions() -> Vec<Value> {
                     "project_id":{"type":"integer","description":"Existing project id from add_project or list_projects. Required — spawn_agent does not auto-create projects."},
                     "task":{"type":"string","description":"Delivered to the agent as their initial task and shown in the dashboard. What to build or do — no [TASK COMPLETE] or parent-wakeup instructions; those are already in every agent's system prompt."},
                     "command":{"type":"string","description":"Raw command to run instead of a backend agent (e.g. 'bash' for a demo window). Mutually exclusive with backend."},
-                    "backend":{"type":"string","enum":["claude","codex","cursor","opencode","gemini"],"description":"Backend agent command to launch. Mutually exclusive with command."},
+                    "backend":{"type":"string","enum":["claude","codex","cursor","opencode","antigravity"],"description":"Backend agent command to launch. Mutually exclusive with command."},
                     "model":{"type":"string","description":"Optional backend model override. Allowed characters are alphanumeric plus '-', '_', '.', '/'."},
                     "reasoning_effort":{"type":"string","enum":["low","medium","high","xhigh"],"description":"Optional Codex reasoning effort override. Supported only with backend='codex'; appends a Codex config override such as -c model_reasoning_effort='\"high\"'."},
                     "workdir":{"type":"string","description":"Working directory for the new session. Defaults to this MCP server's launch workdir."},
@@ -2449,6 +2449,32 @@ mod tests {
             err.to_string().contains("backend='codex'"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn infer_backend_name_recognizes_antigravity() {
+        assert_eq!(
+            infer_backend_name(Some("antigravity"), "ignored"),
+            "antigravity"
+        );
+        assert_eq!(
+            infer_backend_name(None, "env FOO=bar agy --dangerously-skip-permissions"),
+            "antigravity"
+        );
+    }
+
+    #[test]
+    fn list_backends_includes_antigravity() {
+        let server = OmarMcpServer::new(test_context());
+        let response = server.list_backends().unwrap();
+        let backends = response["backends"].as_array().unwrap();
+        let antigravity = backends
+            .iter()
+            .find(|backend| backend["name"].as_str() == Some("antigravity"))
+            .expect("antigravity backend entry");
+
+        assert_eq!(antigravity["command"], "agy --dangerously-skip-permissions");
+        assert!(antigravity["available"].is_boolean());
     }
 
     #[test]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -180,8 +180,8 @@ pub fn load_memory_from(state_dir: &Path) -> String {
 // the EA prompt template (~5 KB) and framing ≈ 117 KB worst case. That
 // leaves ~11 KB headroom under the 128 KB MAX_ARG_STRLEN limit for the
 // surrounding shell expansion (`developer_instructions='''…'''`,
-// `--system-prompt "…"`, etc.) used by codex / gemini / opencode managers
-// and by every worker spawn. The EA prompt teaches managers to keep notes
+// `--system-prompt "…"`, etc.) used by codex / antigravity / opencode
+// managers and by every worker spawn. The EA prompt teaches managers to keep notes
 // well under this hard cap (soft target 16 KB), so truncation should be
 // a rare safety backstop rather than a routine occurrence.
 const PROMPT_CONTEXT_BYTE_CAP: usize = 56 * 1024;

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -551,7 +551,7 @@ fn get_pane_input(base_prefix: &str, receiver: &str, ea_id: ea::EaId) -> Option<
         ));
     }
 
-    if pane_capture.contains("Gemini CLI") {
+    if pane_capture.contains("Antigravity CLI") {
         return Some(extract_prefixed_input_from_capture(
             &pane_capture,
             "*",
@@ -1577,9 +1577,9 @@ mod tests {
     }
 
     #[test]
-    fn gemini_capture_extracts_typed_input_for_restore() {
+    fn antigravity_capture_extracts_typed_input_for_restore() {
         let capture = r#"
- ▝▜▄     Gemini CLI v0.40.1
+      ▄▀▀▄        Antigravity CLI 1.0.3
 
 ────────────────────────────────────────────────────────────────────────────────
  YOLO Ctrl+Y                                                      2 MCP servers

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -27,7 +27,10 @@ pub fn backend_readiness_markers(backend: &str) -> &'static [&'static str] {
     match backend {
         "codex" => &["OpenAI Codex"],
         "cursor" => &["Cursor Agent"],
-        "gemini" => &["Gemini CLI"],
+        // `agy` is not available in CI/local discovery here, so avoid
+        // overfitting to an unverified banner and let delivery use the
+        // existing stable-pane fallback.
+        "antigravity" => &[],
         "claude" => &["Claude Code", "❯"],
         "opencode" => &["tab agents", "ctrl+p commands"],
         _ => &[],

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1260,7 +1260,7 @@ fn render_help_popup(frame: &mut Frame) {
             Style::default().add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
-        Line::from("  Q           Quit"),
+        Line::from("  Q           Quit and reset runtime state"),
         Line::from("  ←/→, h/l   Switch panel (sidebar ↔ main)"),
         Line::from("  ↑/↓, j/k   Move selection up/down"),
         Line::from("  Tab         Drill into selected agent"),
@@ -1308,6 +1308,13 @@ fn render_confirm_dialog(frame: &mut Frame, app: &App, action: ConfirmAction) {
             (" Confirm ", "Kill this agent?", name, String::new(), 40)
         }
         ConfirmAction::Quit => (
+            " Confirm Quit ",
+            "Quit omar?",
+            "This will kill ALL EA sessions and agents.".to_string(),
+            "Persisted EA state, projects, notes, and events will be kept.".to_string(),
+            50,
+        ),
+        ConfirmAction::ResetQuit => (
             " Confirm Quit ",
             "Quit omar?",
             "This will kill ALL EA sessions and agents.".to_string(),

--- a/tests/ci/tmux_exit_behavior.sh
+++ b/tests/ci/tmux_exit_behavior.sh
@@ -38,6 +38,20 @@ session_prefix = "omar-agent-"
 default_command = "bash"
 default_workdir = "."
 EOF
+mkdir -p "$home_dir/.omar/ea/0/status" "$home_dir/.omar/mcp/ea-0" "$home_dir/.omar/slack_outbox" "$home_dir/.omar/logs/panics"
+cat >"$home_dir/.omar/eas.json" <<'EOF'
+[
+  {"id": 0, "name": "OldSessionName", "description": "old session", "created_at": 1}
+]
+EOF
+printf '0' >"$home_dir/.omar/active_ea"
+printf '0' >"$home_dir/.omar/ea_next_id"
+printf '[]' >"$home_dir/.omar/scheduled_events.json"
+printf '%s\n' '1. Keep project' >"$home_dir/.omar/ea/0/tasks.md"
+printf 'keep action log\n' >"$home_dir/.omar/ea/0/action_log.jsonl"
+printf 'keep manager notes\n' >"$home_dir/.omar/manager_notes_ea0.md"
+printf 'queued slack\n' >"$home_dir/.omar/slack_outbox/keep"
+printf 'panic log\n' >"$home_dir/.omar/logs/panics/keep.log"
 
 tmux_cmd() {
   HOME="$home_dir" OMAR_TMUX_SERVER="$server" tmux -L "$server" "$@"
@@ -62,7 +76,7 @@ tmux -L "$server" new-session -d -s omar-dashboard \
 wait_for_session omar-dashboard
 wait_for_session omar-agent-ea-0
 
-python3 - "$server" <<'PY'
+REPO_ROOT="$REPO_ROOT" OMAR_BIN="$OMAR_BIN" python3 - "$server" "$home_dir" <<'PY'
 import os
 import pty
 import signal
@@ -71,6 +85,7 @@ import sys
 import time
 
 server = sys.argv[1]
+home_dir = sys.argv[2]
 
 
 def tmux(*args):
@@ -79,6 +94,25 @@ def tmux(*args):
         text=True,
         capture_output=True,
     )
+
+
+def start_dashboard():
+    command = (
+        f"cd {sh_quote(os.environ['REPO_ROOT'])} && "
+        f"HOME={sh_quote(home_dir)} OMAR_TMUX_SERVER={sh_quote(server)} "
+        f"{sh_quote(os.environ['OMAR_BIN'])}"
+    )
+    result = tmux("new-session", "-d", "-s", "omar-dashboard", command)
+    if result.returncode != 0:
+        fail(f"Failed to restart dashboard: {result.stderr}")
+    if not wait_for(lambda: session_exists("omar-dashboard"), timeout=5.0):
+        fail("Dashboard session did not restart")
+    if not wait_for(lambda: session_exists("omar-agent-ea-0"), timeout=5.0):
+        fail("EA manager session did not restart")
+
+
+def sh_quote(value):
+    return "'" + value.replace("'", "'\"'\"'") + "'"
 
 
 def sessions():
@@ -182,8 +216,43 @@ def test_detach_key():
         wait_for_detached("omar-dashboard")
         if not session_exists("omar-dashboard"):
             fail("Dashboard session disappeared after detach; expected session to persist")
+        assert_runtime_state_present("z")
 
         print("PASS: z detaches without terminating dashboard session")
+    finally:
+        close_dashboard(pid, fd)
+
+
+def assert_runtime_state_present(label):
+    omar_dir = os.path.join(home_dir, ".omar")
+    expected = [
+        "eas.json",
+        "active_ea",
+        "ea_next_id",
+        "scheduled_events.json",
+        os.path.join("ea", "0", "tasks.md"),
+        os.path.join("ea", "0", "action_log.jsonl"),
+        "manager_notes_ea0.md",
+        "mcp",
+    ]
+    missing = [path for path in expected if not os.path.exists(os.path.join(omar_dir, path))]
+    if missing:
+        fail(f"{label} unexpectedly removed persisted runtime state: {missing}")
+
+
+def test_ctrl_c_is_ignored():
+    pid, fd = open_dashboard()
+    try:
+        wait_for_attached("omar-dashboard")
+        os.write(fd, b"\x03")
+        time.sleep(0.1)
+
+        if not session_exists("omar-dashboard"):
+            fail("Dashboard session terminated after Ctrl+C; expected Ctrl+C to be ignored")
+        if not session_exists("omar-agent-ea-0"):
+            fail("EA manager session disappeared after Ctrl+C; expected Ctrl+C to be ignored")
+        assert_runtime_state_present("Ctrl+C")
+        print("PASS: Ctrl+C is ignored")
     finally:
         close_dashboard(pid, fd)
 
@@ -202,11 +271,63 @@ def test_quit_key_kills_all_sessions():
         if has_prefix_session("omar-agent-"):
             fail("OMAR agent sessions still exist after Q+y; expected cleanup on quit")
 
+        omar_dir = os.path.join(home_dir, ".omar")
+        wiped_paths = [
+            "eas.json",
+            "active_ea",
+            "ea_next_id",
+            "scheduled_events.json",
+            "ea",
+            "mcp",
+            "manager_notes_ea0.md",
+        ]
+        leftovers = [path for path in wiped_paths if os.path.exists(os.path.join(omar_dir, path))]
+        if leftovers:
+            fail(f"Persisted runtime state survived Q+y: {leftovers}")
+
+        kept_paths = [
+            "config.toml",
+            os.path.join("slack_outbox", "keep"),
+            os.path.join("logs", "panics", "keep.log"),
+        ]
+        missing = [path for path in kept_paths if not os.path.exists(os.path.join(omar_dir, path))]
+        if missing:
+            fail(f"Expected preserved files missing after Q+y: {missing}")
+
+        action_log_dir = os.path.join(omar_dir, "logs", "action_logs")
+        action_logs = []
+        if os.path.isdir(action_log_dir):
+            action_logs = [
+                name
+                for name in os.listdir(action_log_dir)
+                if name.startswith("ea-0-") and name.endswith(".jsonl")
+            ]
+        if len(action_logs) != 1:
+            fail(f"Q+y did not archive exactly one action log: {action_logs}")
+        with open(os.path.join(action_log_dir, action_logs[0]), encoding="utf-8") as handle:
+            if handle.read() != "keep action log\n":
+                fail("Archived action log content did not match expected content")
+
+        notes_dir = os.path.join(omar_dir, "logs", "manager_notes")
+        notes = []
+        if os.path.isdir(notes_dir):
+            notes = [
+                name
+                for name in os.listdir(notes_dir)
+                if name.startswith("manager_notes_ea0-") and name.endswith(".md")
+            ]
+        if len(notes) != 1:
+            fail(f"Q+y did not archive exactly one manager notes file: {notes}")
+        with open(os.path.join(notes_dir, notes[0]), encoding="utf-8") as handle:
+            if handle.read() != "keep manager notes\n":
+                fail("Archived manager notes content did not match expected content")
+
         print("PASS: Q+y exits dashboard and kills OMAR sessions")
     finally:
         close_dashboard(pid, fd)
 
 
 test_detach_key()
+test_ctrl_c_is_ignored()
 test_quit_key_kills_all_sessions()
 PY

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1067,6 +1067,12 @@ fn test_omar_mcp_server_tools_list_via_cli() {
         "spawn_agent schema must advertise Codex reasoning effort enum: {}",
         spawn_agent["inputSchema"]
     );
+    assert_eq!(
+        props["backend"]["enum"],
+        json!(["claude", "codex", "cursor", "opencode", "antigravity"]),
+        "spawn_agent schema must advertise supported backend enum: {}",
+        spawn_agent["inputSchema"]
+    );
     // Sanity-check required fields.
     let required: Vec<&str> = spawn_agent["inputSchema"]["required"]
         .as_array()


### PR DESCRIPTION
## Summary

- replace Gemini backend support with Google Antigravity CLI (`agy`) support
- wire Antigravity MCP config generation for OMAR-managed agents
- make `Q` the supported reset-quit path: archive action logs and manager notes, wipe persisted runtime state, and keep config/log artifacts
- ignore Ctrl+C in the dashboard so users follow the documented `z`/`Q` commands

## Behavior

`z` still detaches and preserves the live dashboard/runtime state.

`Q` + confirm now kills live OMAR sessions/bridges, archives:

- `~/.omar/ea/<id>/action_log.jsonl` under `~/.omar/logs/action_logs/`
- `~/.omar/manager_notes_ea<id>.md` under `~/.omar/logs/manager_notes/`

Then it removes EA registry/runtime state, scheduled events, and MCP scratch state while preserving `config.toml`, `slack_outbox/`, and logs/panic logs.

## Validation

- `cargo fmt --check`
- `cargo test purge_persisted_runtime_state_archives_logs_and_notes`
- `cargo build && bash tests/ci/tmux_exit_behavior.sh`
- Claude Opus review found issues around Ctrl+C and stale UI text; those were addressed before opening this PR.
