### PR TITLE
Let a team instantiate another team

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
                           ["op", "instance", "kind", "name", "type", "delay"],
                       ), (path, keys)
                   if instruction["op"] == "declare_instance":
-                      assert keys == ["op", "name", "team"], (path, keys)
+                      assert keys == ["op", "name", "parent", "team"], (path, keys)
                   if instruction["op"] == "declare_timer":
                       assert keys == ["op", "instance", "name", "offset", "period"], (path, keys)
                   # Every member names the container it belongs to, so a client

--- a/lang/Omar/Compiler.lean
+++ b/lang/Omar/Compiler.lean
@@ -61,7 +61,7 @@ private partial def lexChars : List Char -> Except String (List Token)
         match value.toNat? with
         | some value => do pure (Token.nat value :: (← lexChars tail))
         | none => throw s!"invalid natural number '{value}'"
-      else if "(),:{}?|=<>[].".contains c then
+      else if "(),;:{}?|=<>[].".contains c then
         do pure (Token.sym c.toString :: (← lexChars rest))
       else
         throw s!"unexpected character '{c}'"
@@ -130,6 +130,12 @@ inductive Literal where
   | str : String -> Literal
   deriving Repr, BEq
 
+structure Instance where
+  name : String
+  team : String
+  args : Array Literal
+  deriving Repr
+
 /-- A team as written: a template, which `main` instantiates. A team is never
     the program itself — that is what `main` is for. -/
 structure TeamDecl where
@@ -140,12 +146,10 @@ structure TeamDecl where
   timers : Array Timer
   connections : Array Connection
   reactions : Array Reaction
-  deriving Repr
-
-structure Instance where
-  name : String
-  team : String
-  args : Array Literal
+  /-- Teams this one instantiates. A team is a template, so instantiating one
+      inside another nests the template rather than sharing it: `b.a.out` is
+      not `c.a.out`. -/
+  instances : Array Instance := #[]
   deriving Repr
 
 /-- `a.out -> b.in after 1`. Ends are qualified by instance, so unlike a
@@ -171,6 +175,8 @@ structure Main where
 structure InstanceDecl where
   name : String
   team : String
+  /-- The instance that declared it, or empty for one `main` declared. -/
+  parent : String := ""
   deriving Repr
 
 /-- The elaborated program. Names are flattened into one namespace because that
@@ -286,14 +292,38 @@ private partial def takeContract (acc : List Token) : List Token -> Except Strin
   | Token.text prompt :: rest => pure (acc.reverse, prompt, rest)
   | token :: rest => takeContract (token :: acc) rest
 
+/-- `port`, or `instance.port` written as one dotted name. -/
+private def qualifiedTail (head : String) : Parser String
+  | Token.sym "." :: rest => do
+      let (member, rest) ← word rest
+      pure (s!"{head}.{member}", rest)
+  | tokens => pure (head, tokens)
+
 private partial def parseDependencies (acc : Array String) : Parser (Array String)
   | Token.sym ")" :: rest => pure (acc, rest)
   | tokens => do
       let (name, tokens) ← word tokens
+      -- `refine.out` reads a contained instance's output, which is how a team
+      -- observes what it instantiated.
+      let (name, tokens) ← qualifiedTail name tokens
       match tokens with
       | Token.sym "," :: rest => parseDependencies (acc.push name) rest
       | Token.sym ")" :: rest => pure (acc.push name, rest)
       | _ => throw "expected ',' or ')' in prompt dependencies"
+
+private def literal : Parser Literal
+  | Token.nat value :: rest => pure (Literal.int value, rest)
+  | Token.text value :: rest => pure (Literal.str value, rest)
+  | tokens => throw s!"expected an int or string argument, found {reprStr tokens.head?}"
+
+private partial def parseArgs (acc : Array Literal) : Parser (Array Literal)
+  | Token.sym ")" :: rest => pure (acc, rest)
+  | tokens => do
+      let (value, tokens) ← literal tokens
+      match tokens with
+      | Token.sym "," :: rest => parseArgs (acc.push value) rest
+      | Token.sym ")" :: rest => pure (acc.push value, rest)
+      | _ => throw "expected ',' or ')' in team arguments"
 
 private def parseActionDelay : Parser (Option Nat)
   | Token.sym "(" :: Token.word "delay" :: Token.sym "=" :: rest => do
@@ -307,29 +337,36 @@ private partial def parseDeclarations
     (ports : Array Port)
     (timers : Array Timer)
     (connections : Array Connection)
-    (reactions : Array Reaction) :
+    (reactions : Array Reaction)
+    (instances : Array Instance) :
     List Token ->
-      Except String (Array Port × Array Timer × Array Connection × Array Reaction × List Token)
-  | Token.sym "}" :: rest => pure (ports, timers, connections, reactions, rest)
+      Except String
+        (Array Port × Array Timer × Array Connection × Array Reaction × Array Instance ×
+          List Token)
+  | Token.sym "}" :: rest => pure (ports, timers, connections, reactions, instances, rest)
+  -- `a = A();` ends with an optional semicolon; it separates declarations and
+  -- means nothing else.
+  | Token.sym ";" :: rest =>
+      parseDeclarations reactionIndex ports timers connections reactions instances rest
   | Token.word "input" :: rest => do
       let (name, rest) ← word rest
       let (_, rest) ← expectSym ":" rest
       let (type, rest) ← parseType rest
-      parseDeclarations reactionIndex (ports.push { name, kind := .input, type }) timers connections reactions rest
+      parseDeclarations reactionIndex (ports.push { name, kind := .input, type }) timers connections reactions instances rest
   | Token.word "output" :: rest => do
       let (name, rest) ← word rest
       let (_, rest) ← expectSym ":" rest
       let (type, rest) ← parseType rest
-      parseDeclarations reactionIndex (ports.push { name, kind := .output, type }) timers connections reactions rest
+      parseDeclarations reactionIndex (ports.push { name, kind := .output, type }) timers connections reactions instances rest
   | Token.word "action" :: rest => do
       let (name, rest) ← word rest
       let (delay, rest) ← parseActionDelay rest
       match rest with
       | Token.sym ":" :: tail =>
           let (type, tail) ← parseType tail
-          parseDeclarations reactionIndex (ports.push { name, kind := .action, type, delay }) timers connections reactions tail
+          parseDeclarations reactionIndex (ports.push { name, kind := .action, type, delay }) timers connections reactions instances tail
       | _ =>
-          parseDeclarations reactionIndex (ports.push { name, kind := .action, type := "signal", delay }) timers connections reactions rest
+          parseDeclarations reactionIndex (ports.push { name, kind := .action, type := "signal", delay }) timers connections reactions instances rest
   | Token.word "timer" :: rest => do
       let (name, rest) ← word rest
       let (_, rest) ← expectSym "(" rest
@@ -337,12 +374,13 @@ private partial def parseDeclarations
       let (_, rest) ← expectSym "," rest
       let (period, rest) ← natural rest
       let (_, rest) ← expectSym ")" rest
-      parseDeclarations reactionIndex ports (timers.push { name, offset, period }) connections reactions rest
-  | Token.word source :: Token.sym "->" :: rest => do
-      let (target, rest) ← word rest
-      let (_, rest) ← expectWord "after" rest
-      let (delay, rest) ← natural rest
-      parseDeclarations reactionIndex ports timers (connections.push { source, target, delay }) reactions rest
+      parseDeclarations reactionIndex ports (timers.push { name, offset, period }) connections reactions instances rest
+  | Token.word name :: Token.sym "=" :: rest => do
+      let (team, rest) ← word rest
+      let (_, rest) ← expectSym "(" rest
+      let (args, rest) ← parseArgs #[] rest
+      parseDeclarations reactionIndex ports timers connections reactions
+        (instances.push { name, team, args }) rest
   | Token.word "prompt" :: rest => do
       let (agent, rest) ← word rest
       let (_, rest) ← expectSym "(" rest
@@ -355,7 +393,21 @@ private partial def parseDeclarations
         id := s!"reaction.{reactionIndex}"
         agent, triggers, effects, contract, prompt
       }
-      parseDeclarations (reactionIndex + 1) ports timers connections (reactions.push reaction) rest
+      parseDeclarations (reactionIndex + 1) ports timers connections (reactions.push reaction) instances rest
+  | Token.word first :: rest => do
+      -- An endpoint is either a port of this team or `instance.port` of one it
+      -- instantiated. Both are one name once the instance path is prepended,
+      -- so the dot is kept rather than resolved here.
+      let (source, rest) ← qualifiedTail first rest
+      let (_, rest) ← expectSym "->" rest
+      let (target, rest) ← word rest
+      let (target, rest) ← qualifiedTail target rest
+      -- `after` is optional, matching main: a connection with no delay still
+      -- lands on the next microstep.
+      let (delay, rest) ← match rest with
+        | Token.word "after" :: tail => natural tail
+        | _ => pure (0, rest)
+      parseDeclarations reactionIndex ports timers (connections.push { source, target, delay }) reactions instances rest
   | token :: _ => throw s!"unexpected token in team body: {reprStr token}"
   | [] => throw "unterminated team body"
 
@@ -377,22 +429,9 @@ private def parseTeam : Parser TeamDecl := fun tokens => do
         pure (agents, rest)
     | _ => pure (#[], tokens)
   let (_, tokens) ← expectSym "{" tokens
-  let (ports, timers, connections, reactions, tokens) ← parseDeclarations 0 #[] #[] #[] #[] tokens
-  pure ({ name, params, agents, ports, timers, connections, reactions }, tokens)
-
-private def literal : Parser Literal
-  | Token.nat value :: rest => pure (Literal.int value, rest)
-  | Token.text value :: rest => pure (Literal.str value, rest)
-  | tokens => throw s!"expected an int or string argument, found {reprStr tokens.head?}"
-
-private partial def parseArgs (acc : Array Literal) : Parser (Array Literal)
-  | Token.sym ")" :: rest => pure (acc, rest)
-  | tokens => do
-      let (value, tokens) ← literal tokens
-      match tokens with
-      | Token.sym "," :: rest => parseArgs (acc.push value) rest
-      | Token.sym ")" :: rest => pure (acc.push value, rest)
-      | _ => throw "expected ',' or ')' in team arguments"
+  let (ports, timers, connections, reactions, instances, tokens) ←
+    parseDeclarations 0 #[] #[] #[] #[] #[] tokens
+  pure ({ name, params, agents, ports, timers, connections, reactions, instances }, tokens)
 
 private partial def parseMainBody
     (instances : Array Instance)
@@ -468,8 +507,13 @@ private def validate (program : Program) : Except String Program := do
     if !containsName agentNames reaction.agent then
       throw s!"reaction references unknown agent '{reaction.agent}'"
     for trigger in reaction.triggers do
+      -- A reaction reads its own team's inputs and actions, and the *outputs*
+      -- of teams its team instantiated. Reading its own output would be
+      -- reading what it is there to write.
       let valid := program.ports.any (fun port =>
-        port.name == trigger && port.kind != .output) || containsName timerNames trigger
+        port.name == trigger &&
+          (port.kind != .output || port.instance_ != reaction.instance_)) ||
+        containsName timerNames trigger
       if !valid then throw s!"unknown input/action dependency '{trigger}'"
     for effect in reaction.effects do
       if containsName timerNames effect then
@@ -521,8 +565,9 @@ private def qualifyContract (inst : String) (ports : Array Port) (contract : Str
     are accepted by the runtime but not matched here, so inside a team that
     `main` instantiates, write `$(port)`. -/
 private def qualifyPrompt
-    (inst : String) (ports : Array Port) (timers : Array Timer) (text : String) : String :=
-  let named := ports.map (·.name) ++ timers.map (·.name)
+    (inst : String) (ports : Array Port) (timers : Array Timer) (reads : Array String)
+    (text : String) : String :=
+  let named := ports.map (·.name) ++ timers.map (·.name) ++ reads
   named.foldl
     (fun acc name => acc.replace s!"$({name})" s!"$({qualify inst name})")
     text
@@ -540,34 +585,77 @@ private def bindArguments (decl : TeamDecl) (inst : Instance) :
       pure (acc.push (param.name, literalText arg)))
     (#[] : Array (String × String))
 
-private def elaborateInstance (teams : Array TeamDecl) (inst : Instance) :
-    Except String
-      (Array Agent × Array Port × Array Timer × Array Connection × Array Reaction) := do
+/-- Everything one instantiation contributes, its nested instantiations
+    included. -/
+structure Elaborated where
+  agents : Array Agent := #[]
+  ports : Array Port := #[]
+  timers : Array Timer := #[]
+  connections : Array Connection := #[]
+  reactions : Array Reaction := #[]
+  instances : Array InstanceDecl := #[]
+
+private def Elaborated.append (a b : Elaborated) : Elaborated :=
+  { agents := a.agents ++ b.agents
+    ports := a.ports ++ b.ports
+    timers := a.timers ++ b.timers
+    connections := a.connections ++ b.connections
+    reactions := a.reactions ++ b.reactions
+    instances := a.instances ++ b.instances }
+
+/-- How deep teams may nest.
+
+    A team that instantiates itself, directly or through another, describes an
+    infinite program. Nothing else in the language recurses, so rather than
+    tracking the path this stops at a depth no honest program reaches and says
+    what it suspects. -/
+private def maxNesting : Nat := 32
+
+private partial def elaborateInstance
+    (teams : Array TeamDecl) (depth : Nat) (parent : String) (inst : Instance) :
+    Except String Elaborated := do
+  if depth > maxNesting then
+    throw s!"team instantiation nests more than {maxNesting} deep at '{inst.name}'; \
+      is a team instantiating itself?"
   let decl ← match teams.find? (·.name == inst.team) with
     | some decl => pure decl
     | none => throw s!"instance '{inst.name}' names unknown team '{inst.team}'"
   let bindings ← bindArguments decl inst
+  -- The path from `main` down to here. Qualifying by it rather than by the
+  -- instance's own name is the whole of nesting: `b.a.out` and `c.a.out` are
+  -- different ports of different copies of the same team.
+  let path := if parent.isEmpty then inst.name else s!"{parent}.{inst.name}"
+  ensureUnique "instance" (decl.instances.map (·.name))
   let agents := decl.agents.map fun agent =>
-    { agent with name := qualify inst.name agent.name, instance_ := inst.name }
+    { agent with name := qualify path agent.name, instance_ := path }
   let ports := decl.ports.map fun port =>
-    { port with name := qualify inst.name port.name, instance_ := inst.name }
+    { port with name := qualify path port.name, instance_ := path }
   let timers := decl.timers.map fun timer =>
-    { timer with name := qualify inst.name timer.name, instance_ := inst.name }
+    { timer with name := qualify path timer.name, instance_ := path }
+  -- An endpoint written `a.out` is already the nested instance's local name,
+  -- so prefixing the path is all it takes to reach `b.a.out`.
   let connections := decl.connections.map fun connection =>
     { connection with
-        source := qualify inst.name connection.source
-        target := qualify inst.name connection.target }
+        source := qualify path connection.source
+        target := qualify path connection.target }
   let reactions := decl.reactions.map fun reaction =>
     { reaction with
-        id := qualify inst.name reaction.id
-        agent := qualify inst.name reaction.agent
-        triggers := reaction.triggers.map (qualify inst.name)
-        effects := reaction.effects.map (qualify inst.name)
-        instance_ := inst.name
-        contract := qualifyContract inst.name decl.ports reaction.contract
+        id := qualify path reaction.id
+        agent := qualify path reaction.agent
+        triggers := reaction.triggers.map (qualify path)
+        effects := reaction.effects.map (qualify path)
+        instance_ := path
+        contract := qualifyContract path decl.ports reaction.contract
         prompt :=
-          substitute bindings (qualifyPrompt inst.name decl.ports decl.timers reaction.prompt) }
-  pure (agents, ports, timers, connections, reactions)
+          substitute bindings
+            (qualifyPrompt path decl.ports decl.timers reaction.triggers reaction.prompt) }
+  let own : Elaborated :=
+    { agents, ports, timers, connections, reactions
+      instances := #[{ name := path, team := inst.team, parent }] }
+  decl.instances.foldlM
+    (fun acc nested => do
+      pure (acc.append (← elaborateInstance teams (depth + 1) path nested)))
+    own
 
 private def elaborate (programName : String) (teams : Array TeamDecl) (main : Main) :
     Except String Program := do
@@ -577,19 +665,20 @@ private def elaborate (programName : String) (teams : Array TeamDecl) (main : Ma
     for side in #[connection.sourceInstance, connection.targetInstance] do
       if !containsName instanceNames side then
         throw s!"main connection names unknown instance '{side}'"
-  let parts ← main.instances.mapM (elaborateInstance teams)
+  let parts ← main.instances.mapM (elaborateInstance teams 0 "")
   let wired := main.connections.map fun connection =>
     { source := qualify connection.sourceInstance connection.sourcePort
       target := qualify connection.targetInstance connection.targetPort
       delay := connection.delay : Connection }
+  let whole := parts.foldl Elaborated.append {}
   pure {
     team := programName
-    instances := main.instances.map fun inst => { name := inst.name, team := inst.team }
-    agents := parts.foldl (fun acc part => acc ++ part.1) #[]
-    ports := parts.foldl (fun acc part => acc ++ part.2.1) #[]
-    timers := parts.foldl (fun acc part => acc ++ part.2.2.1) #[]
-    connections := parts.foldl (fun acc part => acc ++ part.2.2.2.1) #[] ++ wired
-    reactions := parts.foldl (fun acc part => acc ++ part.2.2.2.2) #[]
+    instances := whole.instances
+    agents := whole.agents
+    ports := whole.ports
+    timers := whole.timers
+    connections := whole.connections ++ wired
+    reactions := whole.reactions
   }
 
 /-- `programName` is the fallback when `main` is not named: the source file,
@@ -623,6 +712,7 @@ def compile (program : Program) : String :=
   let instances := program.instances.map fun inst =>
     instruction "declare_instance" [
       ("name", toJson inst.name),
+      ("parent", toJson inst.parent),
       ("team", toJson inst.team)
     ]
   let agents := program.agents.map fun agent =>

--- a/prompts/executive-assistant.md
+++ b/prompts/executive-assistant.md
@@ -80,6 +80,41 @@ its own. Prefer `period 0` unless the operator asked for something that repeats.
 A timer is what lets a program start with no input, which is otherwise
 impossible — every other trigger needs something upstream to write to it.
 
+A team can also instantiate another team, so teams nest:
+
+```
+team Stage(role : string)[worker : Codex]
+{
+    input inp : string
+    output out : string
+
+    prompt worker(inp) -> out "You are the $(role) stage. Got $(inp)."
+}
+
+team Pipeline[reporter : Codex]
+{
+    input brief : string
+    output summary : string
+
+    draft = Stage("draft");
+    refine = Stage("refine");
+
+    brief -> draft.inp
+    draft.out -> refine.inp
+
+    prompt reporter(refine.out) -> summary "Report $(refine.out)."
+}
+```
+
+Inside a team, reach what it instantiated as `instance.port` — the same
+spelling `main` uses. A reaction may read a contained instance's *output*
+(`reporter(refine.out)`), which is how a team observes what it contains; to
+send data the other way, connect to the contained input (`brief -> draft.inp`).
+Reach a nested port from outside with the full path: `run.draft.out`.
+
+Nest when it makes a program clearer — a team that is used twice is worth
+naming once — not for its own sake.
+
 Always name the main block, as `Relay` is named above. That name identifies the
 run in Mission Control, and the runtime lets only one run of a given name go at
 a time, so two designs sharing a name cannot run together.

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -37,6 +37,13 @@ pub struct DiagramInstance {
     pub name: String,
     /// The team it was instantiated from.
     pub team: String,
+    /// The container this one is drawn inside, or empty for a top-level one.
+    ///
+    /// A team can instantiate another team, so containers nest. The id is
+    /// given rather than the name so a client never has to re-derive one from
+    /// the other.
+    #[serde(default)]
+    pub parent: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -126,6 +133,11 @@ impl DiagramSnapshot {
                 id: instance_id(name),
                 name: name.clone(),
                 team: instance.team.clone(),
+                parent: if instance.parent.is_empty() {
+                    String::new()
+                } else {
+                    instance_id(&instance.parent)
+                },
             })
             .collect();
         let agents = state
@@ -754,12 +766,14 @@ mod tests {
                     "writer".to_string(),
                     InstanceState {
                         team: "Drafter".to_string(),
+                        parent: String::new(),
                     },
                 ),
                 (
                     "reviewer".to_string(),
                     InstanceState {
                         team: "Reviewer".to_string(),
+                        parent: String::new(),
                     },
                 ),
             ]),

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -38,6 +38,9 @@ pub enum Instruction {
     DeclareInstance {
         name: String,
         team: String,
+        /// The instance that declared it, empty for one `main` declared.
+        #[serde(default)]
+        parent: String,
     },
     SpawnAgent {
         name: String,
@@ -102,6 +105,10 @@ pub struct AgentState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceState {
     pub team: String,
+    /// Which instance declared it. Empty for a top-level one, and for bytecode
+    /// that predates teams being able to instantiate teams.
+    #[serde(default)]
+    pub parent: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -285,14 +292,25 @@ pub fn verify(bytecode: &Bytecode) -> Result<VmState> {
         match instruction {
             Instruction::BeginPlan { .. } if index == 0 => {}
             Instruction::BeginPlan { .. } => bail!("duplicate begin_plan at instruction {index}"),
-            Instruction::DeclareInstance { name, team } => {
+            Instruction::DeclareInstance { name, team, parent } => {
                 require_identifier("instance", name)?;
                 if team.trim().is_empty() {
                     bail!("instance '{name}' names no team");
                 }
+                // A parent is declared before its children, so this also
+                // rejects a cycle: neither end could be declared first.
+                if !parent.is_empty() && !state.instances.contains_key(parent) {
+                    bail!("instance '{name}' names undeclared parent '{parent}'");
+                }
                 if state
                     .instances
-                    .insert(name.clone(), InstanceState { team: team.clone() })
+                    .insert(
+                        name.clone(),
+                        InstanceState {
+                            team: team.clone(),
+                            parent: parent.clone(),
+                        },
+                    )
                     .is_some()
                 {
                     bail!("duplicate instance '{name}'");
@@ -446,7 +464,10 @@ pub fn verify(bytecode: &Bytecode) -> Result<VmState> {
                     let port = state.ports.get(trigger).with_context(|| {
                         format!("reaction '{id}' has unknown trigger '{trigger}'")
                     })?;
-                    if port.kind == PortKind::Output {
+                    // A reaction may read the output of a team its own team
+                    // instantiated — that is how a parent observes what it
+                    // contains. Its own output is what it is there to write.
+                    if port.kind == PortKind::Output && port.instance == *instance {
                         bail!("reaction '{id}' cannot be triggered by output '{trigger}'");
                     }
                 }
@@ -2046,6 +2067,53 @@ mod tests {
         let error = verify(&bytecode).unwrap_err().to_string();
 
         assert!(error.contains("same tmux session"), "{error}");
+    }
+
+    #[test]
+    fn a_nested_instance_names_the_instance_that_declared_it() {
+        // A team can instantiate another team, so instances form a tree rather
+        // than a list. The VM keeps one flat namespace, so the tree only
+        // survives if each instance says who declared it.
+        let bytecode: Bytecode = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "team": "Nest",
+              "instructions": [
+                {"op":"begin_plan","team":"Nest"},
+                {"op":"declare_instance","name":"b","team":"B","parent":""},
+                {"op":"declare_instance","name":"b.a","team":"A","parent":"b"},
+                {"op":"spawn_agent","name":"b.a.agent","backend":"Codex","instance":"b.a"},
+                {"op":"define_port","kind":"input","name":"b.a.inp","type":"int","instance":"b.a"},
+                {"op":"define_port","kind":"output","name":"b.done","type":"int","instance":"b"},
+                {"op":"install_reaction","id":"b.a.reaction.0","agent":"b.a.agent","triggers":["b.a.inp"],"effects":["b.done"],"contract":"b.done","prompt":"x","instance":"b.a"},
+                {"op":"commit_plan"}
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        let state = verify(&bytecode).unwrap();
+
+        assert_eq!(state.instances["b"].parent, "");
+        assert_eq!(state.instances["b.a"].parent, "b");
+        assert_eq!(state.instances["b.a"].team, "A");
+
+        // A parent has to exist. Since one is always declared before its
+        // children, this also rules out a cycle: neither end could come first.
+        let orphan: Bytecode = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "team": "Orphan",
+              "instructions": [
+                {"op":"begin_plan","team":"Orphan"},
+                {"op":"declare_instance","name":"b.a","team":"A","parent":"b"},
+                {"op":"commit_plan"}
+              ]
+            }"#,
+        )
+        .unwrap();
+        let error = verify(&orphan).unwrap_err().to_string();
+        assert!(error.contains("undeclared parent 'b'"), "{error}");
     }
 
     /// Records the tag every invocation arrived at, so a timer's schedule can

--- a/tests/topology/run_local.sh
+++ b/tests/topology/run_local.sh
@@ -294,6 +294,8 @@ run_case Recurrence Recurrence rec.result --input rec.start=0
 # Three instances wired into a ring. Only the seed is supplied; the other two
 # inputs come off the ring itself.
 run_case Ring Ring n1.done --input n1.token=0
+# A team instantiating teams: two nested Stage instances inside one Pipeline.
+run_case Nested Nested run.summary --input run.brief='hierarchy'
 # No --input: a timer is the only thing that starts this one.
 run_case Timer Timer beacon.note
 run_case SameAgentSerial SameAgentSerial serial.result \

--- a/tests/topology/src/Nested.omar
+++ b/tests/topology/src/Nested.omar
@@ -1,0 +1,39 @@
+// OMAR topology integration source.
+// Exercises hierarchy: a team instantiating another team, so containers nest.
+//
+// `Pipeline` knows nothing about how `Stage` does its work, and `Stage` knows
+// nothing about being nested. The wiring inside `Pipeline` reaches its own
+// instances by name — `refine.inp` — the same spelling `main` uses.
+team Stage(role : string)[worker : Codex]
+{
+    input inp : string
+    output out : string
+
+    prompt worker(inp) -> out
+    "
+        You are the $(role) stage. The text you received is: $(inp)
+        Set `out` to that text with the word $(role) appended.
+    "
+}
+
+team Pipeline[reporter : Codex]
+{
+    input brief : string
+    output summary : string
+
+    draft = Stage("draft");
+    refine = Stage("refine");
+
+    brief -> draft.inp
+    draft.out -> refine.inp
+
+    prompt reporter(refine.out) -> summary
+    "
+        The pipeline produced: $(refine.out)
+        Set `summary` to exactly that text.
+    "
+}
+
+main Nested {
+    run = Pipeline()
+}


### PR DESCRIPTION
```
team A[agent : Claude] {
  input inp : int
  output out : int
  prompt agent(inp) -> out "..."
}

team B[another : Codex] {
  a = A();
}
```

Teams were templates only `main` could instantiate, so every program was exactly one level deep. A team can now instantiate teams of its own.

## How it works

Instantiating is still a renaming — only now the name is a **path**. Elaboration qualifies by the whole chain from `main` down, so `b.a.out` and `c.a.out` are different ports of different copies of one team. The VM's namespace stays flat and knows nothing about nesting; what it gains is a `parent` on each instance, so the tree survives into the diagram instead of being re-derived by splitting names on `.`.

Inside a team, reach what it instantiated as `instance.port` — the spelling `main` already used:

```
brief -> draft.inp
draft.out -> refine.inp
prompt reporter(refine.out) -> summary "..."
```

A reaction may read a **contained instance's output**, as in Lingua Franca. That is how a team observes what it contains, and it is the one case where a reaction reads an output rather than writing it — reading its *own* output is still rejected. Data goes the other way through a connection to a contained input.

`;` now lexes, as a declaration separator and nothing else, because that is how the feature was asked for.

## Termination

A team that instantiated itself would describe an infinite program. The compiler stops at 32 levels and says what it suspects; the VM rejects it independently, since a parent is declared before its children and neither end of a cycle can be declared first.

## Verification

- `a_nested_instance_names_the_instance_that_declared_it` — the tree survives `verify`, and an unknown parent is rejected.
- `tests/topology/src/Nested.omar`, registered in `run_local.sh`: a `Pipeline` instantiating two `Stage`s, with the parent reading `refine.out`.

End to end against a real `omar serve`: the program compiles to `run` / `run.draft` / `run.refine` with parents `""` / `run` / `run`, wires `run.brief -> run.draft.inp` and `run.draft.out -> run.refine.inp`, and the run reaches `completed` with no error.

319 unit tests, clippy clean, `lake build` clean.

Client side: omar-os/mission-control#18.