### PR TITLE
fix: use temp file in paste_text, bound event channel

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -72,14 +72,14 @@ fn coalesce_alt_arrow(first: KeyEvent, next: Option<Event>) -> (AppEvent, Option
 
 /// Handles input events and tick timing
 pub struct EventHandler {
-    rx: mpsc::UnboundedReceiver<AppEvent>,
-    _tx: mpsc::UnboundedSender<AppEvent>,
+    rx: mpsc::Receiver<AppEvent>,
+    _tx: mpsc::Sender<AppEvent>,
 }
 
 impl EventHandler {
     /// Create a new event handler with the given tick rate
     pub fn new(tick_rate: Duration) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(1024);
         let event_tx = tx.clone();
 
         // Spawn event polling task
@@ -90,7 +90,7 @@ impl EventHandler {
 
             loop {
                 if let Some(event) = pending_event.take() {
-                    if event_tx.send(event).is_err() {
+                    if event_tx.send(event).await.is_err() {
                         break;
                     }
                     continue;
@@ -129,7 +129,7 @@ impl EventHandler {
                     }
                 };
 
-                if event_tx.send(event).is_err() {
+                if event_tx.send(event).await.is_err() {
                     break;
                 }
             }

--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -398,28 +398,15 @@ impl TmuxClient {
         let target = exact_pane_target(target);
         let buffer_name = format!("omar-paste-{}", uuid::Uuid::new_v4());
 
-        // Load text into a uniquely-named tmux buffer via stdin.
-        let child = tmux_command()
-            .args(["load-buffer", "-b", &buffer_name, "-"])
-            .stdin(std::process::Stdio::piped())
-            .spawn()
-            .context("Failed to spawn tmux load-buffer")?;
-        use std::io::Write;
-        child
-            .stdin
-            .as_ref()
-            .unwrap()
-            .write_all(text.as_bytes())
-            .context("Failed to write to tmux load-buffer stdin")?;
-        let output = child
-            .wait_with_output()
-            .context("Failed to wait for tmux load-buffer")?;
-        if !output.status.success() {
-            anyhow::bail!(
-                "tmux load-buffer failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
+        let tmp_path =
+            std::env::temp_dir().join(format!("omar-paste-{}.txt", uuid::Uuid::new_v4()));
+        std::fs::write(&tmp_path, text).context("Failed to write paste text to temp file")?;
+        let path_str = tmp_path
+            .to_str()
+            .context("Temp file path is not valid UTF-8")?;
+        self.run(&["load-buffer", "-b", &buffer_name, path_str])?;
+        std::fs::remove_file(&tmp_path).ok(); // best-effort cleanup
+
         // Paste from the named buffer using bracketed paste mode so the
         // target pane treats it as a single paste operation. `-d` deletes
         // the buffer after pasting. `-r` preserves LFs verbatim — see the


### PR DESCRIPTION
The crash report in #118 shows repeated tmux 3.2a server segfaults while hosting omar. One candidate trigger identified during investigation is `paste_text`, which currently uses `load-buffer -` reading from piped stdin. This PR avoids that code path by writing the payload to a temp file and passing the file path to `load-buffer` instead.

The root cause has not been confirmed, as no stack trace or reproducer was available. But this change removes a tmux interaction pattern that was flagged during investigation and aligns `paste_text` with the temp-file approach already used in `send_keys_literal` for large payloads.

This PR also replaces `mpsc::unbounded_channel()` in the event handler with `mpsc::channel(1024)`. Over long sessions an unbounded channel is a latent memory growth vector if the consumer falls behind.

**Changes:**
- `src/tmux/client.rs`: `paste_text` writes to a temp file instead of piping via stdin to `load-buffer`
- `src/event.rs`: `EventHandler` uses `mpsc::channel(1024)` instead of `mpsc::unbounded_channel`

Related to #118