### PR TITLE
Start the daemon and Mission Control with one command

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -67,6 +67,28 @@ jobs:
       - name: Compare the fake against the real daemon
         run: npm run test:conformance
 
+  # `make dev` starts two servers and has to point them at each other and stop
+  # them together. Nothing else in either suite exercises that, and every bug it
+  # has had looked fine until something ran it.
+  dev-script:
+    name: Web Dev Script
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - uses: dtolnay/rust-toolchain@stable
+      # `omar serve` launches the assistant in a tmux pane.
+      - run: sudo apt-get update && sudo apt-get install -y tmux
+        working-directory: .
+      - run: npm ci
+      - name: Start both, check both, stop both
+        run: ./tests/dev-script.test.sh
+
   e2e:
     name: Web E2E
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install uninstall test-topology
+.PHONY: build install uninstall test-topology dev
 
 BINARIES := omar omar-computer omar-slack
 INSTALL_DIR := $(HOME)/.cargo/bin
@@ -15,3 +15,8 @@ uninstall:
 
 test-topology:
 	OMAR_TEST_CASE="$(CASE)" ./tests/topology/run_local.sh
+
+# The daemon and Mission Control together, pointed at each other. Ctrl-C stops
+# both. Needs Node; see web/README.md.
+dev:
+	./web/dev.sh

--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ The web client for authoring and observing topology programs lives in
 [`web/`](web/), and is built from this same commit as the runtime it talks to.
 
 ```bash
-cargo run --bin omar -- serve --address 127.0.0.1:7340   # here
-cd web && OMAR_SERVE_URL=http://127.0.0.1:7340 npm run dev
+make dev
 ```
 
-Open `http://localhost:3000`. Without `OMAR_SERVE_URL` it runs an offline demo
-topology: you can draft and inspect, but not run. See [`web/README.md`](web/README.md).
+Builds the runtime, starts the daemon, starts Mission Control pointed at it,
+and opens a browser. Ctrl-C stops both. Needs Node.js 22.13+; see
+[`web/README.md`](web/README.md) for running the two halves separately.
 
 ## Supported Agent Backends
 

--- a/web/README.md
+++ b/web/README.md
@@ -26,8 +26,16 @@ npm run dev
 Open `http://localhost:3000`. With no flag it runs the offline demo topology:
 you can draft and inspect, but not run.
 
-Mode is chosen at launch, not in the UI. To run for real, start the daemon and
-point Mission Control at it:
+Mode is chosen at launch, not in the UI. To run for real, use `make dev` from
+the repository root — it builds the runtime, starts the daemon, starts Mission
+Control pointed at it, and opens a browser. Ctrl-C stops both.
+
+```bash
+make dev
+```
+
+`OMAR_SERVE_ADDRESS`, `OMAR_WEB_PORT` and `OMAR_DEV_OPEN=0` adjust it. The two
+halves separately, if you want them in separate terminals:
 
 ```bash
 cargo run --bin omar -- serve --address 127.0.0.1:7340   # from the repository root

--- a/web/dev.sh
+++ b/web/dev.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Runs the daemon and Mission Control together, pointed at each other.
+#
+# Mode is chosen when Mission Control is launched rather than in the UI, so the
+# two have to start in the right order with the right address between them.
+# Doing that by hand means two terminals and a variable that is easy to forget;
+# forgetting it is not an error, it is a UI that quietly cannot deploy.
+#
+# Both surfaces are loopback-only. Ctrl-C stops both.
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/.." && pwd)
+
+serve_address=${OMAR_SERVE_ADDRESS:-127.0.0.1:7340}
+web_port=${OMAR_WEB_PORT:-3000}
+# Set to skip the browser: a smoke test wants the servers, not a window.
+open_browser=${OMAR_DEV_OPEN:-1}
+# How long each side gets to start answering before this gives up.
+ready_timeout=${OMAR_DEV_READY_TIMEOUT:-120}
+
+serve_pid=""
+web_pid=""
+
+# `npm run` is a shell wrapping node, so killing the pid this script holds
+# leaves the dev server running and the port taken. Take the descendants too.
+kill_tree() {
+  local pid=$1 child
+  for child in $(pgrep -P "$pid" 2>/dev/null); do
+    kill_tree "$child"
+  done
+  kill "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  trap - INT TERM EXIT
+  for pid in "$web_pid" "$serve_pid"; do
+    [[ -n $pid ]] && kill_tree "$pid"
+  done
+  wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+wait_for() {
+  local url=$1 what=$2 pid=$3 waited=0
+  until curl -fsS -o /dev/null "$url" 2>/dev/null; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      printf '%s exited before it answered %s\n' "$what" "$url" >&2
+      return 1
+    fi
+    if ((waited >= ready_timeout)); then
+      printf '%s did not answer %s within %ds\n' "$what" "$url" "$ready_timeout" >&2
+      return 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+}
+
+open_url() {
+  local url=$1
+  if command -v open >/dev/null 2>&1; then
+    open "$url" 2>/dev/null || true
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 || true
+  else
+    printf 'Open %s\n' "$url"
+  fi
+}
+
+printf 'Building the runtime...\n'
+(cd "$repo_root" && cargo build --quiet --bin omar)
+
+if [[ ! -d "$script_dir/node_modules" ]]; then
+  printf 'Installing web dependencies...\n'
+  (cd "$script_dir" && npm install --silent)
+fi
+
+printf 'Starting omar serve on %s...\n' "$serve_address"
+"$repo_root/target/debug/omar" serve --address "$serve_address" &
+serve_pid=$!
+wait_for "http://$serve_address/health" "omar serve" "$serve_pid"
+
+printf 'Starting Mission Control on port %s...\n' "$web_port"
+(cd "$script_dir" && OMAR_SERVE_URL="http://$serve_address" npm run dev -- --port "$web_port") &
+web_pid=$!
+# Named `localhost`, not `127.0.0.1`: the dev server binds the IPv6 loopback
+# only, so the v4 address never answers and waiting on it would time out with
+# the server up and running.
+web_url="http://localhost:$web_port"
+wait_for "$web_url/" "Mission Control" "$web_pid"
+
+printf '\nMission Control: %s (live against http://%s)\n' "$web_url" "$serve_address"
+printf 'Ctrl-C stops both.\n\n'
+
+[[ $open_browser == 1 ]] && open_url "$web_url"
+
+# Either side going down takes the pair with it: a Mission Control pointed at a
+# dead daemon looks live until you try to deploy.
+#
+# Polled rather than `wait -n`, which bash 3.2 — still what macOS ships — does
+# not have.
+while kill -0 "$serve_pid" 2>/dev/null && kill -0 "$web_pid" 2>/dev/null; do
+  sleep 1
+done

--- a/web/tests/dev-script.test.sh
+++ b/web/tests/dev-script.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Smoke test for `make dev`.
+#
+# The script's whole job is that both sides come up pointed at each other and
+# both go down together. That is not something the Node or Rust suites can see,
+# and every failure it has had so far — a readiness probe on an address the dev
+# server does not bind, `wait -n` on a bash that does not have it, a kill that
+# left the dev server orphaned — looked fine until something ran it.
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+web_dir=$(cd "$script_dir/.." && pwd)
+
+serve_address=${SMOKE_SERVE_ADDRESS:-127.0.0.1:7351}
+web_port=${SMOKE_WEB_PORT:-3021}
+web_url="http://localhost:$web_port"
+
+dev_pid=""
+log=$(mktemp)
+
+finish() {
+  [[ -n $dev_pid ]] && kill "$dev_pid" 2>/dev/null || true
+  # Belt and braces: if the script leaked children, this test must not.
+  pkill -f "vinext dev --port $web_port" 2>/dev/null || true
+  pkill -f "omar serve --address $serve_address" 2>/dev/null || true
+  rm -f "$log"
+}
+trap finish EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  printf -- '--- dev.sh output ---\n' >&2
+  cat "$log" >&2
+  exit 1
+}
+
+printf 'Starting dev.sh...\n'
+OMAR_DEV_OPEN=0 \
+  OMAR_SERVE_ADDRESS="$serve_address" \
+  OMAR_WEB_PORT="$web_port" \
+  "$web_dir/dev.sh" >"$log" 2>&1 &
+dev_pid=$!
+
+for _ in $(seq 1 300); do
+  grep -q "Ctrl-C stops both" "$log" && break
+  kill -0 "$dev_pid" 2>/dev/null || fail "dev.sh exited before it was ready"
+  sleep 1
+done
+grep -q "Ctrl-C stops both" "$log" || fail "dev.sh never reported ready"
+
+curl -fsS "http://$serve_address/health" | grep -q '"status":"ok"' \
+  || fail "the daemon did not answer /health"
+curl -fsS -o /dev/null "$web_url/" || fail "Mission Control did not answer"
+
+# Live mode is the point: the page is rendered with the daemon's address, so a
+# demo-mode shell here means the two started without being pointed at anything.
+curl -fsS "$web_url/" | grep -q "$serve_address" \
+  || fail "the page does not name the daemon, so it launched in demo mode"
+
+printf 'Both answered. Stopping...\n'
+kill "$dev_pid"
+for _ in $(seq 1 30); do
+  kill -0 "$dev_pid" 2>/dev/null || break
+  sleep 1
+done
+
+# Nothing may outlive the script: an orphaned dev server holds the port and the
+# next run fails with something that looks unrelated.
+sleep 2
+! curl -fsS -o /dev/null "$web_url/" 2>/dev/null \
+  || fail "Mission Control outlived dev.sh"
+! curl -fsS -o /dev/null "http://$serve_address/health" 2>/dev/null \
+  || fail "the daemon outlived dev.sh"
+
+printf 'PASS: both came up pointed at each other, and both went down.\n'


### PR DESCRIPTION
Stacked on #183, which puts `web/` in this repository. Retarget to `main` once that lands.

## Why

Mode is chosen when Mission Control launches, not in the UI: an address means live, absent means the offline demo. So the two have to start in the right order with the right address between them. By hand that is two terminals and an environment variable — and forgetting the variable is not an error, it is a UI that looks fine and quietly cannot deploy.

```bash
make dev
```

Builds the runtime, starts the daemon, starts Mission Control pointed at it, opens a browser, and stops both on Ctrl-C. `OMAR_SERVE_ADDRESS`, `OMAR_WEB_PORT`, `OMAR_DEV_OPEN=0` adjust it.

## Two bugs that only appear when something runs it

Both were written, looked correct, and failed on first execution:

- **The dev server binds the IPv6 loopback only.** A readiness probe against `127.0.0.1:3000` never connects and waits out its full timeout with the server up and serving. Probing `localhost` resolves to whatever is actually listening.
- **`npm run` is a shell wrapping node.** Killing the pid the script holds left the dev server running and the port taken. Cleanup now takes the descendants. `wait -n` also had to go: bash 3.2, which macOS still ships, does not have it.

## The test

`web/tests/dev-script.test.sh`, run by a new `Web Dev Script` CI job. It starts the script for real and asserts:

- the daemon answers `/health`;
- Mission Control answers;
- **the served page names the daemon's address** — a demo-mode shell here means the two started without being pointed at each other, which is exactly the failure this command exists to prevent;
- after stopping, **neither is still listening** — an orphan holds the port and makes the next run fail with something that looks unrelated.

Passing locally end to end on macOS (bash 3.2), and the job runs it on Ubuntu.

## Next

`omar serve --ui` — the daemon serving the client from its own port, for people who installed a binary and have no `web/` or Node. That needs an SPA build target and static serving in `serve.rs`, and is its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)