### PR TITLE
Add timers to the language, the VM and the diagram protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,8 @@ jobs:
                       ), (path, keys)
                   if instruction["op"] == "declare_instance":
                       assert keys == ["op", "name", "team"], (path, keys)
+                  if instruction["op"] == "declare_timer":
+                      assert keys == ["op", "instance", "name", "offset", "period"], (path, keys)
                   # Every member names the container it belongs to, so a client
                   # never has to infer the grouping from a dotted name.
                   if instruction["op"] in ("spawn_agent", "define_port", "install_reaction"):

--- a/GrandTest.omar
+++ b/GrandTest.omar
@@ -1,0 +1,512 @@
+// GrandTest - large runtime stress test.
+// Self-contained: no repo, no filesystem, no network. Every prompt is word-capped
+// so the topology, not the token count, is the load.
+//
+// 37 agents, 53 cross-instance edges, every agent on the Claude Code backend:
+//
+//   Coordinator --> 16 Explorers --> 8 Aggregators --> 4 SectorLeads --> Synthesizer
+//                                                                            |
+//                                                                            v
+//   Closer(3 agents) <-- Coordinator <-- 4 Adversaries <----------------------+
+//                             |
+//                             +--> back to the 16 Explorers for another round
+//
+// Exercises: 16-way fan-out, three staged fan-in levels (2->1 three times over),
+// a 4-input barrier, a 4-way barrier that closes a bounded cycle, one agent
+// carrying two prompts with memory between them, alternative effects deciding
+// loop-vs-finish, and a three-agent team wired internally with `action` ports.
+
+team Coordinator[agent : Claude]
+{
+    input  topic      : string
+    input  max_rounds : int
+
+    input  red    : string  // the four adversary reports, closing the cycle
+    input  blue   : string
+    input  black  : string
+    input  yellow : string
+
+    output spec   : string  // coordinator -> all 16 explorers
+    output report : string  // coordinator -> closer, once converged
+
+    // ---- seed round 1 -------------------------------------------------------
+    prompt agent(topic, max_rounds) -> spec
+    "
+        You are the Coordinator of a 37-agent test run. Topic: $(topic).
+        The run lasts at most $(max_rounds) rounds. Remember that cap.
+
+        Set `spec` to a brief for sixteen parallel explorers containing:
+          - the line `TOPIC: $(topic)`
+          - the line `ROUND: 1 of $(max_rounds)`
+          - two sentences framing the problem
+          - sixteen numbered angles, one per explorer, each one short sentence
+          - the line `SETTLED SO FAR: none`
+        Under 400 words. Do not solve the problem yourself.
+    "
+
+    // ---- merge the adversaries, then loop or finish --------------------------
+    prompt agent(red, blue, black, yellow) -> (spec | report)
+    "
+        The four adversaries have reported on this round's synthesis.
+
+        Feasibility: $(red)
+        Coherence:   $(blue)
+        Risk:        $(black)
+        Evidence:    $(yellow)
+
+        You wrote the previous brief, so you know the topic, the round number and
+        the cap. Merge these verdicts into your running list of settled points.
+
+        Set exactly one effect.
+
+        Set `spec` for another round if at least one adversary raised something
+        unsettled AND the round number is still below the cap. It repeats the
+        `TOPIC:` line, gives `ROUND: <n> of <cap>` incremented, restates
+        `SETTLED SO FAR:` in full so the explorers do not redo settled work, and
+        gives sixteen numbered angles aimed at what is still open. Under 450 words.
+
+        Otherwise set `report`, because the run converged or hit the cap: the
+        topic, a one-paragraph conclusion, the settled points, the open questions,
+        and the number of rounds that ran. Under 400 words.
+    "
+}
+
+// ---- sixteen explorers, differing only in index and lens --------------------
+
+team ExplorerC(idx : int, lens : string)[agent : Claude]
+{
+    input  spec : string
+    output note : string
+
+    prompt agent(spec) -> note
+    "
+        $(spec)
+
+        You are Explorer $(idx). Work angle $(idx) only, through the lens of
+        $(lens). Ignore anything the brief lists as settled. Set `note` to a
+        section titled `Explorer $(idx) - $(lens)` with at most four bullets, each
+        a concrete claim rather than a topic heading. Under 150 words.
+    "
+}
+
+team ExplorerX(idx : int, lens : string)[agent : Claude]
+{
+    input  spec : string
+    output note : string
+
+    prompt agent(spec) -> note
+    "
+        $(spec)
+
+        You are Explorer $(idx). Work angle $(idx) only, through the lens of
+        $(lens). Ignore anything the brief lists as settled. Set `note` to a
+        section titled `Explorer $(idx) - $(lens)` with at most four bullets, each
+        a concrete claim rather than a topic heading. Under 150 words.
+    "
+}
+
+team ExplorerU(idx : int, lens : string)[agent : Claude]
+{
+    input  spec : string
+    output note : string
+
+    prompt agent(spec) -> note
+    "
+        $(spec)
+
+        You are Explorer $(idx). Work angle $(idx) only, through the lens of
+        $(lens). Ignore anything the brief lists as settled. Set `note` to a
+        section titled `Explorer $(idx) - $(lens)` with at most four bullets, each
+        a concrete claim rather than a topic heading. Under 150 words.
+    "
+}
+
+team ExplorerO(idx : int, lens : string)[agent : Claude]
+{
+    input  spec : string
+    output note : string
+
+    prompt agent(spec) -> note
+    "
+        $(spec)
+
+        You are Explorer $(idx). Work angle $(idx) only, through the lens of
+        $(lens). Ignore anything the brief lists as settled. Set `note` to a
+        section titled `Explorer $(idx) - $(lens)` with at most four bullets, each
+        a concrete claim rather than a topic heading. Under 150 words.
+    "
+}
+
+// ---- eight aggregators, each a 2-input barrier ------------------------------
+
+team AggregatorA(band : string)[agent : Claude]
+{
+    input  n1     : string
+    input  n2     : string
+    output digest : string
+
+    prompt agent(n1, n2) -> digest
+    "
+        You are the $(band) aggregator. Two explorers reported:
+
+        A) $(n1)
+        B) $(n2)
+
+        Merge them into one section titled `$(band)`. Drop duplicates, keep every
+        distinct claim, and mark any place where the two disagree with the word
+        CONFLICT. Under 150 words. Do not add claims of your own.
+    "
+}
+
+team AggregatorB(band : string)[agent : Claude]
+{
+    input  n1     : string
+    input  n2     : string
+    output digest : string
+
+    prompt agent(n1, n2) -> digest
+    "
+        You are the $(band) aggregator. Two explorers reported:
+
+        A) $(n1)
+        B) $(n2)
+
+        Merge them into one section titled `$(band)`. Drop duplicates, keep every
+        distinct claim, and mark any place where the two disagree with the word
+        CONFLICT. Under 150 words. Do not add claims of your own.
+    "
+}
+
+team AggregatorU(band : string)[agent : Claude]
+{
+    input  n1     : string
+    input  n2     : string
+    output digest : string
+
+    prompt agent(n1, n2) -> digest
+    "
+        You are the $(band) aggregator. Two explorers reported:
+
+        A) $(n1)
+        B) $(n2)
+
+        Merge them into one section titled `$(band)`. Drop duplicates, keep every
+        distinct claim, and mark any place where the two disagree with the word
+        CONFLICT. Under 150 words. Do not add claims of your own.
+    "
+}
+
+team AggregatorO(band : string)[agent : Claude]
+{
+    input  n1     : string
+    input  n2     : string
+    output digest : string
+
+    prompt agent(n1, n2) -> digest
+    "
+        You are the $(band) aggregator. Two explorers reported:
+
+        A) $(n1)
+        B) $(n2)
+
+        Merge them into one section titled `$(band)`. Drop duplicates, keep every
+        distinct claim, and mark any place where the two disagree with the word
+        CONFLICT. Under 150 words. Do not add claims of your own.
+    "
+}
+
+// ---- four sector leads, a second 2-input barrier level -----------------------
+
+team SectorLeadA(sector : string)[agent : Claude]
+{
+    input  d1     : string
+    input  d2     : string
+    output sector_view : string
+
+    prompt agent(d1, d2) -> sector_view
+    "
+        You lead the $(sector) sector. Two aggregated digests arrived together:
+
+        1) $(d1)
+        2) $(d2)
+
+        Set `sector_view` to a section titled `SECTOR: $(sector)` holding the
+        three strongest claims across both digests, then a line headed
+        `CONFLICTS:` listing every CONFLICT still unresolved, or `CONFLICTS: none`.
+        Under 180 words. Do not introduce material that is not above.
+    "
+}
+
+team SectorLeadB(sector : string)[agent : Claude]
+{
+    input  d1     : string
+    input  d2     : string
+    output sector_view : string
+
+    prompt agent(d1, d2) -> sector_view
+    "
+        You lead the $(sector) sector. Two aggregated digests arrived together:
+
+        1) $(d1)
+        2) $(d2)
+
+        Set `sector_view` to a section titled `SECTOR: $(sector)` holding the
+        three strongest claims across both digests, then a line headed
+        `CONFLICTS:` listing every CONFLICT still unresolved, or `CONFLICTS: none`.
+        Under 180 words. Do not introduce material that is not above.
+    "
+}
+
+// ---- the 4-input barrier -----------------------------------------------------
+
+team Synthesizer[agent : Claude]
+{
+    input  s1        : string
+    input  s2        : string
+    input  s3        : string
+    input  s4        : string
+    output synthesis : string
+
+    prompt agent(s1, s2, s3, s4) -> synthesis
+    "
+        Four sector leads reported at the same tag. Merge all four into one
+        coherent position.
+
+        1) $(s1)
+        2) $(s2)
+        3) $(s3)
+        4) $(s4)
+
+        Set `synthesis` to: a one-paragraph position, then the supporting points
+        grouped by theme, then a list headed `UNRESOLVED:` naming every conflict
+        you could not settle. Under 350 words.
+    "
+}
+
+// ---- four adversaries, one lens each ----------------------------------------
+
+team AdversaryX[agent : Claude]
+{
+    input  synthesis : string
+    output finding   : string
+
+    prompt agent(synthesis) -> finding
+    "
+        $(synthesis)
+
+        Attack this synthesis on FEASIBILITY only: what it assumes is available,
+        what it would cost, what it cannot actually be built out of. Set `finding`
+        to a numbered list, each entry one sentence naming the problem plus one
+        sentence on what breaks. If nothing survives your scrutiny, set `finding`
+        to exactly `NONE`. Under 150 words.
+    "
+}
+
+team AdversaryY[agent : Claude]
+{
+    input  synthesis : string
+    output finding   : string
+
+    prompt agent(synthesis) -> finding
+    "
+        $(synthesis)
+
+        Attack this synthesis on COHERENCE only: internal contradictions, claims
+        that do not follow, vagueness standing in for a decision, and anything in
+        UNRESOLVED that was quietly dropped. Set `finding` to a numbered list, each
+        entry one sentence naming the problem plus one sentence on what breaks. If
+        you find nothing, set `finding` to exactly `NONE`. Under 150 words.
+    "
+}
+
+team AdversaryZ[agent : Claude]
+{
+    input  synthesis : string
+    output finding   : string
+
+    prompt agent(synthesis) -> finding
+    "
+        $(synthesis)
+
+        Attack this synthesis on RISK only: how it fails under load, under abuse,
+        or when an assumption turns out false, and what it would take to notice.
+        Set `finding` to a numbered list, each entry one sentence naming the risk
+        plus one sentence on the failure it produces. If you find nothing, set
+        `finding` to exactly `NONE`. Under 150 words.
+    "
+}
+
+team AdversaryW[agent : Claude]
+{
+    input  synthesis : string
+    output finding   : string
+
+    prompt agent(synthesis) -> finding
+    "
+        $(synthesis)
+
+        Attack this synthesis on EVIDENCE only: which claims are asserted without
+        support, which would change if one unstated assumption were false, and
+        what observation would settle each. Set `finding` to a numbered list, each
+        entry one sentence naming the unsupported claim plus one sentence on the
+        check that would settle it. If you find nothing, set `finding` to exactly
+        `NONE`. Under 150 words.
+    "
+}
+
+// ---- terminal sink: one team, three agents, wired with internal actions -------
+
+team Closer[editor : Claude, checker : Claude, publisher : Claude]
+{
+    input  report  : string
+    output summary : string
+
+    action draft   : string
+    action verdict : string
+
+    prompt editor(report) -> draft
+    "
+        $(report)
+
+        Rewrite this for someone who watched the run but read none of it: what the
+        question was, what the run concluded, what is still open, and how many
+        rounds it took. Plain prose, under 250 words. Set `draft`. Add nothing that
+        is not in the report above.
+    "
+
+    prompt checker(draft) -> verdict
+    "
+        A draft summary of the run:
+
+        $(draft)
+
+        Check it for claims stated more confidently than a test run can support,
+        and for anything an outside reader would not understand without the run.
+        Set `verdict` to at most five short corrections, or exactly `OK` if there
+        is nothing to fix. Under 120 words.
+    "
+
+    prompt publisher(draft, verdict) -> summary
+    "
+        Draft:   $(draft)
+        Verdict: $(verdict)
+
+        Apply the corrections and set `summary` to the final text: plain prose,
+        under 250 words, no headings, no bullet lists. If the verdict is `OK`,
+        pass the draft through with only light copy-editing.
+    "
+}
+
+main GrandTest {
+    coord = Coordinator()
+
+    // 16 explorers
+    e1  = ExplorerC(1,  "first principles")
+    e2  = ExplorerC(2,  "prior art")
+    e3  = ExplorerC(3,  "definitions and scope")
+    e4  = ExplorerC(4,  "counterexamples")
+    e5  = ExplorerX(5,  "mechanism and cost")
+    e6  = ExplorerX(6,  "failure modes")
+    e7  = ExplorerX(7,  "implementation path")
+    e8  = ExplorerX(8,  "dependencies")
+    e9  = ExplorerU(9,  "the user's day")
+    e10 = ExplorerU(10, "adoption and incentives")
+    e11 = ExplorerU(11, "who is excluded")
+    e12 = ExplorerU(12, "competing alternatives")
+    e13 = ExplorerO(13, "measurement")
+    e14 = ExplorerO(14, "second-order effects")
+    e15 = ExplorerO(15, "time horizon")
+    e16 = ExplorerO(16, "what would falsify it")
+
+    // 8 aggregators
+    g1 = AggregatorA("Foundations")
+    g2 = AggregatorB("Boundaries")
+    g3 = AggregatorU("Mechanics")
+    g4 = AggregatorO("Dependencies")
+    g5 = AggregatorA("People")
+    g6 = AggregatorB("Alternatives")
+    g7 = AggregatorU("Evidence")
+    g8 = AggregatorO("Consequences")
+
+    // 4 sector leads
+    lead1 = SectorLeadA("Theory")
+    lead2 = SectorLeadB("Build")
+    lead3 = SectorLeadA("Adoption")
+    lead4 = SectorLeadB("Proof")
+
+    syn = Synthesizer()
+
+    ax = AdversaryX()
+    ay = AdversaryY()
+    az = AdversaryZ()
+    aw = AdversaryW()
+
+    close = Closer()
+
+    // fan out: one brief, sixteen explorers
+    coord.spec -> e1.spec
+    coord.spec -> e2.spec
+    coord.spec -> e3.spec
+    coord.spec -> e4.spec
+    coord.spec -> e5.spec
+    coord.spec -> e6.spec
+    coord.spec -> e7.spec
+    coord.spec -> e8.spec
+    coord.spec -> e9.spec
+    coord.spec -> e10.spec
+    coord.spec -> e11.spec
+    coord.spec -> e12.spec
+    coord.spec -> e13.spec
+    coord.spec -> e14.spec
+    coord.spec -> e15.spec
+    coord.spec -> e16.spec
+
+    // fan-in level 1: sixteen notes, eight 2-input barriers
+    e1.note  -> g1.n1
+    e2.note  -> g1.n2
+    e3.note  -> g2.n1
+    e4.note  -> g2.n2
+    e5.note  -> g3.n1
+    e6.note  -> g3.n2
+    e7.note  -> g4.n1
+    e8.note  -> g4.n2
+    e9.note  -> g5.n1
+    e10.note -> g5.n2
+    e11.note -> g6.n1
+    e12.note -> g6.n2
+    e13.note -> g7.n1
+    e14.note -> g7.n2
+    e15.note -> g8.n1
+    e16.note -> g8.n2
+
+    // fan-in level 2: eight digests, four 2-input barriers
+    g1.digest -> lead1.d1
+    g2.digest -> lead1.d2
+    g3.digest -> lead2.d1
+    g4.digest -> lead2.d2
+    g5.digest -> lead3.d1
+    g6.digest -> lead3.d2
+    g7.digest -> lead4.d1
+    g8.digest -> lead4.d2
+
+    // fan-in level 3: four sector views, one 4-input barrier
+    lead1.sector_view -> syn.s1
+    lead2.sector_view -> syn.s2
+    lead3.sector_view -> syn.s3
+    lead4.sector_view -> syn.s4
+
+    // fan out again into four adversaries
+    syn.synthesis -> ax.synthesis
+    syn.synthesis -> ay.synthesis
+    syn.synthesis -> az.synthesis
+    syn.synthesis -> aw.synthesis
+
+    // 4-way barrier closes the cycle back at the coordinator
+    ax.finding -> coord.red
+    ay.finding -> coord.blue
+    az.finding -> coord.black
+    aw.finding -> coord.yellow
+
+    // and out
+    coord.report -> close.report
+}

--- a/lang/Omar/Compiler.lean
+++ b/lang/Omar/Compiler.lean
@@ -88,6 +88,19 @@ structure Port where
   instance_ : String := ""
   deriving Repr
 
+/-- `timer t(offset, period)`.
+
+    A trigger that fires from the runtime's own clock rather than from another
+    reaction. `period = 0` fires once, at `offset`; a non-zero period re-arms
+    it forever. Both are logical time, the same unit an action's `delay` and a
+    connection's `after` are counted in. -/
+structure Timer where
+  name : String
+  offset : Nat
+  period : Nat
+  instance_ : String := ""
+  deriving Repr
+
 structure Connection where
   source : String
   target : String
@@ -124,6 +137,7 @@ structure TeamDecl where
   params : Array Param
   agents : Array Agent
   ports : Array Port
+  timers : Array Timer
   connections : Array Connection
   reactions : Array Reaction
   deriving Repr
@@ -168,6 +182,7 @@ structure Program where
   instances : Array InstanceDecl
   agents : Array Agent
   ports : Array Port
+  timers : Array Timer
   connections : Array Connection
   reactions : Array Reaction
   deriving Repr
@@ -290,34 +305,44 @@ private def parseActionDelay : Parser (Option Nat)
 private partial def parseDeclarations
     (reactionIndex : Nat)
     (ports : Array Port)
+    (timers : Array Timer)
     (connections : Array Connection)
     (reactions : Array Reaction) :
-    List Token -> Except String (Array Port × Array Connection × Array Reaction × List Token)
-  | Token.sym "}" :: rest => pure (ports, connections, reactions, rest)
+    List Token ->
+      Except String (Array Port × Array Timer × Array Connection × Array Reaction × List Token)
+  | Token.sym "}" :: rest => pure (ports, timers, connections, reactions, rest)
   | Token.word "input" :: rest => do
       let (name, rest) ← word rest
       let (_, rest) ← expectSym ":" rest
       let (type, rest) ← parseType rest
-      parseDeclarations reactionIndex (ports.push { name, kind := .input, type }) connections reactions rest
+      parseDeclarations reactionIndex (ports.push { name, kind := .input, type }) timers connections reactions rest
   | Token.word "output" :: rest => do
       let (name, rest) ← word rest
       let (_, rest) ← expectSym ":" rest
       let (type, rest) ← parseType rest
-      parseDeclarations reactionIndex (ports.push { name, kind := .output, type }) connections reactions rest
+      parseDeclarations reactionIndex (ports.push { name, kind := .output, type }) timers connections reactions rest
   | Token.word "action" :: rest => do
       let (name, rest) ← word rest
       let (delay, rest) ← parseActionDelay rest
       match rest with
       | Token.sym ":" :: tail =>
           let (type, tail) ← parseType tail
-          parseDeclarations reactionIndex (ports.push { name, kind := .action, type, delay }) connections reactions tail
+          parseDeclarations reactionIndex (ports.push { name, kind := .action, type, delay }) timers connections reactions tail
       | _ =>
-          parseDeclarations reactionIndex (ports.push { name, kind := .action, type := "signal", delay }) connections reactions rest
+          parseDeclarations reactionIndex (ports.push { name, kind := .action, type := "signal", delay }) timers connections reactions rest
+  | Token.word "timer" :: rest => do
+      let (name, rest) ← word rest
+      let (_, rest) ← expectSym "(" rest
+      let (offset, rest) ← natural rest
+      let (_, rest) ← expectSym "," rest
+      let (period, rest) ← natural rest
+      let (_, rest) ← expectSym ")" rest
+      parseDeclarations reactionIndex ports (timers.push { name, offset, period }) connections reactions rest
   | Token.word source :: Token.sym "->" :: rest => do
       let (target, rest) ← word rest
       let (_, rest) ← expectWord "after" rest
       let (delay, rest) ← natural rest
-      parseDeclarations reactionIndex ports (connections.push { source, target, delay }) reactions rest
+      parseDeclarations reactionIndex ports timers (connections.push { source, target, delay }) reactions rest
   | Token.word "prompt" :: rest => do
       let (agent, rest) ← word rest
       let (_, rest) ← expectSym "(" rest
@@ -330,7 +355,7 @@ private partial def parseDeclarations
         id := s!"reaction.{reactionIndex}"
         agent, triggers, effects, contract, prompt
       }
-      parseDeclarations (reactionIndex + 1) ports connections (reactions.push reaction) rest
+      parseDeclarations (reactionIndex + 1) ports timers connections (reactions.push reaction) rest
   | token :: _ => throw s!"unexpected token in team body: {reprStr token}"
   | [] => throw "unterminated team body"
 
@@ -352,8 +377,8 @@ private def parseTeam : Parser TeamDecl := fun tokens => do
         pure (agents, rest)
     | _ => pure (#[], tokens)
   let (_, tokens) ← expectSym "{" tokens
-  let (ports, connections, reactions, tokens) ← parseDeclarations 0 #[] #[] #[] tokens
-  pure ({ name, params, agents, ports, connections, reactions }, tokens)
+  let (ports, timers, connections, reactions, tokens) ← parseDeclarations 0 #[] #[] #[] #[] tokens
+  pure ({ name, params, agents, ports, timers, connections, reactions }, tokens)
 
 private def literal : Parser Literal
   | Token.nat value :: rest => pure (Literal.int value, rest)
@@ -429,17 +454,26 @@ private def validate (program : Program) : Except String Program := do
   let portNames := program.ports.map (·.name)
   let connectionNames := program.connections.map fun connection =>
     s!"{connection.source}->{connection.target}"
+  let timerNames := program.timers.map (·.name)
   ensureUnique "agent" agentNames
   ensureUnique "port" portNames
+  ensureUnique "timer" timerNames
   ensureUnique "connection" connectionNames
+  for timer in program.timers do
+    if containsName portNames timer.name then
+      throw s!"timer '{timer.name}' is also a port; a trigger has one name"
+    if timer.offset == 0 && timer.period == 0 then
+      throw s!"timer '{timer.name}' never fires; give it an offset, a period, or both"
   for reaction in program.reactions do
     if !containsName agentNames reaction.agent then
       throw s!"reaction references unknown agent '{reaction.agent}'"
     for trigger in reaction.triggers do
-      let valid := program.ports.any fun port =>
-        port.name == trigger && port.kind != .output
+      let valid := program.ports.any (fun port =>
+        port.name == trigger && port.kind != .output) || containsName timerNames trigger
       if !valid then throw s!"unknown input/action dependency '{trigger}'"
     for effect in reaction.effects do
+      if containsName timerNames effect then
+        throw s!"timer '{effect}' cannot be written to; a timer is a trigger"
       let valid := program.ports.any fun port =>
         port.name == effect && port.kind != .input
       if !valid then throw s!"unknown output/action production '{effect}'"
@@ -486,9 +520,11 @@ private def qualifyContract (inst : String) (ports : Array Port) (contract : Str
     Only the plain spelling is rewritten. `$( port )` and `$(port /* note */)`
     are accepted by the runtime but not matched here, so inside a team that
     `main` instantiates, write `$(port)`. -/
-private def qualifyPrompt (inst : String) (ports : Array Port) (text : String) : String :=
-  ports.foldl
-    (fun acc port => acc.replace s!"$({port.name})" s!"$({qualify inst port.name})")
+private def qualifyPrompt
+    (inst : String) (ports : Array Port) (timers : Array Timer) (text : String) : String :=
+  let named := ports.map (·.name) ++ timers.map (·.name)
+  named.foldl
+    (fun acc name => acc.replace s!"$({name})" s!"$({qualify inst name})")
     text
 
 private def bindArguments (decl : TeamDecl) (inst : Instance) :
@@ -505,7 +541,8 @@ private def bindArguments (decl : TeamDecl) (inst : Instance) :
     (#[] : Array (String × String))
 
 private def elaborateInstance (teams : Array TeamDecl) (inst : Instance) :
-    Except String (Array Agent × Array Port × Array Connection × Array Reaction) := do
+    Except String
+      (Array Agent × Array Port × Array Timer × Array Connection × Array Reaction) := do
   let decl ← match teams.find? (·.name == inst.team) with
     | some decl => pure decl
     | none => throw s!"instance '{inst.name}' names unknown team '{inst.team}'"
@@ -514,6 +551,8 @@ private def elaborateInstance (teams : Array TeamDecl) (inst : Instance) :
     { agent with name := qualify inst.name agent.name, instance_ := inst.name }
   let ports := decl.ports.map fun port =>
     { port with name := qualify inst.name port.name, instance_ := inst.name }
+  let timers := decl.timers.map fun timer =>
+    { timer with name := qualify inst.name timer.name, instance_ := inst.name }
   let connections := decl.connections.map fun connection =>
     { connection with
         source := qualify inst.name connection.source
@@ -526,8 +565,9 @@ private def elaborateInstance (teams : Array TeamDecl) (inst : Instance) :
         effects := reaction.effects.map (qualify inst.name)
         instance_ := inst.name
         contract := qualifyContract inst.name decl.ports reaction.contract
-        prompt := substitute bindings (qualifyPrompt inst.name decl.ports reaction.prompt) }
-  pure (agents, ports, connections, reactions)
+        prompt :=
+          substitute bindings (qualifyPrompt inst.name decl.ports decl.timers reaction.prompt) }
+  pure (agents, ports, timers, connections, reactions)
 
 private def elaborate (programName : String) (teams : Array TeamDecl) (main : Main) :
     Except String Program := do
@@ -547,8 +587,9 @@ private def elaborate (programName : String) (teams : Array TeamDecl) (main : Ma
     instances := main.instances.map fun inst => { name := inst.name, team := inst.team }
     agents := parts.foldl (fun acc part => acc ++ part.1) #[]
     ports := parts.foldl (fun acc part => acc ++ part.2.1) #[]
-    connections := parts.foldl (fun acc part => acc ++ part.2.2.1) #[] ++ wired
-    reactions := parts.foldl (fun acc part => acc ++ part.2.2.2) #[]
+    timers := parts.foldl (fun acc part => acc ++ part.2.2.1) #[]
+    connections := parts.foldl (fun acc part => acc ++ part.2.2.2.1) #[] ++ wired
+    reactions := parts.foldl (fun acc part => acc ++ part.2.2.2.2) #[]
   }
 
 /-- `programName` is the fallback when `main` is not named: the source file,
@@ -600,6 +641,13 @@ def compile (program : Program) : String :=
       | some delay => [("delay", toJson delay)]
       | none => []
     instruction "define_port" fields
+  let timers := program.timers.map fun timer =>
+    instruction "declare_timer" [
+      ("instance", toJson timer.instance_),
+      ("name", toJson timer.name),
+      ("offset", toJson timer.offset),
+      ("period", toJson timer.period)
+    ]
   let connections := program.connections.map fun connection =>
     instruction "connect_ports" [
       ("source", toJson connection.source),
@@ -618,7 +666,7 @@ def compile (program : Program) : String :=
     ]
   let commit := instruction "commit_plan"
   let instructions :=
-    #[begin] ++ instances ++ agents ++ ports ++ connections ++ reactions ++ #[commit]
+    #[begin] ++ instances ++ agents ++ ports ++ timers ++ connections ++ reactions ++ #[commit]
   let rendered := String.intercalate ",\n    " instructions.toList
   "{\n  \"version\": 1,\n  \"team\": " ++ (toJson program.team).compress ++
     ",\n  \"instructions\": [\n    " ++ rendered ++ "\n  ]\n}\n"

--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -58,6 +58,28 @@ main Relay {
 
 Inputs and outputs are then named `instance.port` — `n1.token`, `n2.out`.
 
+A reaction can also be triggered by a timer, which the runtime fires from its
+own logical clock. Nothing feeds a timer and nothing can write to it:
+
+```
+timer t(0, 10)
+```
+
+The first number is the offset of its first firing, the second its period.
+Both are logical time — the same unit an action's `delay` and a connection's
+`after` are counted in, not seconds. A period of `0` fires once and stops:
+
+```
+timer once(5, 0)
+```
+
+A non-zero period re-arms forever, so a program built on one does not finish on
+its own. Prefer `period 0` unless the operator asked for something that repeats.
+`$(t)` in a prompt reads back the time the timer fired at.
+
+A timer is what lets a program start with no input, which is otherwise
+impossible — every other trigger needs something upstream to write to it.
+
 Always name the main block, as `Relay` is named above. That name identifies the
 run in Mission Control, and the runtime lets only one run of a given name go at
 a time, so two designs sharing a name cannot run together.

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -52,6 +52,23 @@ pub struct DiagramPort {
     pub instance: String,
 }
 
+/// A trigger the runtime fires from its own clock.
+///
+/// Drawn as a clock rather than a port, because that is what it is: nothing
+/// feeds it and nothing can write to it. `last_tag` is when it last fired, so a
+/// client can show the hand where the schedule actually is rather than
+/// animating on a guess.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiagramTimer {
+    pub id: String,
+    pub name: String,
+    pub offset: u64,
+    /// `0` fires once; anything else re-arms forever.
+    pub period: u64,
+    pub last_tag: Option<DiagramTag>,
+    pub instance: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiagramReaction {
     pub id: String,
@@ -93,6 +110,9 @@ pub struct DiagramSnapshot {
     pub instances: Vec<DiagramInstance>,
     pub agents: Vec<DiagramAgent>,
     pub ports: Vec<DiagramPort>,
+    /// Empty for a program with no timer, and for bytecode that predates them.
+    #[serde(default)]
+    pub timers: Vec<DiagramTimer>,
     pub reactions: Vec<DiagramReaction>,
     pub edges: Vec<DiagramEdge>,
 }
@@ -132,6 +152,28 @@ impl DiagramSnapshot {
                 instance: port.instance.clone(),
             })
             .collect();
+        let timers = state
+            .timers
+            .iter()
+            .map(|(name, timer)| DiagramTimer {
+                id: timer_id(name),
+                name: name.clone(),
+                offset: timer.offset,
+                period: timer.period,
+                last_tag: None,
+                instance: timer.instance.clone(),
+            })
+            .collect();
+        // A trigger names either a port or a timer, and the two have separate
+        // id spaces, so which one it is has to be decided here rather than by
+        // the client pattern-matching on the name.
+        let trigger_id = |name: &String| {
+            if state.timers.contains_key(name) {
+                timer_id(name)
+            } else {
+                port_id(name)
+            }
+        };
         let reactions = state
             .reactions
             .iter()
@@ -140,7 +182,7 @@ impl DiagramSnapshot {
                 name: name.clone(),
                 agent: agent_id(&reaction.agent),
                 order: reaction.order,
-                triggers: reaction.triggers.iter().map(|name| port_id(name)).collect(),
+                triggers: reaction.triggers.iter().map(&trigger_id).collect(),
                 effects: reaction.effects.iter().map(|name| port_id(name)).collect(),
                 contract: reaction.contract.clone(),
                 status: "idle".to_string(),
@@ -163,7 +205,7 @@ impl DiagramSnapshot {
                 edges.push(DiagramEdge {
                     id: format!("trigger::{trigger}::{name}"),
                     kind: "trigger".to_string(),
-                    source: port_id(trigger),
+                    source: trigger_id(trigger),
                     target: reaction_id(name),
                     delay: 0,
                 });
@@ -187,6 +229,7 @@ impl DiagramSnapshot {
             instances,
             agents,
             ports,
+            timers,
             reactions,
             edges,
         }
@@ -301,6 +344,13 @@ impl TopologyObserver for DiagramPublisher {
                     if let Some(port) = snapshot.ports.iter_mut().find(|port| port.name == *name) {
                         port.value = Some(value.clone());
                         port.last_tag = Some(tag);
+                    }
+                    // A timer arrives in the same event map as a port; it is
+                    // the one that fired at this tag.
+                    if let Some(timer) =
+                        snapshot.timers.iter_mut().find(|timer| timer.name == *name)
+                    {
+                        timer.last_tag = Some(tag);
                     }
                 }
             },
@@ -623,16 +673,23 @@ fn reaction_id(name: &str) -> String {
     format!("reaction::{name}")
 }
 
+fn timer_id(name: &str) -> String {
+    format!("timer::{name}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::topology::{AgentState, ConnectionState, InstanceState, PortState, ReactionState};
+    use crate::topology::{
+        AgentState, ConnectionState, InstanceState, PortState, ReactionState, TimerState,
+    };
 
     fn sample_state() -> VmState {
         VmState {
             version: 1,
             team: "Sample".to_string(),
             instances: BTreeMap::new(),
+            timers: BTreeMap::new(),
             agents: BTreeMap::from([(
                 "worker".to_string(),
                 AgentState {
@@ -691,6 +748,7 @@ mod tests {
         VmState {
             version: 1,
             team: "SimpleBrief".to_string(),
+            timers: BTreeMap::new(),
             instances: BTreeMap::from([
                 (
                     "writer".to_string(),
@@ -740,6 +798,67 @@ mod tests {
                 },
             )]),
         }
+    }
+
+    #[test]
+    fn a_timer_is_carried_as_a_timer_and_not_as_a_port() {
+        // A timer shares the trigger namespace with ports but nothing else: no
+        // value feeds it and no reaction can write to it. If the snapshot gave
+        // it a port id, a client would draw it as a port and wire an inbound
+        // edge to something that can never have one.
+        let mut state = sample_state();
+        state.timers.insert(
+            "beat".to_string(),
+            TimerState {
+                offset: 0,
+                period: 10,
+                instance: String::new(),
+            },
+        );
+        state
+            .reactions
+            .get_mut("respond")
+            .expect("sample reaction")
+            .triggers = vec!["beat".to_string()];
+
+        let snapshot = DiagramSnapshot::from_vm_state(&state);
+
+        let timer = snapshot.timers.first().expect("the timer is carried");
+        assert_eq!(timer.id, "timer::beat");
+        assert_eq!((timer.offset, timer.period), (0, 10));
+        assert_eq!(timer.last_tag, None, "it has not fired yet");
+        assert!(
+            !snapshot.ports.iter().any(|port| port.name == "beat"),
+            "a timer is not also a port"
+        );
+
+        // The reaction and its edge both reach for the timer's own id.
+        assert_eq!(
+            snapshot.reactions[0].triggers,
+            vec!["timer::beat".to_string()]
+        );
+        let trigger = snapshot
+            .edges
+            .iter()
+            .find(|edge| edge.kind == "trigger")
+            .expect("the timer triggers the reaction");
+        assert_eq!(trigger.source, "timer::beat");
+
+        // Firing is what the clock face reads, so it has to survive the wire.
+        let publisher = DiagramPublisher {
+            snapshot: Arc::new(RwLock::new(snapshot)),
+            subscribers: Arc::new(Mutex::new(Vec::new())),
+            sequence: Arc::new(AtomicU64::new(0)),
+        };
+        publisher.tag_advanced(30, 0, &BTreeMap::from([("beat".into(), json!(30))]));
+        let fired = publisher.snapshot.read().expect("snapshot").clone();
+        assert_eq!(
+            fired.timers[0].last_tag,
+            Some(DiagramTag {
+                timestamp: 30,
+                microstep: 0
+            })
+        );
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1169,6 +1169,7 @@ mod tests {
             version: 1,
             team: "Sample".to_string(),
             instances: BTreeMap::new(),
+            timers: BTreeMap::new(),
             agents: BTreeMap::from([(
                 "worker".to_string(),
                 AgentState {

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -55,6 +55,14 @@ pub enum Instruction {
         #[serde(default)]
         instance: String,
     },
+    /// A trigger the runtime fires itself, from the logical clock.
+    DeclareTimer {
+        name: String,
+        offset: u64,
+        period: u64,
+        #[serde(default)]
+        instance: String,
+    },
     ConnectPorts {
         source: String,
         target: String,
@@ -107,6 +115,19 @@ pub struct PortState {
     pub instance: String,
 }
 
+/// `timer t(offset, period)`.
+///
+/// It occupies the same trigger namespace as ports but is not one: nothing can
+/// write to it, and it carries no value of its own beyond the time it fired.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimerState {
+    pub offset: u64,
+    /// `0` fires once. Anything else re-arms, forever.
+    pub period: u64,
+    #[serde(default)]
+    pub instance: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConnectionState {
     pub source: String,
@@ -133,6 +154,8 @@ pub struct VmState {
     #[serde(default)]
     pub instances: BTreeMap<String, InstanceState>,
     pub agents: BTreeMap<String, AgentState>,
+    #[serde(default)]
+    pub timers: BTreeMap<String, TimerState>,
     pub ports: BTreeMap<String, PortState>,
     pub connections: Vec<ConnectionState>,
     pub reactions: BTreeMap<String, ReactionState>,
@@ -248,6 +271,7 @@ pub fn verify(bytecode: &Bytecode) -> Result<VmState> {
         team: bytecode.team.clone(),
         instances: BTreeMap::new(),
         agents: BTreeMap::new(),
+        timers: BTreeMap::new(),
         ports: BTreeMap::new(),
         connections: Vec::new(),
         reactions: BTreeMap::new(),
@@ -339,6 +363,37 @@ pub fn verify(bytecode: &Bytecode) -> Result<VmState> {
                     bail!("duplicate port '{name}'");
                 }
             }
+            Instruction::DeclareTimer {
+                name,
+                offset,
+                period,
+                instance,
+            } => {
+                require_identifier("timer", name)?;
+                check_instance(&state, "timer", name, instance)?;
+                // Triggers are looked up by name in one namespace, so a timer
+                // that shadowed a port would silently take its reactions.
+                if state.ports.contains_key(name) {
+                    bail!("timer '{name}' is also a port; a trigger has one name");
+                }
+                if *offset == 0 && *period == 0 {
+                    bail!("timer '{name}' never fires; give it an offset, a period, or both");
+                }
+                if state
+                    .timers
+                    .insert(
+                        name.clone(),
+                        TimerState {
+                            offset: *offset,
+                            period: *period,
+                            instance: instance.clone(),
+                        },
+                    )
+                    .is_some()
+                {
+                    bail!("duplicate timer '{name}'");
+                }
+            }
             Instruction::ConnectPorts {
                 source,
                 target,
@@ -385,6 +440,9 @@ pub fn verify(bytecode: &Bytecode) -> Result<VmState> {
                     bail!("reaction '{id}' references unknown agent '{agent}'");
                 }
                 for trigger in triggers {
+                    if state.timers.contains_key(trigger) {
+                        continue;
+                    }
                     let port = state.ports.get(trigger).with_context(|| {
                         format!("reaction '{id}' has unknown trigger '{trigger}'")
                     })?;
@@ -393,6 +451,9 @@ pub fn verify(bytecode: &Bytecode) -> Result<VmState> {
                     }
                 }
                 for effect in effects {
+                    if state.timers.contains_key(effect) {
+                        bail!("reaction '{id}' cannot write to timer '{effect}'");
+                    }
                     let port = state.ports.get(effect).with_context(|| {
                         format!("reaction '{id}' has unknown effect '{effect}'")
                     })?;
@@ -1225,6 +1286,17 @@ fn run_event_loop_observed<E: ReactionExecutor>(
     observer: &dyn TopologyObserver,
 ) -> Result<BTreeMap<String, Value>> {
     let mut queue = BTreeMap::from([(Tag::START, inputs)]);
+    // Arm every timer for its first firing. A timer's value is the timestamp it
+    // fired at, which is what makes `$(t)` in a prompt worth reading.
+    for (name, timer) in &state.timers {
+        queue
+            .entry(Tag {
+                timestamp: timer.offset,
+                microstep: 0,
+            })
+            .or_default()
+            .insert(name.clone(), json!(timer.offset));
+    }
     let mut outputs = BTreeMap::new();
     let mut steps = 0usize;
 
@@ -1232,7 +1304,28 @@ fn run_event_loop_observed<E: ReactionExecutor>(
         observer.tag_advanced(tag.timestamp, tag.microstep, &events);
         steps += 1;
         if steps > 1024 {
+            // A periodic timer re-arms forever by design, so for those this is
+            // the end of the run rather than a fault: stop with what the
+            // program has produced so far.
+            if state.timers.values().any(|timer| timer.period > 0) {
+                return Ok(outputs);
+            }
             bail!("topology exceeded 1024 logical tags");
+        }
+        for (name, timer) in &state.timers {
+            if timer.period > 0 && events.contains_key(name) {
+                let next = tag
+                    .timestamp
+                    .checked_add(timer.period)
+                    .context("logical timestamp overflow")?;
+                queue
+                    .entry(Tag {
+                        timestamp: next,
+                        microstep: 0,
+                    })
+                    .or_default()
+                    .insert(name.clone(), json!(next));
+            }
         }
         for (name, value) in &events {
             if state
@@ -1686,6 +1779,7 @@ mod tests {
             version: 1,
             team: "HR".into(),
             instances: BTreeMap::new(),
+            timers: BTreeMap::new(),
             agents: BTreeMap::from([
                 (
                     "manager".into(),
@@ -1952,6 +2046,117 @@ mod tests {
         let error = verify(&bytecode).unwrap_err().to_string();
 
         assert!(error.contains("same tmux session"), "{error}");
+    }
+
+    /// Records the tag every invocation arrived at, so a timer's schedule can
+    /// be read off the run rather than inferred from its outputs.
+    struct TimerExecutor {
+        fired: Mutex<Vec<u64>>,
+    }
+
+    impl ReactionExecutor for TimerExecutor {
+        fn invoke(&self, invocation: InvocationSpec) -> Result<BTreeMap<String, Value>> {
+            let at = invocation
+                .trigger_values
+                .values()
+                .next()
+                .and_then(Value::as_u64)
+                .expect("a timer carries the time it fired at");
+            self.fired.lock().unwrap().push(at);
+            let writes = BTreeMap::from([("note".into(), json!("tick"))]);
+            validate_contract(&invocation.contract, &writes)?;
+            Ok(writes)
+        }
+    }
+
+    fn timer_bytecode(offset: u64, period: u64) -> Bytecode {
+        serde_json::from_str(&format!(
+            r#"{{
+              "version": 1,
+              "team": "Poller",
+              "instructions": [
+                {{"op":"begin_plan","team":"Poller"}},
+                {{"op":"spawn_agent","name":"agent","backend":"Codex"}},
+                {{"op":"define_port","kind":"output","name":"note","type":"string"}},
+                {{"op":"declare_timer","name":"t","offset":{offset},"period":{period}}},
+                {{"op":"install_reaction","id":"reaction.0","agent":"agent","triggers":["t"],"effects":["note"],"contract":"note","prompt":"tick at $(t)"}},
+                {{"op":"commit_plan"}}
+              ]
+            }}"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn a_timer_with_no_period_fires_once_at_its_offset() {
+        let state = verify(&timer_bytecode(3, 0)).unwrap();
+        let executor = TimerExecutor {
+            fired: Mutex::new(Vec::new()),
+        };
+
+        let outputs = run_event_loop(&state, BTreeMap::new(), &executor).unwrap();
+
+        // Once, at the offset — not at tag 0, and not again afterwards.
+        assert_eq!(*executor.fired.lock().unwrap(), vec![3]);
+        assert_eq!(outputs, BTreeMap::from([("note".into(), json!("tick"))]));
+    }
+
+    #[test]
+    fn a_periodic_timer_re_arms_itself_at_every_period() {
+        let state = verify(&timer_bytecode(0, 10)).unwrap();
+        let executor = TimerExecutor {
+            fired: Mutex::new(Vec::new()),
+        };
+
+        // A periodic timer never stops on its own, so the run ends at the tag
+        // cap rather than failing: what it produced up to then still stands.
+        let outputs = run_event_loop(&state, BTreeMap::new(), &executor).unwrap();
+
+        let fired = executor.fired.lock().unwrap().clone();
+        assert_eq!(&fired[..4], &[0, 10, 20, 30], "fired at {fired:?}");
+        assert!(
+            fired.len() > 100,
+            "a periodic timer keeps going: {}",
+            fired.len()
+        );
+        assert_eq!(outputs, BTreeMap::from([("note".into(), json!("tick"))]));
+    }
+
+    #[test]
+    fn a_timer_cannot_share_a_name_with_a_port_or_be_written_to() {
+        let shadowing: Bytecode = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "team": "Clash",
+              "instructions": [
+                {"op":"begin_plan","team":"Clash"},
+                {"op":"define_port","kind":"input","name":"t","type":"int"},
+                {"op":"declare_timer","name":"t","offset":1,"period":0},
+                {"op":"commit_plan"}
+              ]
+            }"#,
+        )
+        .unwrap();
+        let error = verify(&shadowing).unwrap_err().to_string();
+        assert!(error.contains("a trigger has one name"), "{error}");
+
+        let written: Bytecode = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "team": "Written",
+              "instructions": [
+                {"op":"begin_plan","team":"Written"},
+                {"op":"spawn_agent","name":"agent","backend":"Codex"},
+                {"op":"define_port","kind":"input","name":"go","type":"int"},
+                {"op":"declare_timer","name":"t","offset":1,"period":0},
+                {"op":"install_reaction","id":"reaction.0","agent":"agent","triggers":["go"],"effects":["t"],"contract":"t","prompt":"x"},
+                {"op":"commit_plan"}
+              ]
+            }"#,
+        )
+        .unwrap();
+        let error = verify(&written).unwrap_err().to_string();
+        assert!(error.contains("cannot write to timer"), "{error}");
     }
 
     struct SuperdenseExecutor {

--- a/tests/topology/run_local.sh
+++ b/tests/topology/run_local.sh
@@ -294,6 +294,8 @@ run_case Recurrence Recurrence rec.result --input rec.start=0
 # Three instances wired into a ring. Only the seed is supplied; the other two
 # inputs come off the ring itself.
 run_case Ring Ring n1.done --input n1.token=0
+# No --input: a timer is the only thing that starts this one.
+run_case Timer Timer beacon.note
 run_case SameAgentSerial SameAgentSerial serial.result \
   --input serial.request='serialize these reactions'
 run_case SuperdenseTime SuperdenseTime time.fixed_result,time.connected_result \

--- a/tests/topology/src/Timer.omar
+++ b/tests/topology/src/Timer.omar
@@ -1,0 +1,22 @@
+// OMAR topology integration source.
+// Exercises a timer: a trigger the runtime fires from its own logical clock
+// rather than from another reaction. The program takes no input at all — the
+// timer is what starts it, which is the point.
+//
+// The period is 0, so it fires once, at logical time 5. A non-zero period
+// re-arms forever and has no place in a test that must finish.
+team Beacon(label : string)[agent : Codex]
+{
+    timer t(5, 0)
+    output note : string
+
+    prompt agent(t) -> note
+    "
+        The $(label) timer fired at logical time $(t).
+        Set `note` to exactly: fired at $(t)
+    "
+}
+
+main Timer {
+    beacon = Beacon("beacon")
+}


### PR DESCRIPTION
```
timer t(0, 10)
prompt agent(t) -> out "..."
```

A trigger the runtime fires from its own clock rather than from another reaction — the Lingua Franca feature, in OMAR's spelling.

## Semantics

The first number is the offset of the first firing, the second the period. Both are **logical time**, the same unit an action's `delay` and a connection's `after` already use — not seconds. `period = 0` fires once and stops. `$(t)` in a prompt reads back the tag it fired at.

A timer is what lets a program start with **no input at all**, which nothing else could do: every other trigger needs something upstream to write to it. `tests/topology/src/Timer.omar` is the first integration case that runs with no `--input`.

Timers share the trigger namespace with ports but are not ports — nothing can write to one, and one cannot shadow a port. Both are rejected in the compiler and again in the VM, since bytecode also arrives from elsewhere.

A periodic timer never stops on its own, so a program built on one ends at the existing 1024-tag cap. For those that is the end of the run rather than a fault, and the outputs produced up to then stand; a program with no periodic timer still fails on the cap exactly as before.

## The protocol

Timers are carried as their own kind with their own id space (`timer::name`), so a client is never left deciding whether a trigger names a port or a timer by pattern-matching. `last_tag` says when it last fired. Both fields are `#[serde(default)]`, so older bytecode and older clients are unaffected.

## Verification

- `a_timer_with_no_period_fires_once_at_its_offset` — once, at the offset, not at tag 0 and not again.
- `a_periodic_timer_re_arms_itself_at_every_period` — fires at 0, 10, 20, 30, keeps going past 100 firings, and ends cleanly at the cap.
- `a_timer_cannot_share_a_name_with_a_port_or_be_written_to` — both rejections.
- `a_timer_is_carried_as_a_timer_and_not_as_a_port` — id space, no phantom port, trigger edge sourced at the timer, and `last_tag` surviving a live `tag_advanced`.
- `tests/topology/src/Timer.omar`, registered in `run_local.sh` with no `--input`.

End to end against a real `omar serve`: the one-shot program reaches `completed` with no error, and a periodic one reports `last_tag` climbing 0, 10, 20 … 710 over six seconds with the reaction's trigger reading `timer::beacon.t`.

318 unit tests, `cargo clippy --all-targets -- -D warnings` clean, `lake build` clean.

Client side: omar-os/mission-control#17.