### PR TITLE
[codex] Reset OMAR runtime state on Q quit

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -24,6 +24,8 @@ pub enum ConfirmAction {
     Kill,
     /// Quit the dashboard while leaving EA sessions and persisted state intact.
     Quit,
+    /// Quit OMAR and reset persisted runtime state.
+    ResetQuit,
     /// Delete the currently active EA (blocked only if it is the last one)
     DeleteEa,
 }
@@ -88,6 +90,7 @@ pub struct App {
     pub selected: usize,
     pub manager_selected: bool,
     pub should_quit: bool,
+    pub reset_on_quit: bool,
     pub show_help: bool,
     pub pending_confirm: Option<ConfirmAction>,
     pub filter: String,
@@ -186,6 +189,7 @@ impl App {
             selected: 0,
             manager_selected: true,
             should_quit: false,
+            reset_on_quit: false,
             show_help: false,
             pending_confirm: None,
             filter: String::new(),

--- a/src/ea.rs
+++ b/src/ea.rs
@@ -261,16 +261,6 @@ pub fn unregister_ea(base_dir: &Path, ea_id: EaId) -> anyhow::Result<()> {
     save_registry(base_dir, &eas)
 }
 
-/// Compact the ID counter on clean quit.
-/// Resets ea_next_id to max(registered_ids) so the next session starts
-/// numbering from a compact point rather than the old high-water mark.
-/// Safe to call only on graceful exit — not during crash recovery.
-pub fn compact_id_counter(base_dir: &Path) -> anyhow::Result<()> {
-    let eas = load_registry(base_dir);
-    let max_id = eas.iter().map(|e| e.id).max().unwrap_or(0);
-    save_next_id_counter(base_dir, max_id)
-}
-
 fn save_registry(base_dir: &Path, eas: &[EaInfo]) -> anyhow::Result<()> {
     let path = base_dir.join("eas.json");
     fs::create_dir_all(base_dir).ok();
@@ -573,25 +563,6 @@ mod tests {
         // Create another — should get ID 4, NOT 1 or 2
         let id4 = register_ea(dir.path(), "Delta", None).unwrap();
         assert_eq!(id4, 4, "ID should be 4 (monotonic), not a reused ID");
-    }
-
-    #[test]
-    fn test_compact_id_counter() {
-        let dir = tempfile::tempdir().unwrap();
-        // Create EAs 1, 2, 3; delete 2 and 3
-        let _id1 = register_ea(dir.path(), "Alpha", None).unwrap();
-        let id2 = register_ea(dir.path(), "Beta", None).unwrap();
-        let id3 = register_ea(dir.path(), "Gamma", None).unwrap();
-        unregister_ea(dir.path(), id2).unwrap();
-        unregister_ea(dir.path(), id3).unwrap();
-        // Counter is at 3 (high-water mark)
-        assert_eq!(load_next_id_counter(dir.path()), 3);
-        // Compact: counter should drop to max registered (which is 1)
-        compact_id_counter(dir.path()).unwrap();
-        assert_eq!(load_next_id_counter(dir.path()), 1);
-        // Next register should get ID 2, not 4
-        let id_next = register_ea(dir.path(), "Delta", None).unwrap();
-        assert_eq!(id_next, 2);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1032,7 +1032,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
                         continue;
                     }
 
-                    // Handle confirmation dialog (kill, quit, or delete EA)
+                    // Handle confirmation dialog (kill, quit, reset quit, or delete EA)
                     if let Some(action) = app.pending_confirm {
                         match key.code {
                             KeyCode::Char('y') | KeyCode::Char('Y') => match action {
@@ -1045,6 +1045,11 @@ async fn run_dashboard(config: Config) -> Result<()> {
                                     }
                                 }
                                 app::ConfirmAction::Quit => {
+                                    app.reset_on_quit = false;
+                                    app.should_quit = true;
+                                }
+                                app::ConfirmAction::ResetQuit => {
+                                    app.reset_on_quit = true;
                                     app.should_quit = true;
                                 }
                                 app::ConfirmAction::DeleteEa => {
@@ -1172,7 +1177,7 @@ async fn run_dashboard(config: Config) -> Result<()> {
                     // Normal key handling
                     match key.code {
                         KeyCode::Char('Q') => {
-                            app.pending_confirm = Some(app::ConfirmAction::Quit);
+                            app.pending_confirm = Some(app::ConfirmAction::ResetQuit);
                         }
                         KeyCode::Esc => {
                             app.drill_up();
@@ -1220,9 +1225,6 @@ async fn run_dashboard(config: Config) -> Result<()> {
                         }
                         KeyCode::Char('[') => {
                             app.cycle_previous_ea();
-                        }
-                        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.pending_confirm = Some(app::ConfirmAction::Quit);
                         }
                         KeyCode::Char('j') | KeyCode::Down => {
                             if app.sidebar_focused {
@@ -1471,19 +1473,15 @@ async fn run_dashboard(config: Config) -> Result<()> {
         }
 
         // Check quit flag
-        let should_quit = {
+        let quit_request = {
             let app = shared_app.lock().await;
             if app.should_quit {
-                Some(app.omar_dir.clone())
+                Some((app.omar_dir.clone(), app.reset_on_quit))
             } else {
                 None
             }
         };
-        if let Some(omar_dir) = should_quit {
-            // Compact EA ID counter on clean quit so next session starts from a compact point
-            if let Err(e) = ea::compact_id_counter(&omar_dir) {
-                eprintln!("compact_id_counter failed: {}", e);
-            }
+        if quit_request.is_some() {
             break;
         }
     }
@@ -1521,12 +1519,215 @@ async fn run_dashboard(config: Config) -> Result<()> {
         kill_child_gracefully(child, Duration::from_secs(3));
     }
 
+    let reset_on_quit = {
+        let app = shared_app.lock().await;
+        app.reset_on_quit
+    };
+    if reset_on_quit {
+        let omar_dir = {
+            let app = shared_app.lock().await;
+            app.omar_dir.clone()
+        };
+        purge_persisted_runtime_state_on_quit(&omar_dir)?;
+    }
+
     Ok(())
+}
+
+fn purge_persisted_runtime_state_on_quit(omar_dir: &std::path::Path) -> io::Result<()> {
+    archive_action_logs(omar_dir)?;
+    archive_manager_notes(omar_dir)?;
+
+    for file in [
+        "eas.json",
+        "eas.json.tmp",
+        "active_ea",
+        "ea_next_id",
+        "scheduled_events.json",
+        "scheduled_events.lock",
+        "scheduled_events.tmp",
+    ] {
+        remove_file_if_exists(&omar_dir.join(file))?;
+    }
+
+    remove_dir_if_exists(&omar_dir.join("ea"))?;
+    remove_dir_if_exists(&omar_dir.join("mcp"))?;
+
+    Ok(())
+}
+
+fn archive_action_logs(omar_dir: &std::path::Path) -> io::Result<()> {
+    let ea_dir = omar_dir.join("ea");
+    if !ea_dir.exists() {
+        return Ok(());
+    }
+
+    let archive_dir = omar_dir.join("logs").join("action_logs");
+    std::fs::create_dir_all(&archive_dir)?;
+
+    for entry in std::fs::read_dir(ea_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let ea_id = entry.file_name().to_string_lossy().into_owned();
+        let source = entry.path().join("action_log.jsonl");
+        if !source.exists() {
+            continue;
+        }
+
+        let archive_path =
+            unique_archive_path(&archive_dir, &format!("ea-{}-{}", ea_id, now_ns()), "jsonl");
+        std::fs::rename(source, archive_path)?;
+    }
+
+    Ok(())
+}
+
+fn archive_manager_notes(omar_dir: &std::path::Path) -> io::Result<()> {
+    let archive_dir = omar_dir.join("logs").join("manager_notes");
+    std::fs::create_dir_all(&archive_dir)?;
+
+    let prefix = "manager_notes_ea";
+    for entry in std::fs::read_dir(omar_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+
+        let file_name = entry.file_name().to_string_lossy().into_owned();
+        if !file_name.starts_with(prefix) || !file_name.ends_with(".md") {
+            continue;
+        }
+
+        let ea_id = file_name
+            .strip_prefix(prefix)
+            .and_then(|name| name.strip_suffix(".md"))
+            .unwrap_or("unknown");
+        let archive_path = unique_archive_path(
+            &archive_dir,
+            &format!("manager_notes_ea{}-{}", ea_id, now_ns()),
+            "md",
+        );
+        std::fs::rename(entry.path(), archive_path)?;
+    }
+
+    Ok(())
+}
+
+fn unique_archive_path(dir: &std::path::Path, stem: &str, extension: &str) -> PathBuf {
+    let mut candidate = dir.join(format!("{}.{}", stem, extension));
+    let mut attempt = 1;
+    while candidate.exists() {
+        candidate = dir.join(format!("{}-{}.{}", stem, attempt, extension));
+        attempt += 1;
+    }
+    candidate
+}
+
+fn remove_file_if_exists(path: &std::path::Path) -> io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn remove_dir_if_exists(path: &std::path::Path) -> io::Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn purge_persisted_runtime_state_archives_logs_and_notes() {
+        let dir = tempfile::tempdir().unwrap();
+        let omar_dir = dir.path();
+
+        std::fs::create_dir_all(omar_dir.join("ea/7")).unwrap();
+        std::fs::create_dir_all(omar_dir.join("mcp")).unwrap();
+        std::fs::create_dir_all(omar_dir.join("slack_outbox")).unwrap();
+        std::fs::create_dir_all(omar_dir.join("logs/panics")).unwrap();
+
+        std::fs::write(omar_dir.join("config.toml"), "keep config").unwrap();
+        std::fs::write(omar_dir.join("eas.json"), "wipe registry").unwrap();
+        std::fs::write(omar_dir.join("eas.json.tmp"), "wipe registry tmp").unwrap();
+        std::fs::write(omar_dir.join("active_ea"), "7").unwrap();
+        std::fs::write(omar_dir.join("ea_next_id"), "8").unwrap();
+        std::fs::write(omar_dir.join("scheduled_events.json"), "wipe events").unwrap();
+        std::fs::write(omar_dir.join("scheduled_events.lock"), "wipe lock").unwrap();
+        std::fs::write(omar_dir.join("scheduled_events.tmp"), "wipe tmp").unwrap();
+        std::fs::write(omar_dir.join("ea/7/action_log.jsonl"), "keep action\n").unwrap();
+        std::fs::write(omar_dir.join("ea/7/tasks.md"), "wipe task").unwrap();
+        std::fs::write(omar_dir.join("manager_notes_ea7.md"), "keep notes\n").unwrap();
+        std::fs::write(omar_dir.join("mcp/state.json"), "wipe mcp").unwrap();
+        std::fs::write(omar_dir.join("slack_outbox/keep"), "keep slack").unwrap();
+        std::fs::write(omar_dir.join("logs/panics/keep.log"), "keep panic").unwrap();
+
+        purge_persisted_runtime_state_on_quit(omar_dir).unwrap();
+
+        for wiped in [
+            "eas.json",
+            "eas.json.tmp",
+            "active_ea",
+            "ea_next_id",
+            "scheduled_events.json",
+            "scheduled_events.lock",
+            "scheduled_events.tmp",
+            "ea",
+            "mcp",
+            "manager_notes_ea7.md",
+        ] {
+            assert!(
+                !omar_dir.join(wiped).exists(),
+                "{wiped} should be removed by Q reset"
+            );
+        }
+
+        for kept in ["config.toml", "slack_outbox/keep", "logs/panics/keep.log"] {
+            assert!(
+                omar_dir.join(kept).exists(),
+                "{kept} should survive Q reset"
+            );
+        }
+
+        let action_logs: Vec<_> = std::fs::read_dir(omar_dir.join("logs/action_logs"))
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        assert_eq!(action_logs.len(), 1);
+        assert_eq!(
+            std::fs::read_to_string(&action_logs[0]).unwrap(),
+            "keep action\n"
+        );
+        assert!(action_logs[0]
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("ea-7-"));
+
+        let manager_notes: Vec<_> = std::fs::read_dir(omar_dir.join("logs/manager_notes"))
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        assert_eq!(manager_notes.len(), 1);
+        assert_eq!(
+            std::fs::read_to_string(&manager_notes[0]).unwrap(),
+            "keep notes\n"
+        );
+        assert!(manager_notes[0]
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("manager_notes_ea7-"));
+    }
 
     /// Regression: `extended-keys always` forces tmux to emit modify-other-keys
     /// sequences to every client, including omar's dashboard, which doesn't

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1260,7 +1260,7 @@ fn render_help_popup(frame: &mut Frame) {
             Style::default().add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
-        Line::from("  Q           Quit"),
+        Line::from("  Q           Quit and reset runtime state"),
         Line::from("  ←/→, h/l   Switch panel (sidebar ↔ main)"),
         Line::from("  ↑/↓, j/k   Move selection up/down"),
         Line::from("  Tab         Drill into selected agent"),
@@ -1308,6 +1308,13 @@ fn render_confirm_dialog(frame: &mut Frame, app: &App, action: ConfirmAction) {
             (" Confirm ", "Kill this agent?", name, String::new(), 40)
         }
         ConfirmAction::Quit => (
+            " Confirm Quit ",
+            "Quit omar?",
+            "This will kill ALL EA sessions and agents.".to_string(),
+            "Persisted EA state, projects, notes, and events will be kept.".to_string(),
+            62,
+        ),
+        ConfirmAction::ResetQuit => (
             " Confirm Quit ",
             "Quit omar?",
             "This will kill ALL EA sessions and agents.".to_string(),

--- a/tests/ci/tmux_exit_behavior.sh
+++ b/tests/ci/tmux_exit_behavior.sh
@@ -28,7 +28,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$home_dir/.omar"
+mkdir -p \
+  "$home_dir/.omar/ea/0/status" \
+  "$home_dir/.omar/mcp/ea-0" \
+  "$home_dir/.omar/slack_outbox" \
+  "$home_dir/.omar/logs/panics"
+
 cat >"$home_dir/.omar/config.toml" <<'EOF'
 [dashboard]
 refresh_interval = 1
@@ -38,6 +43,25 @@ session_prefix = "omar-agent-"
 default_command = "bash"
 default_workdir = "."
 EOF
+
+cat >"$home_dir/.omar/eas.json" <<'EOF'
+[
+  {
+    "id": 0,
+    "name": "OldSessionName",
+    "description": null,
+    "created_at": 1
+  }
+]
+EOF
+printf '0' >"$home_dir/.omar/active_ea"
+printf '1' >"$home_dir/.omar/ea_next_id"
+printf '[]' >"$home_dir/.omar/scheduled_events.json"
+printf 'keep task\n' >"$home_dir/.omar/ea/0/tasks.md"
+printf 'keep action log\n' >"$home_dir/.omar/ea/0/action_log.jsonl"
+printf 'keep manager notes\n' >"$home_dir/.omar/manager_notes_ea0.md"
+printf 'keep slack\n' >"$home_dir/.omar/slack_outbox/keep"
+printf 'keep panic\n' >"$home_dir/.omar/logs/panics/keep.log"
 
 tmux_cmd() {
   HOME="$home_dir" OMAR_TMUX_SERVER="$server" tmux -L "$server" "$@"
@@ -62,15 +86,16 @@ tmux -L "$server" new-session -d -s omar-dashboard \
 wait_for_session omar-dashboard
 wait_for_session omar-agent-ea-0
 
-python3 - "$server" <<'PY'
+python3 - "$server" "$home_dir" <<'PY'
 import os
-import pty
-import signal
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 server = sys.argv[1]
+home_dir = Path(sys.argv[2])
+omar_dir = home_dir / ".omar"
 
 
 def tmux(*args):
@@ -98,11 +123,6 @@ def sessions():
         name, attached, command = parts
         result[name] = {"attached": attached == "1", "command": command}
     return result
-
-
-def session_attached(name):
-    session = sessions().get(name)
-    return bool(session and session["attached"])
 
 
 def session_exists(name):
@@ -137,76 +157,110 @@ def fail(message):
     sys.exit(1)
 
 
-def open_dashboard():
-    pid, fd = pty.fork()
-    if pid == 0:
-        os.environ.setdefault("TERM", "xterm-256color")
-        os.execvp("tmux", ["tmux", "-L", server, "attach-session", "-t", "omar-dashboard"])
-    return pid, fd
+def send_keys(*keys):
+    result = tmux("send-keys", "-t", "omar-dashboard:0.0", *keys)
+    if result.returncode != 0:
+        fail(f"Failed to send keys {keys}: {result.stderr}")
 
 
-def close_dashboard(pid, fd):
-    try:
-        os.kill(pid, signal.SIGHUP)
-    except ProcessLookupError:
-        pass
-    try:
-        os.close(fd)
-    except OSError:
-        pass
-    try:
-        os.waitpid(pid, os.WNOHANG)
-    except OSError:
-        pass
+def assert_exists(path):
+    if not (omar_dir / path).exists():
+        fail(f"Expected path to exist: {path}")
 
 
-def wait_for_attached(session, timeout=5.0):
-    if not wait_for(lambda: session_attached(session), timeout=timeout):
-        fail(f"Session was not attached when expected: {session}")
+def assert_missing(path):
+    if (omar_dir / path).exists():
+        fail(f"Expected path to be removed: {path}")
 
 
-def wait_for_detached(session, timeout=5.0):
-    if not wait_for(
-        lambda: session_exists(session) and not session_attached(session),
-        timeout=timeout,
-    ):
-        fail(f"Session did not detach within timeout: {session}")
+def assert_runtime_state_present(label):
+    for path in [
+        "config.toml",
+        "eas.json",
+        "active_ea",
+        "ea_next_id",
+        "scheduled_events.json",
+        "ea/0/tasks.md",
+        "ea/0/action_log.jsonl",
+        "manager_notes_ea0.md",
+        "mcp/ea-0",
+        "slack_outbox/keep",
+        "logs/panics/keep.log",
+    ]:
+        assert_exists(path)
+    print(f"PASS: {label} preserves persisted runtime state")
 
 
 def test_detach_key():
-    pid, fd = open_dashboard()
-    try:
-        wait_for_attached("omar-dashboard")
-        os.write(fd, b"z")
+    send_keys("z")
+    time.sleep(0.2)
+    if not session_exists("omar-dashboard"):
+        fail("Dashboard session disappeared after detach; expected session to persist")
 
-        wait_for_detached("omar-dashboard")
-        if not session_exists("omar-dashboard"):
-            fail("Dashboard session disappeared after detach; expected session to persist")
-
-        print("PASS: z detaches without terminating dashboard session")
-    finally:
-        close_dashboard(pid, fd)
+    assert_runtime_state_present("z")
+    print("PASS: z preserves dashboard session and runtime state")
 
 
-def test_quit_key_kills_all_sessions():
-    pid, fd = open_dashboard()
-    try:
-        wait_for_attached("omar-dashboard")
-        os.write(fd, b"Q")
-        time.sleep(0.1)
-        os.write(fd, b"y")
+def test_ctrl_c_is_ignored():
+    send_keys("C-c")
+    time.sleep(0.2)
 
-        if not wait_for(lambda: not session_exists("omar-dashboard"), timeout=10.0):
-            fail("Dashboard session did not terminate after Q+y")
+    if not session_exists("omar-dashboard"):
+        fail("Dashboard session disappeared after Ctrl+C; expected Ctrl+C to be ignored")
+    if not session_exists("omar-agent-ea-0"):
+        fail("EA manager session disappeared after Ctrl+C; expected Ctrl+C to be ignored")
 
-        if has_prefix_session("omar-agent-"):
-            fail("OMAR agent sessions still exist after Q+y; expected cleanup on quit")
+    assert_runtime_state_present("Ctrl+C")
+    print("PASS: Ctrl+C is ignored")
 
-        print("PASS: Q+y exits dashboard and kills OMAR sessions")
-    finally:
-        close_dashboard(pid, fd)
+
+def test_quit_key_kills_all_sessions_and_resets_runtime_state():
+    send_keys("Q")
+    time.sleep(0.1)
+    send_keys("y")
+
+    if not wait_for(lambda: not session_exists("omar-dashboard"), timeout=10.0):
+        fail("Dashboard session did not terminate after Q+y")
+
+    if has_prefix_session("omar-agent-"):
+        fail("OMAR agent sessions still exist after Q+y; expected cleanup on quit")
+
+    for path in [
+        "eas.json",
+        "active_ea",
+        "ea_next_id",
+        "scheduled_events.json",
+        "ea",
+        "mcp",
+        "manager_notes_ea0.md",
+    ]:
+        assert_missing(path)
+
+    for path in ["config.toml", "slack_outbox/keep", "logs/panics/keep.log"]:
+        assert_exists(path)
+
+    action_logs = sorted((omar_dir / "logs" / "action_logs").iterdir())
+    if len(action_logs) != 1:
+        fail(f"Expected one archived action log, found {len(action_logs)}")
+    action_name = action_logs[0].name
+    if not (action_name.startswith("ea-0-") and action_name.endswith(".jsonl")):
+        fail(f"Unexpected archived action log name: {action_name}")
+    if action_logs[0].read_text() != "keep action log\n":
+        fail("Archived action log content did not match")
+
+    manager_notes = sorted((omar_dir / "logs" / "manager_notes").iterdir())
+    if len(manager_notes) != 1:
+        fail(f"Expected one archived manager notes file, found {len(manager_notes)}")
+    notes_name = manager_notes[0].name
+    if not (notes_name.startswith("manager_notes_ea0-") and notes_name.endswith(".md")):
+        fail(f"Unexpected archived manager notes name: {notes_name}")
+    if manager_notes[0].read_text() != "keep manager notes\n":
+        fail("Archived manager notes content did not match")
+
+    print("PASS: Q+y exits dashboard, kills OMAR sessions, and resets runtime state")
 
 
 test_detach_key()
-test_quit_key_kills_all_sessions()
+test_ctrl_c_is_ignored()
+test_quit_key_kills_all_sessions_and_resets_runtime_state()
 PY


### PR DESCRIPTION
## Summary

- Makes `Q` use a reset-quit path while keeping the existing terse confirmation copy.
- Ignores Ctrl+C in the dashboard normal key handler so users follow the supported `z` / `Q` commands.
- Archives EA action logs and manager notes before clearing persisted runtime state.
- Clears EA registry/counter/active EA, scheduled events, EA state, and MCP state on `Q+y`.
- Preserves config, Slack outbox, panic logs, and archived logs/notes.

## Validation

- `cargo fmt --check`
- `cargo test purge_persisted_runtime_state_archives_logs_and_notes`
- `cargo build`
- `bash tests/ci/tmux_exit_behavior.sh`