### PR TITLE
fix: write tmux/backend payloads to user-private temp files (#146)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod mcp;
 mod memory;
 mod metrics;
 mod panic_hook;
+mod paths;
 mod process;
 mod projects;
 mod scheduler;

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -215,9 +215,6 @@ fn materialize_prompt_file(prompt_file: &Path, substitutions: &[(&str, &str)]) -
         content = content.replace(pattern, replacement);
     }
 
-    let dir = std::env::temp_dir().join("omar-prompts");
-    std::fs::create_dir_all(&dir).ok();
-
     let stem = prompt_file
         .file_stem()
         .and_then(|s| s.to_str())
@@ -226,12 +223,23 @@ fn materialize_prompt_file(prompt_file: &Path, substitutions: &[(&str, &str)]) -
         .extension()
         .and_then(|s| s.to_str())
         .unwrap_or("md");
-    let rendered = dir.join(format!("{}-{}.{}", stem, Uuid::new_v4(), ext));
 
-    if std::fs::write(&rendered, content).is_ok() {
-        rendered
-    } else {
-        prompt_file.to_path_buf()
+    // Backend reads this later, so no self-deleting guard; 0600 in the private dir.
+    let rendered = match crate::paths::private_temp_dir() {
+        Ok(dir) => dir.join(format!("{}-{}.{}", stem, Uuid::new_v4(), ext)),
+        Err(_) => return prompt_file.to_path_buf(),
+    };
+
+    match crate::paths::create_private_file(&rendered) {
+        Ok(mut file) => {
+            if file.write_all(content.as_bytes()).is_ok() {
+                rendered
+            } else {
+                let _ = std::fs::remove_file(&rendered);
+                prompt_file.to_path_buf()
+            }
+        }
+        Err(_) => prompt_file.to_path_buf(),
     }
 }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,187 @@
+//! User-private temp files for payloads handed off to tmux / backend CLIs.
+//! Files live in a per-user dir (0700) and are created 0600 with `create_new`,
+//! so other accounts on a shared host can't read the payloads.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+/// A 0600 temp file that deletes itself on drop (even on panic / early return).
+pub struct PrivateTempFile {
+    path: PathBuf,
+    file: File,
+}
+
+impl PrivateTempFile {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Write for PrivateTempFile {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.file.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.flush()
+    }
+}
+
+impl Drop for PrivateTempFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Per-user dir (mode 0700): `$XDG_RUNTIME_DIR` if set, else `temp_dir()`,
+/// with an `omar-<user>` subdir so the `/tmp` fallback isn't shared.
+pub fn private_temp_dir() -> io::Result<PathBuf> {
+    let base = dirs::runtime_dir().unwrap_or_else(std::env::temp_dir);
+    let user = sanitize_user(
+        &std::env::var("USER")
+            .or_else(|_| std::env::var("LOGNAME"))
+            .unwrap_or_default(),
+    );
+    let dir = base.join(format!("omar-{user}"));
+    ensure_private_dir(&dir)?;
+    Ok(dir)
+}
+
+/// `$USER`/`$LOGNAME` are user-controlled, so strip everything but a safe
+/// charset to keep the joined name from escaping `base` via separators or `..`.
+fn sanitize_user(raw: &str) -> String {
+    let s: String = raw
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        .collect();
+    if s.is_empty() {
+        "user".to_string()
+    } else {
+        s
+    }
+}
+
+/// Self-deleting 0600 temp file under [`private_temp_dir`], named
+/// `<prefix>-<uuid>.<ext>`.
+pub fn create_private_temp_file(prefix: &str, ext: &str) -> io::Result<PrivateTempFile> {
+    let dir = private_temp_dir()?;
+    let path = dir.join(format!("{prefix}-{}.{ext}", Uuid::new_v4()));
+    let file = create_private_file(&path)?;
+    Ok(PrivateTempFile { path, file })
+}
+
+/// New 0600 file at `path` (no self-delete), for files that outlive the scope.
+/// `create_new` fails rather than truncate or follow a planted symlink.
+pub fn create_private_file(path: &Path) -> io::Result<File> {
+    let mut opts = OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts.open(path)
+}
+
+/// Ensure `dir` exists at mode 0700. An existing dir is tightened back to 0700,
+/// which also errors if we don't own it.
+fn ensure_private_dir(dir: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::fs::{DirBuilder, Permissions};
+        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+        match DirBuilder::new().mode(0o700).create(dir) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                // Reject a pre-planted symlink or file before chmod follows it.
+                if !std::fs::symlink_metadata(dir)?.is_dir() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        "private temp dir is not a directory",
+                    ));
+                }
+                std::fs::set_permissions(dir, Permissions::from_mode(0o700))
+            }
+            Err(err) => Err(err),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn private_temp_dir_is_owner_only() {
+        let dir = private_temp_dir().expect("private temp dir");
+        assert!(dir.is_dir());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "private temp dir must be owner-only");
+        }
+    }
+
+    #[test]
+    fn create_private_temp_file_is_mode_0600() {
+        let mut tmp = create_private_temp_file("omar-test", "txt").expect("temp file");
+        tmp.write_all(b"secret payload").expect("write");
+        assert!(tmp.path().exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(tmp.path()).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "private temp file must be owner-only");
+        }
+    }
+
+    #[test]
+    fn create_private_temp_file_deletes_on_drop() {
+        let path = {
+            let tmp = create_private_temp_file("omar-test-drop", "txt").expect("temp file");
+            tmp.path().to_path_buf()
+        };
+        assert!(!path.exists(), "file must be removed when guard is dropped");
+    }
+
+    #[test]
+    fn create_private_file_refuses_existing_path() {
+        let mut tmp = create_private_temp_file("omar-test-excl", "txt").expect("temp file");
+        tmp.write_all(b"original").expect("write");
+        // create_new must fail rather than truncate an existing file.
+        let err = create_private_file(tmp.path()).expect_err("must not clobber existing file");
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn sanitize_user_strips_path_separators() {
+        assert_eq!(sanitize_user("alice"), "alice");
+        assert_eq!(sanitize_user("../../etc"), "etc");
+        assert_eq!(sanitize_user("a/b"), "ab");
+        assert_eq!(sanitize_user(""), "user");
+        assert_eq!(sanitize_user("///"), "user");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn ensure_private_dir_rejects_symlink() {
+        use std::os::unix::fs::symlink;
+        let base = std::env::temp_dir().join(format!("omar-symtest-{}", Uuid::new_v4()));
+        std::fs::create_dir(&base).unwrap();
+        let target = base.join("target");
+        std::fs::create_dir(&target).unwrap();
+        let link = base.join("omar-link");
+        symlink(&target, &link).unwrap();
+        let err = ensure_private_dir(&link).expect_err("symlink must be rejected");
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        std::fs::remove_dir_all(&base).ok();
+    }
+}

--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use anyhow::{anyhow, Context, Result};
+use std::io::Write;
 use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -360,16 +361,17 @@ impl TmuxClient {
         if text.len() < Self::LARGE_PAYLOAD_THRESHOLD {
             self.run(&["send-keys", "-t", &target, "-l", "--", text])?;
         } else {
-            // Write to a temp file, load into tmux buffer, paste, then clean up.
-            // This avoids passing large text as a command-line argument.
-            let tmp_path =
-                std::env::temp_dir().join(format!("omar-task-{}.txt", uuid::Uuid::new_v4()));
-            std::fs::write(&tmp_path, text).context("Failed to write task to temp file")?;
-            let path_str = tmp_path
+            // Avoid passing large text as a CLI arg; owner-only temp file is
+            // removed when `tmp` drops.
+            let mut tmp = crate::paths::create_private_temp_file("omar-task", "txt")
+                .context("Failed to create temp file for task payload")?;
+            tmp.write_all(text.as_bytes())
+                .context("Failed to write task to temp file")?;
+            let path_str = tmp
+                .path()
                 .to_str()
                 .context("Temp file path is not valid UTF-8")?;
             self.run(&["load-buffer", path_str])?;
-            std::fs::remove_file(&tmp_path).ok(); // best-effort cleanup
             self.run(&["paste-buffer", "-t", &target])?;
         }
         Ok(())
@@ -398,15 +400,17 @@ impl TmuxClient {
         let target = exact_pane_target(target);
         let buffer_name = format!("omar-paste-{}", uuid::Uuid::new_v4());
 
-        let tmp_path =
-            std::env::temp_dir().join(format!("omar-paste-{}.txt", uuid::Uuid::new_v4()));
-        std::fs::write(&tmp_path, text).context("Failed to write paste text to temp file")?;
-        let path_str = tmp_path
+        // Owner-only temp file (payloads can carry pasted secrets), removed
+        // when `tmp` drops.
+        let mut tmp = crate::paths::create_private_temp_file("omar-paste", "txt")
+            .context("Failed to create temp file for paste payload")?;
+        tmp.write_all(text.as_bytes())
+            .context("Failed to write paste text to temp file")?;
+        let path_str = tmp
+            .path()
             .to_str()
             .context("Temp file path is not valid UTF-8")?;
-        let load_result = self.run(&["load-buffer", "-b", &buffer_name, path_str]);
-        std::fs::remove_file(&tmp_path).ok(); // best-effort cleanup
-        load_result?;
+        self.run(&["load-buffer", "-b", &buffer_name, path_str])?;
         // Paste from the named buffer using bracketed paste mode so the
         // target pane treats it as a single paste operation. `-d` deletes
         // the buffer after pasting. `-r` preserves LFs verbatim — see the


### PR DESCRIPTION
omar writes paste and prompt payloads to `/tmp` with `fs::write`, which picks up the default umask (usually `0644`), so anyone else on a shared box can read them while they're there. We already write MCP config at `0600` in `write_private_file`, so this does the same for the payload files.

Adds a small `src/paths.rs` helper used by the three call sites. It creates files with `0600` permissions in a per-user `0700` temp directory (preferring `$XDG_RUNTIME_DIR` and falling back to `temp_dir()`), and provides a guard that removes temporary files when no longer needed.

**Changes:**
- `src/paths.rs`: the helper and the self-deleting guard
- `src/tmux/client.rs`: `send_keys_literal` and `paste_text` use it
- `src/manager/mod.rs`: `materialize_prompt_file` writes `0600` in the private dir
- `src/main.rs`: registers the module

Closes #146
