### PR TITLE
fix: avoid tmux stdin path in paste_text (related to #118)

### DIFF
--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -375,28 +375,15 @@ impl TmuxClient {
         let target = exact_pane_target(target);
         let buffer_name = format!("omar-paste-{}", uuid::Uuid::new_v4());
 
-        // Load text into a uniquely-named tmux buffer via stdin.
-        let child = tmux_command()
-            .args(["load-buffer", "-b", &buffer_name, "-"])
-            .stdin(std::process::Stdio::piped())
-            .spawn()
-            .context("Failed to spawn tmux load-buffer")?;
-        use std::io::Write;
-        child
-            .stdin
-            .as_ref()
-            .unwrap()
-            .write_all(text.as_bytes())
-            .context("Failed to write to tmux load-buffer stdin")?;
-        let output = child
-            .wait_with_output()
-            .context("Failed to wait for tmux load-buffer")?;
-        if !output.status.success() {
-            anyhow::bail!(
-                "tmux load-buffer failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
+        let tmp_path =
+            std::env::temp_dir().join(format!("omar-paste-{}.txt", uuid::Uuid::new_v4()));
+        std::fs::write(&tmp_path, text).context("Failed to write paste text to temp file")?;
+        let path_str = tmp_path
+            .to_str()
+            .context("Temp file path is not valid UTF-8")?;
+        let load_result = self.run(&["load-buffer", "-b", &buffer_name, path_str]);
+        std::fs::remove_file(&tmp_path).ok(); // best-effort cleanup
+        load_result?;
         // Paste from the named buffer using bracketed paste mode so the
         // target pane treats it as a single paste operation. `-d` deletes
         // the buffer after pasting. `-r` preserves LFs verbatim — see the


### PR DESCRIPTION
The crash report in #118 shows repeated tmux 3.2a server segfaults while hosting omar. After looking, it showed `load-buffer -` (reading from piped stdin) in `paste_text` as a potential candidate trigger. This PR avoids that code path by writing the payload to a temp file and passing the file path to `load-buffer` instead, aligning `paste_text` with the existing temp-file approach already used in `send_keys_literal` for large payloads.

Also addresses the cleanup-on-error gap flagged by Copilot in #144: the temp file is now always deleted even if `load-buffer` fails.

This is a focused version of #144 with the `mpsc::unbounded_channel` change dropped per maintainer feedback.

Closes #144. Related to #118.