### PR TITLE
Check the backend a source declared, not one the corpus agreed on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,31 @@ jobs:
           echo "$output"
           grep -Fq 'Output run.result = "hello"' <<<"$output"
 
-      - name: Check bytecode layout and Codex-only test agents
+      - name: Check bytecode layout and declared agent backends
         run: |
           python3 - <<'PY'
           import glob
           import json
           import os
+          import re
+
+          # `[name : Backend, other : Backend]` on a team. A port's type is
+          # lowercase (`inp : string`), so naming the backends keeps ports out.
+          BACKENDS = "ClaudeCode|Claude|Codex|Cursor|OpenCode|Agy|Stub"
+          declaration = re.compile(rf"\b(\w+)\s*:\s*({BACKENDS})\b")
+
+          def declared_backends(name):
+              """Agent name -> the backends its source gives it.
+
+              A set: two teams may reuse a local agent name, and instantiating
+              qualifies it by a path the source itself never spells.
+              """
+              with open(f"tests/topology/src/{name}.omar", encoding="utf-8") as source:
+                  text = source.read()
+              declared = {}
+              for agent, backend in declaration.findall(text):
+                  declared.setdefault(agent, set()).add(backend)
+              return declared
 
           field_rank = {
               "op": 0, "instance": 1, "kind": 2, "name": 3, "type": 4,
@@ -154,6 +173,8 @@ jobs:
           for path in bytecodes:
               with open(path) as file:
                   bytecode = json.load(file)
+              declared = declared_backends(os.path.basename(path)[: -len(".json")])
+              assert declared, (path, "source declares no agent")
               for instruction in bytecode["instructions"]:
                   keys = list(instruction)
                   assert keys[0] == "op", (path, keys)
@@ -176,8 +197,16 @@ jobs:
                       assert keys == connection_order, (path, keys)
                   if instruction["op"] == "install_reaction":
                       assert keys == reaction_order, (path, keys)
-                  if os.path.basename(path) != "HR.json" and instruction["op"] == "spawn_agent":
-                      assert instruction["backend"] == "Codex", (path, instruction)
+                  # A program picks its own backends; what CI pins is that the
+                  # bytecode spawns the one its source asked for. Instantiating
+                  # qualifies an agent by its instance path, so the declaration
+                  # is found under the last segment.
+                  if instruction["op"] == "spawn_agent":
+                      local = instruction["name"].rsplit(".", 1)[-1]
+                      assert local in declared, (path, instruction)
+                      assert instruction["backend"] in declared[local], (
+                          path, instruction, sorted(declared[local])
+                      )
           PY
 
   popup-quote-integration:

--- a/src/omar.rs
+++ b/src/omar.rs
@@ -144,8 +144,10 @@ enum Commands {
         /// OMAR source program
         program: PathBuf,
 
-        /// External input in NAME=VALUE form; repeat for multiple inputs
-        #[arg(long = "input", required = true)]
+        /// External input in NAME=VALUE form; repeat for multiple inputs.
+        /// A timer-driven program takes none, and the runtime still rejects a
+        /// missing one by name, so requiring it here only blocked those.
+        #[arg(long = "input")]
         inputs: Vec<String>,
 
         /// Replace existing agent sessions with topology-scoped sessions

--- a/tests/topology/README.md
+++ b/tests/topology/README.md
@@ -1,7 +1,9 @@
 # OMAR topology integration corpus
 
-The `.omar` sources live in `tests/topology/src/`. Every scenario except the
-heterogeneous `HR.omar` uses Codex for every agent. CI performs login-free
+The `.omar` sources live in `tests/topology/src/`. Each picks its own backends;
+CI checks that the bytecode spawns the backend its source declared, not that
+every source agrees on one. Most use Codex, and running the whole corpus needs
+every backend it names installed and authenticated. CI performs login-free
 compiler and Rust VM dry-run checks on every pull request. The authenticated
 suite runs from trusted branches and can also be invoked locally.
 
@@ -22,6 +24,13 @@ Coverage:
   additive connection delay, and chronological delivery.
 - `HR.omar`: the heterogeneous hiring example using Claude and Codex.
 - `HRCodex.omar`: the original hiring example using Codex for every role.
+- `Cadence.omar`: one-shot timers opening three rounds and a deadline, with a
+  chair whose four prompts share one agent memory. Claude Code.
+- `Bureau.omar`: four levels of containment and 32 agents — the heaviest case
+  here. Claude Code.
+- `Heartbeat.omar`: a periodic timer driving a program that never finishes.
+  Compiled and checked, never run: `run_local.sh` waits for a completion
+  marker this program does not produce.
 
 Every program declares its teams and then instantiates them in a `main` block,
 so ports are named `instance.port` and each program takes its source file's

--- a/tests/topology/run_local.sh
+++ b/tests/topology/run_local.sh
@@ -298,10 +298,18 @@ run_case Ring Ring n1.done --input n1.token=0
 run_case Nested Nested run.summary --input run.brief='hierarchy'
 # No --input: a timer is the only thing that starts this one.
 run_case Timer Timer beacon.note
+# Four one-shot timers opening three rounds and a deadline, on Claude Code.
+run_case Cadence Cadence chair.report
+# Four levels of containment and 32 agents: the heaviest case in the corpus.
+run_case Bureau Bureau audit.ruling \
+  --input bureau.topic='Whether on-device LLM inference will displace cloud APIs as the default for consumer applications within three years'
 run_case SameAgentSerial SameAgentSerial serial.result \
   --input serial.request='serialize these reactions'
 run_case SuperdenseTime SuperdenseTime time.fixed_result,time.connected_result \
   --input time.start=7
+# `Heartbeat` is deliberately absent: its timer has a non-zero period, so the
+# program never finishes and has no completion marker to wait for. It is
+# compiled and checked like every other source, just never run here.
 
 if ((passed_cases + failed_cases == 0)); then
   printf 'No topology case named %s\n' "$case_filter" >&2

--- a/tests/topology/src/Bureau.omar
+++ b/tests/topology/src/Bureau.omar
@@ -1,0 +1,182 @@
+// A hierarchy four levels deep: main -> Bureau -> Division -> Cell -> Analyst.
+// Every level speaks only to its own children: a team hands work down through a
+// connection to a contained input, and observes what came back by reading a
+// contained output. Nothing reaches past one level, so the containers are real
+// structure rather than decoration.
+//
+// 32 agents. Self-contained: every agent answers from its own knowledge and is
+// told not to browse, read files, or run commands.
+
+team Analyst(lens : string)[analyst : ClaudeCode]
+{
+    input brief : string
+    output finding : string
+
+    prompt analyst(brief) -> finding
+    "
+        You are an analyst working the $(lens) angle. Answer from your own
+        knowledge: do not browse the web, read files, or run commands.
+
+        The brief you were handed: $(brief)
+
+        Set `finding` to at most 80 words — the two or three things the $(lens)
+        angle says about this brief, each stated as a claim someone could argue
+        with. No preamble.
+    "
+}
+
+team Cell(charter : string)[lead : ClaudeCode]
+{
+    input assignment : string
+    output report : string
+
+    evidence = Analyst("supporting evidence");
+    counter = Analyst("counter-evidence");
+    ripple = Analyst("second-order effects");
+
+    assignment -> evidence.brief
+    assignment -> counter.brief
+    assignment -> ripple.brief
+
+    prompt lead(evidence.finding, counter.finding, ripple.finding) -> report
+    "
+        You lead the $(charter) cell. Three analysts worked the same assignment
+        from different angles.
+
+        Supporting evidence: $(evidence.finding)
+        Counter-evidence: $(counter.finding)
+        Second-order effects: $(ripple.finding)
+
+        Set `report` to at most 100 words — what the three agree on, where they
+        genuinely conflict, and the one claim this cell would stake its name on.
+        Do not browse or run commands.
+    "
+}
+
+team Division(mission : string)[director : ClaudeCode]
+{
+    input mandate : string
+    output brief : string
+    action probe_task : string
+    action stress_task : string
+
+    probe = Cell("probe");
+    stress = Cell("stress");
+
+    prompt director(mandate) -> probe_task, stress_task
+    "
+        You direct the $(mission) division. Your mandate: $(mandate)
+
+        Split it into two assignments of at most 40 words each for two cells that
+        must not duplicate each other's work.
+        Set `probe_task` to the assignment that establishes what is true.
+        Set `stress_task` to the assignment that tries to break it.
+        Answer from your own knowledge; do not browse or run commands.
+    "
+
+    probe_task -> probe.assignment
+    stress_task -> stress.assignment
+
+    prompt director(probe.report, stress.report) -> brief
+    "
+        Both of your cells have reported on the $(mission) mandate.
+
+        Probe cell: $(probe.report)
+        Stress cell: $(stress.report)
+
+        Set `brief` to at most 120 words — the division's position on the
+        $(mission) question, the strongest objection to that position, and your
+        confidence in it (low, medium, or high) with one line of why.
+    "
+}
+
+team Bureau[chief : ClaudeCode, editor : ClaudeCode]
+{
+    input topic : string
+    output dossier : string
+    action markets_mandate : string
+    action tech_mandate : string
+    action risk_mandate : string
+
+    d_markets = Division("markets");
+    d_tech = Division("technology");
+    d_risk = Division("risk");
+
+    prompt chief(topic) -> markets_mandate, tech_mandate, risk_mandate
+    "
+        You run a research bureau with three divisions. The topic is: $(topic)
+
+        Write one mandate per division, at most 50 words each, phrased as a
+        question that division can actually answer. They must not overlap.
+        Set `markets_mandate` for the markets division (demand, money, adoption).
+        Set `tech_mandate` for the technology division (what is buildable, and when).
+        Set `risk_mandate` for the risk division (what fails, and who is harmed).
+        Answer from your own knowledge; do not browse or run commands.
+    "
+
+    markets_mandate -> d_markets.mandate
+    tech_mandate -> d_tech.mandate
+    risk_mandate -> d_risk.mandate
+
+    prompt editor(d_markets.brief, d_tech.brief, d_risk.brief) -> dossier
+    "
+        The three divisions have reported on the bureau's topic.
+
+        Markets: $(d_markets.brief)
+        Technology: $(d_tech.brief)
+        Risk: $(d_risk.brief)
+
+        Set `dossier` to at most 250 words, in this shape:
+        a one-sentence bottom line; three bullets, one per division, in that
+        division's own words; then `Tensions:` naming any place two divisions
+        disagree, or `Tensions: none` if they do not. Do not browse or run commands.
+    "
+}
+
+team Referee(standard : string)[referee : ClaudeCode]
+{
+    input dossier : string
+    output verdict : string
+
+    prompt referee(dossier) -> verdict
+    "
+        Judge this dossier on one standard only: $(standard).
+
+        $(dossier)
+
+        Set `verdict` to at most 60 words — a grade of pass, weak, or fail on
+        $(standard), and the single change that would most improve it. Judge from
+        your own knowledge; do not browse or run commands.
+    "
+}
+
+team Audit[judge : ClaudeCode]
+{
+    input dossier : string
+    output ruling : string
+
+    rigor = Referee("rigor: are the claims specific and falsifiable");
+    usefulness = Referee("usefulness: could a decision be made from this");
+
+    dossier -> rigor.dossier
+    dossier -> usefulness.dossier
+
+    prompt judge(rigor.verdict, usefulness.verdict) -> ruling
+    "
+        Two referees graded the bureau's dossier.
+
+        Rigor: $(rigor.verdict)
+        Usefulness: $(usefulness.verdict)
+
+        Set `ruling` to at most 120 words — accept, revise, or reject; the one
+        reason; and, if revise, the single most valuable change. Do not browse or
+        run commands.
+    "
+}
+
+main Bureau {
+    bureau = Bureau()
+    audit = Audit()
+
+    bureau.dossier -> audit.dossier
+}

--- a/tests/topology/src/Cadence.omar
+++ b/tests/topology/src/Cadence.omar
@@ -1,0 +1,165 @@
+// Cadence — a standing review that runs itself on a clock.
+//
+// The program takes no input at all. A timer is what starts it, which nothing
+// else in the language can do: every other trigger needs something upstream to
+// write to it.
+//
+// Timers appear here in three distinct roles:
+//
+//   ignition   `open1(1, 0)`  fires with nothing upstream and opens round 1.
+//              (Offset and period cannot both be 0 — a timer that never fires
+//              is rejected at compile time — so ignition sits at tag 1.)
+//   cadence    `open2(10, 0)`, `open3(20, 0)` open the later rounds. Logical
+//              time is event-driven, so everything at tag 0 — the whole
+//              scout-and-digest fan-out for round 1, including the digest
+//              landing back in the chair's memory — has drained before tag 10
+//              exists. The rounds cannot interleave, and no delay arithmetic
+//              is needed to say so.
+//   deadline   `close(30, 0)` publishes. It is guaranteed to fire after the
+//              last round has fully settled, for the same reason.
+//
+// Every period is 0, so every timer fires once and the program ends on its
+// own. A non-zero period re-arms forever and would run to the tag cap.
+//
+// Self-contained: every agent answers from its own knowledge and is told not
+// to browse, read files, or run commands.
+
+team Scout(lens : string)[scout : ClaudeCode]
+{
+    input brief : string
+    output finding : string
+
+    prompt scout(brief) -> finding
+    "
+        You are a scout working one angle only: $(lens). Answer from your own
+        knowledge — do not browse the web, read files, or run commands.
+
+        This round's brief: $(brief)
+
+        Set `finding` to at most 80 words: the two or three things the $(lens)
+        angle says about this brief, each stated as a claim someone could
+        argue with. If a previous round already covered a point, say something
+        new instead. No preamble.
+    "
+}
+
+team Desk[editor : ClaudeCode]
+{
+    input evidence : string
+    input risk : string
+    input practice : string
+    output digest : string
+
+    prompt editor(evidence, risk, practice) -> digest
+    "
+        Three scouts worked this round from different angles. The tag barrier
+        delivers all three together.
+
+        Evidence: $(evidence)
+        Risk: $(risk)
+        Practice: $(practice)
+
+        Set `digest` to at most 120 words: what the three agree on, the
+        sharpest disagreement between them, and the single question this round
+        leaves open. Answer from your own knowledge; do not browse or run
+        commands.
+    "
+}
+
+team Chair(topic : string)[chair : ClaudeCode]
+{
+    timer open1(1, 0)
+    timer open2(10, 0)
+    timer open3(20, 0)
+    timer close(30, 0)
+
+    input digest : string
+    output brief : string
+    output journal : string
+    output report : string
+
+    // Ignition. Nothing upstream; the clock alone starts the program.
+    prompt chair(open1) -> brief
+    "
+        You chair a standing review of this topic: $(topic)
+
+        This is round 1 of 3, opened by the clock at logical time $(open1).
+        Nothing has been said yet.
+
+        Set `brief` to at most 60 words: the question round 1 should settle,
+        phrased so three scouts working evidence, risk, and practice can each
+        answer it. Answer from your own knowledge; do not browse or run
+        commands.
+    "
+
+    // The digest is not a trigger for the rounds — it only has to land in the
+    // chair's memory, which every prompt on this agent shares. The clock, not
+    // the digest, decides when the chair acts on what it learned.
+    prompt chair(digest) -> journal
+    "
+        A round has just reported. Read it and remember it; you will be asked
+        about it when the clock opens the next round.
+
+        $(digest)
+
+        Set `journal` to at most 25 words — a one-line note to yourself about
+        what changed. Do not browse or run commands.
+    "
+
+    prompt chair(open2) -> brief
+    "
+        The clock has opened round 2 of 3 at logical time $(open2). Round 1 has
+        fully reported and you have already read its digest — recall it from
+        your own memory of this review of $(topic).
+
+        Set `brief` to at most 60 words: the question round 2 should settle.
+        It must follow from what round 1 left open, and must not re-ask what
+        round 1 already answered. Do not browse or run commands.
+    "
+
+    prompt chair(open3) -> brief
+    "
+        The clock has opened round 3 of 3 at logical time $(open3). You have
+        read the digests of rounds 1 and 2 — recall them from your own memory
+        of this review of $(topic).
+
+        Set `brief` to at most 60 words: the question round 3 should settle.
+        This is the last round, so ask the one thing that most changes what a
+        reader would do. Do not browse or run commands.
+    "
+
+    // The deadline. It fires at tag 30, after every round has settled, so it
+    // always publishes a complete review rather than a partial one.
+    prompt chair(close) -> report
+    "
+        The deadline has arrived at logical time $(close). Three rounds have
+        reported on $(topic) and you have read all three digests — recall them
+        from your own memory.
+
+        Set `report` to at most 250 words, in this shape:
+        a one-sentence bottom line; then `Round 1:`, `Round 2:`, `Round 3:`,
+        one or two lines each on what that round established; then
+        `Unresolved:` naming what three rounds did not settle, or
+        `Unresolved: none`. Do not browse or run commands.
+    "
+}
+
+main Cadence {
+    chair = Chair("the operational risks of running many autonomous coding agents in parallel against one repository")
+
+    evidence = Scout("evidence: what is actually known to happen")
+    risk = Scout("risk: what fails, and who it costs")
+    practice = Scout("practice: what a team should do on Monday")
+
+    desk = Desk()
+
+    chair.brief -> evidence.brief
+    chair.brief -> risk.brief
+    chair.brief -> practice.brief
+
+    evidence.finding -> desk.evidence
+    risk.finding -> desk.risk
+    practice.finding -> desk.practice
+
+    desk.digest -> chair.digest
+}

--- a/tests/topology/src/Heartbeat.omar
+++ b/tests/topology/src/Heartbeat.omar
@@ -1,0 +1,52 @@
+// Heartbeat — the smallest thing a periodic timer can drive.
+//
+// `tick(0, 10)` fires at logical time 0 and re-arms every 10 forever. Nothing
+// feeds it and nothing can write to it: the clock alone drives this program,
+// and it takes no input at all.
+//
+// A periodic timer does not stop. This run ends only at the runtime's 1024-tag
+// cap, or when you stop it — whichever comes first. Whatever it produced up to
+// then stands.
+//
+// Both prompts on `monitor` share one agent memory, so each tick sees every
+// tick before it. That is what makes a heartbeat rather than a repeated
+// question.
+
+team Pulse[monitor : ClaudeCode]
+{
+    timer tick(0, 10)
+    output reading : string
+
+    prompt monitor(tick) -> reading
+    "
+        Tick at logical time $(tick).
+
+        Name one risk of running many autonomous coding agents against one
+        repository. Answer from your own knowledge; do not browse or run
+        commands.
+
+        Set `reading` to at most 25 words, and do not repeat a risk you named
+        on an earlier tick.
+    "
+}
+
+team Watch[watcher : ClaudeCode]
+{
+    input reading : string
+    output verdict : string
+
+    prompt watcher(reading) -> verdict
+    "
+        $(reading)
+
+        Set `verdict` to at most 15 words: `real:` or `noise:` and one clause
+        of why. Do not browse or run commands.
+    "
+}
+
+main Heartbeat {
+    pulse = Pulse()
+    watch = Watch()
+
+    pulse.reading -> watch.reading
+}


### PR DESCRIPTION
## The check was a policy, not a check

CI asserted every agent outside `HR.json` spawned on `Codex`. That says nothing about whether the compiler emits what a program asked for — and it rejects any new program on another backend for a reason no reader of the failure could act on.

It now reads each source's `[name : Backend]` declarations and asserts the bytecode spawns that agent on that backend. That is the property worth pinning, and the old assertion never checked it even for Codex: a compiler that emitted `Codex` for an agent declared `Claude` passed.

A declaration is matched under the last segment of the spawned name, because instantiating qualifies an agent by its instance path (`bureau.d_risk.probe.evidence.analyst` → `analyst`). Backends are held in a set per name, since two teams may reuse a local agent name.

Verified it has teeth: flipping one `spawn_agent` backend in `Heartbeat.json` fails with the file, the instruction, and what the source declared.

## Three programs come with it

All on Claude Code, all of which the old check would have refused:

| | |
| --- | --- |
| `Heartbeat` | a periodic timer driving a program that never finishes |
| `Cadence` | one-shot timers opening three rounds and a deadline, chair prompts sharing one agent memory |
| `Bureau` | four levels of containment, 32 agents — the heaviest case in the corpus |

`Cadence` and `Bureau` are registered in `run_local.sh`. **`Heartbeat` is not**, and the script says why: a non-zero period means it never produces the completion marker the runner waits for. It is compiled and layout-checked like every other source.

`Bureau.omar`'s main block was named `NestedBureau`; renamed to `Bureau` so the run name matches the file, as every other case does.

## A prerequisite fix

`--input` was `required` at the command line, so a program driven only by a timer could not be started at all — `Timer` has been registered since timers landed and fails there for exactly this reason. The runtime already rejects an unsupplied unconnected input by name, so the flag requirement added nothing but that failure.

Confirmed both directions against live agents:

```
$ omar run tests/topology/src/Timer.omar --replace
Topology 'Timer' completed
Output beacon.note = "fired at 5"

$ omar run tests/topology/src/Bureau.omar --replace
Error: missing input 'bureau.topic'
```

## Verification

`Cadence` was run end to end against live Claude Code agents — `Topology 'Cadence' completed`, with `chair.report` and every intermediate output produced, and with no `--input`, which exercises the CLI fix in exactly the new case.

Whole corpus (17 sources) compiles; the rewritten layout + backend check passes over all of it and fails on a deliberately corrupted backend. 319 unit tests, clippy clean, `cargo fmt` clean.

`Bureau` has **not** been run live here — 32 agents across 8 sequential stages is the heaviest case in the corpus and may want `OMAR_TEST_CASE_TIMEOUT_SECONDS` above the 900s default in the release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)