### PR TITLE
release: v0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "bridges/slack", "bridges/computer"]
 
 [package]
 name = "omar"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Agent dashboard for tmux"
 license = "MIT"


### PR DESCRIPTION
Bump OMAR version from 0.3.1 to 0.3.2.

Patch release — bug fixes and small enhancements since v0.3.1, no breaking changes. The `v0.3.2` tag has been pushed on `main`; the release workflow built the binaries, published the GitHub release with auto-generated notes, and updated the Homebrew formula.

## Changes since v0.3.1
- fix: write tmux/backend payloads to user-private temp files (#146) (#148)
- fix: avoid tmux stdin path in paste_text (#147)
- fix(mcp): strip "(deleted)" from server exe path so spawned agents get OMAR tools (#139)
- fix: dashboard launch handoff (#137)
- fix: smart event input capture + popup deferral for agent suggestions (#143, #133, #138)
- fix(prompts): restore explicit agent cleanup duties lost in MCP migration (#132)
- feat: swap gemini backend for agy (#142)
- feat: add Codex reasoning effort to spawn_agent (#131)
- chore/docs/test: CLAUDE.md karpathy template (#145), star-history responsive images (#136), opencode session-name test alignment (#134)

🤖 Generated with [Claude Code](https://claude.com/claude-code)