### PR TITLE
release: v0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "bridges/slack", "bridges/computer"]
 
 [package]
 name = "omar"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "Agent dashboard for tmux"
 license = "MIT"


### PR DESCRIPTION
Bump OMAR from 0.3.2 to 0.3.3 for the patch release.

Includes changes merged since v0.3.2:
- prompt OMAR tool discovery before orchestration
- README updates
- prune dead code
- remove watchdog auth-failure fallback

Verification:
- cargo fmt --check
- cargo build --release
- cargo test --workspace -- --skip tmux::client::tests::test_session_has_live_pane_rejects_dead_remain_on_exit_session

Note: the excluded tmux test fails reproducibly on local tmux 3.6a because detached non-interactive `sh` exits before the test targets its pane; it is unrelated to this version-only change.