### PR TITLE
Stop re-delivering a prompt the agent has already answered

### DIFF
--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -488,6 +488,26 @@ impl TmuxClient {
     /// 6. Verify with `wait_for_change` that Enter caused an observable
     ///    transition. If not, clear the input and retry.
     pub fn deliver_prompt(&self, session: &str, text: &str, opts: &DeliveryOptions) -> Result<()> {
+        self.deliver_prompt_until(session, text, opts, &|| false)
+    }
+
+    /// The same, for a caller that can tell whether the prompt was acted on.
+    ///
+    /// Step 6 assumes the agent does nothing until Enter, which is true of a
+    /// TUI backend but not of one that reads its pane a line at a time: that
+    /// one answers while the paste is still arriving, so its output lands
+    /// *before* the pre-Enter snapshot and Enter changes nothing. The pane
+    /// alone cannot tell "the prompt never arrived" from "the prompt arrived
+    /// and was already handled", and the two need opposite responses — retry,
+    /// or stop. `answered` is the caller's own evidence, which is why it is
+    /// the one signal here that does not come from the terminal.
+    pub fn deliver_prompt_until(
+        &self,
+        session: &str,
+        text: &str,
+        opts: &DeliveryOptions,
+        answered: &dyn Fn() -> bool,
+    ) -> Result<()> {
         // Per-delivery UUID so a stale sentinel from a previous delivery
         // cannot false-positive the end-sentinel poll on retry.
         let delivery_id = uuid::Uuid::new_v4().simple().to_string();
@@ -497,6 +517,12 @@ impl TmuxClient {
         let wrapped = format!("{}\n{}\n{}", start_sentinel, text, end_sentinel);
 
         for attempt in 1..=opts.max_retries {
+            // Re-delivering something the agent already answered is not a
+            // harmless retry: the second copy is a second invocation the
+            // runtime has to reject.
+            if answered() {
+                return Ok(());
+            }
             // Clear any leftover input from a prior attempt. No-op on the
             // first attempt against a fresh widget.
             let _ = self.send_keys(session, "C-u");
@@ -560,6 +586,7 @@ impl TmuxClient {
                 &content_before,
                 opts.verify_timeout,
                 opts.poll_interval,
+                answered,
             ) {
                 return Ok(());
             }
@@ -622,9 +649,16 @@ impl TmuxClient {
         content_before: &str,
         timeout: Duration,
         poll_interval: Duration,
+        answered: &dyn Fn() -> bool,
     ) -> bool {
         let start = Instant::now();
         while start.elapsed() < timeout {
+            // An agent that acted on the paste before the submit drew its
+            // output before `content_before` was taken, so there is no change
+            // left for Enter to cause. It answered: the prompt arrived.
+            if answered() {
+                return true;
+            }
             if let Ok(current) = self.get_pane_activity(session) {
                 if current > activity_before {
                     return true;
@@ -1833,6 +1867,87 @@ mod tests {
         assert_eq!(
             begins_id, ends_id,
             "start and end sentinel UUIDs must match"
+        );
+    }
+
+    /// An agent that answers during the paste still counts as delivered.
+    ///
+    /// A line-oriented agent acts on the prompt before Enter, so its output is
+    /// already in the pre-Enter snapshot and Enter changes nothing. Judging by
+    /// the pane alone, that is indistinguishable from a prompt that never
+    /// arrived — and the retry it provoked re-delivered an invocation the agent
+    /// had already answered, which the runtime then rejected, failing a run
+    /// whose work was done.
+    #[test]
+    fn an_answered_prompt_is_delivered_even_if_the_pane_does_not_change() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let session = "omar-test-answered-delivery";
+        let _ = tmux_command()
+            .args(["kill-session", "-t", session])
+            .output();
+        let _guard = SessionGuard(session.to_string());
+
+        // `cat` into nothing: it swallows the paste and prints nothing back, so
+        // pressing Enter leaves the pane exactly as it was. A shell would echo
+        // a fresh prompt and hide the very case under test.
+        let ok = tmux_command()
+            .args(["new-session", "-d", "-s", session, "cat > /dev/null"])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            eprintln!("Skipping test: failed to create tmux session");
+            return;
+        }
+
+        let client = TmuxClient::new("omar-test-");
+        let opts = DeliveryOptions {
+            startup_timeout: Duration::from_secs(3),
+            stable_quiet: Duration::from_millis(200),
+            verify_timeout: Duration::from_millis(600),
+            max_retries: 3,
+            poll_interval: Duration::from_millis(50),
+            retry_delay: Duration::from_millis(50),
+            require_initial_change: false,
+        };
+
+        // Nothing to go on but the pane: the delivery cannot be confirmed, and
+        // every attempt pastes the prompt again.
+        let blind = client.deliver_prompt_until(session, "OMAR ANSWERED PROBE", &opts, &|| false);
+        assert!(blind.is_err(), "a pane that never changes cannot confirm");
+        let pasted = client
+            .capture_pane_plain(session, 400)
+            .unwrap_or_default()
+            .matches("OMAR ANSWERED PROBE")
+            .count();
+        assert!(
+            pasted > 1,
+            "expected the blind delivery to retry, saw {pasted} paste(s)"
+        );
+
+        // Told the agent answered, the same delivery succeeds without a second
+        // copy — which is the part that matters, since re-delivering is what
+        // the runtime rejects.
+        let _ = tmux_command()
+            .args(["kill-session", "-t", session])
+            .output();
+        let _ = tmux_command()
+            .args(["new-session", "-d", "-s", session, "cat > /dev/null"])
+            .status();
+        let answered = client.deliver_prompt_until(session, "OMAR ANSWERED PROBE", &opts, &|| true);
+        assert!(answered.is_ok(), "an answered prompt was delivered");
+        let pasted = client
+            .capture_pane_plain(session, 400)
+            .unwrap_or_default()
+            .matches("OMAR ANSWERED PROBE")
+            .count();
+        assert!(
+            pasted <= 1,
+            "an answered prompt must not be delivered twice, saw {pasted}"
         );
     }
 

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -510,6 +510,23 @@ impl InvocationRegistry {
         }
     }
 
+    /// Whether this invocation has already been answered.
+    ///
+    /// Delivery needs this because an agent that reads its pane a line at a
+    /// time answers before the submit, leaving the terminal with no change to
+    /// show for it. An entry that has gone counts as answered: there is
+    /// nothing left to deliver to either way.
+    fn answered(&self, invocation_id: &str) -> bool {
+        match self.entries.lock() {
+            Ok(entries) => entries
+                .get(invocation_id)
+                .is_none_or(|entry| entry.record.completed),
+            // A poisoned lock is not evidence of an answer, and claiming one
+            // would turn a lost delivery into a silent hang.
+            Err(_) => false,
+        }
+    }
+
     fn execute(&self, team: &str, agent: &str, command: InvocationCommand) -> Result<Value> {
         let mut entries = self
             .entries
@@ -913,7 +930,9 @@ impl ReactionExecutor for TmuxReactionExecutor {
         let session = self.client.session_for(&invocation.agent);
         if let Err(error) = self
             .client
-            .deliver_prompt(&session, &message, &DeliveryOptions::default())
+            .deliver_prompt_until(&session, &message, &DeliveryOptions::default(), &|| {
+                self.registry.answered(&invocation_id)
+            })
             .with_context(|| format!("failed to deliver {}", invocation.reaction_id))
         {
             self.registry.remove(&invocation_id);


### PR DESCRIPTION
Fixes Mission Control's `conformance` job, which has failed on **every** main run since mission-control#5. It is skipped on PRs, so nothing gated on it and it went unnoticed.

## What was happening

The conformance suite's real run with stub agents ended `run_failed`:

```
failed to deliver flow.reaction.0: prompt delivery to
'…-flow_writer' was not verified after 3 attempt(s)
```

The invocation had actually been answered. The agent's pane shows it plainly — the answer is printed on the *same line* as the end sentinel, before Enter was ever sent:

```
1:OMAR stub agent ready: StubFlow/flow.writer
2:<UserPromptBegins:815b239a>
14:<UserPromptEnds:815b239a>stub agent answered bc9b5b2e-…
16:<UserPromptBegins:815b239a>
28:<UserPromptEnds:815b239a>stub agent could not answer: … 'bc9b5b2e-…' is already complete
30:<UserPromptBegins:815b239a>
42:<UserPromptEnds:815b239a>stub agent could not answer: … 'bc9b5b2e-…' is already complete
```

`deliver_prompt` proves delivery by snapshotting the pane, pressing Enter, and waiting for a change. That is right for a TUI backend, which does nothing until Enter. A line-oriented agent is different: the invocation's fields end at a blank line, so it answers while the paste is still arriving. Its output is already in the pre-Enter snapshot, Enter changes nothing, and the check reports failure.

The retries then re-delivered an invocation that was already complete — the runtime rejected each one — and the run failed with its work done.

## The fix

The pane cannot distinguish "the prompt never arrived" from "the prompt arrived and was already handled", and those need opposite responses. So the caller supplies the evidence the terminal does not have: `deliver_prompt_until` takes an `answered` predicate, checked before each attempt and while waiting for the post-Enter change. `TmuxReactionExecutor` answers it from the invocation registry.

`deliver_prompt` keeps its signature and behaviour — the five other call sites are untouched.

## Verification

- New test `an_answered_prompt_is_delivered_even_if_the_pane_does_not_change`, against a `cat > /dev/null` pane that genuinely does not change after Enter. It asserts the blind delivery retries and fails, and that an answered one succeeds **without a second paste** — re-delivery being what the runtime rejects. Removing the fix makes it fail.
- Conformance goes 11/12 → **12/12** locally (`OMAR_BIN`/`OMARC_BIN` against this branch).
- A probe run now shows one delivery, one answer, `completed` with no error.
- Full suite green: 364 tests, `cargo clippy --all-targets -- -D warnings` clean.