### PR TITLE
Move project domain to omar.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Lead a team of 100 agents to solve humanity's biggest problems.
 
 
 <p align="center">
-  <a href="https://omar.tech">omar.tech</a>&nbsp; • &nbsp;
-  <a href="https://omar.tech/zh/">中文</a>&nbsp; • &nbsp;
+  <a href="https://omar.rs">omar.rs</a>&nbsp; • &nbsp;
+  <a href="https://omar.rs/zh/">中文</a>&nbsp; • &nbsp;
   <a href="https://opensource.org/licenses/BSD-3-Clause"><img src="https://img.shields.io/badge/License-BSD_3--Clause-blue.svg" alt="License" valign="middle"/></a>&nbsp; • &nbsp;
   <a href="https://github.com/lsk567/omar/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/lsk567/omar/ci.yml?label=CI&logo=github" alt="CI Status" valign="middle"/></a>&nbsp; • &nbsp;
   <a href="https://discord.gg/X76PSzmfWr"><img src="https://img.shields.io/discord/1467663881588572182?label=Discord&logo=discord&logoColor=white&color=5865F2&cacheSeconds=60" alt="Discord" valign="middle"/></a>
@@ -41,7 +41,7 @@ Other features include messaging systems integration (e.g., Slack), computer use
 ### One-liner (recommended)
 
 ```bash
-curl -fsSL https://omar.tech/install.sh | sh
+curl -fsSL https://omar.rs/install.sh | sh
 ```
 
 Installs all binaries to `/usr/local/bin`.


### PR DESCRIPTION
## Summary

- replace project website links from `omar.tech` to `omar.rs`
- update the documented install command to use `https://omar.rs/install.sh`

## Verification

- `git grep 'omar\.tech'` returns no tracked matches
- `git diff --check origin/main...HEAD`