### PR TITLE
Prompt OMAR tool discovery before orchestration

### DIFF
--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -9,7 +9,7 @@ Use OMAR MCP tools for orchestration. Do not use curl or built-in background-age
 
 ## Tool Discovery
 
-Before any orchestration action, inspect the runtime's available MCP tool catalog or discovery mechanism. Locate the `mcp__omar__` tools and use them exclusively for OMAR work. Do not substitute built-in collaboration, scheduling, or task-management tools when an OMAR tool is available.
+Before any orchestration action, inspect the runtime's available MCP tool catalog or discovery mechanism. Identify the OMAR server's tools by their purpose and server name: backends may expose them as `mcp__omar__<tool>` or simply `<tool>` (for example, `spawn_agent` and `schedule_omar_event`). Use those OMAR tools exclusively for OMAR work. Do not substitute built-in collaboration, scheduling, or task-management tools when an OMAR tool is available.
 
 ## Wake-Up Policy
 

--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -7,6 +7,10 @@ You operate in one of two roles:
 
 Use OMAR MCP tools for orchestration. Do not use curl or built-in background-agent features outside OMAR.
 
+## Tool Discovery
+
+Before any orchestration action, inspect the runtime's available MCP tool catalog or discovery mechanism. Locate the `mcp__omar__` tools and use them exclusively for OMAR work. Do not substitute built-in collaboration, scheduling, or task-management tools when an OMAR tool is available.
+
 ## Wake-Up Policy
 
 All timed waits, reminders, check-ins, retries, and completion notifications MUST use the OMAR MCP tool `schedule_omar_event`.

--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -10,7 +10,7 @@ IMPORTANT:
 
 ## Tool Discovery
 
-Before any orchestration action, inspect the runtime's available MCP tool catalog or discovery mechanism. Locate the `mcp__omar__` tools and use them exclusively for OMAR work. Do not substitute built-in collaboration, scheduling, or task-management tools when an OMAR tool is available.
+Before any orchestration action, inspect the runtime's available MCP tool catalog or discovery mechanism. Identify the OMAR server's tools by their purpose and server name: backends may expose them as `mcp__omar__<tool>` or simply `<tool>` (for example, `spawn_agent` and `schedule_omar_event`). Use those OMAR tools exclusively for OMAR work. Do not substitute built-in collaboration, scheduling, or task-management tools when an OMAR tool is available.
 
 ## Wake-Up Policy
 

--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -8,6 +8,10 @@ IMPORTANT:
 - Use OMAR MCP tools for all orchestration work.
 - Do not use raw curl commands or any built-in multi-agent feature outside OMAR.
 
+## Tool Discovery
+
+Before any orchestration action, inspect the runtime's available MCP tool catalog or discovery mechanism. Locate the `mcp__omar__` tools and use them exclusively for OMAR work. Do not substitute built-in collaboration, scheduling, or task-management tools when an OMAR tool is available.
+
 ## Wake-Up Policy
 
 All timed waits, reminders, check-ins, retries, and worker/EA notifications MUST use the OMAR MCP tool `schedule_omar_event`.

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -1902,4 +1902,14 @@ mod tests {
         assert!(pdir.join("executive-assistant.md").exists());
         assert!(pdir.join("agent.md").exists());
     }
+
+    #[test]
+    fn embedded_prompts_accept_namespaced_and_plain_omar_tool_names() {
+        for prompt in [PROMPT_EA, PROMPT_AGENT] {
+            assert!(prompt.contains("mcp__omar__<tool>"));
+            assert!(prompt.contains("simply `<tool>`"));
+            assert!(prompt.contains("`spawn_agent`"));
+            assert!(prompt.contains("`schedule_omar_event`"));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- require EA and worker prompts to inspect the runtime MCP tool catalog before orchestration
- direct agents to use discovered OMAR MCP tools instead of built-in orchestration alternatives

## Validation
- git diff --check
- cargo fmt --check
- cargo test manager