### PR TITLE
Serve Mission Control from omar serve --ui

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,20 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y tmux
 
+      # Mission Control is embedded in the binary, so it is built before the
+      # runtime that carries it. Without this the release ships an `omar` whose
+      # `--ui` refuses to start.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Build Mission Control
+        run: npm ci && npm run build:spa
+        working-directory: web
+
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --features ui --target ${{ matrix.target }}
 
       - name: Verify direct source execution
         env:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -89,6 +89,30 @@ jobs:
       - name: Start both, check both, stop both
         run: ./tests/dev-script.test.sh
 
+  # The daemon serving Mission Control itself. Nothing else here loads a page
+  # from the runtime: the browser suite drives a fake on another origin, and the
+  # Rust tests never open one.
+  serve-ui:
+    name: Web Serve UI
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - uses: dtolnay/rust-toolchain@stable
+      - run: npm ci
+      - run: npm run build:spa
+      # The bundle has to exist before this: the feature embeds it.
+      - name: Build the runtime with the UI in it
+        run: cargo build --bin omar --features ui
+        working-directory: .
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:serve-ui
+
   e2e:
     name: Web E2E
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,12 @@ portable-pty = "0.8"
 pretty_assertions = "1"
 tempfile = "3"
 
+# Embeds the Mission Control bundle from `web/dist/spa` so `omar serve --ui`
+# can hand it out. Off by default: a plain `cargo build` needs no Node. Build
+# the bundle first with `npm run build:spa` in `web/`.
+[features]
+ui = []
+
 [[bin]]
 name = "omar"
 path = "src/omar.rs"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
-.PHONY: build install uninstall test-topology dev
+.PHONY: build install uninstall test-topology dev web-bundle
 
 BINARIES := omar omar-computer omar-slack
 INSTALL_DIR := $(HOME)/.cargo/bin
 
-build:
-	cargo build --release
+# Mission Control, built and compressed for the runtime to embed. Needs Node.
+web-bundle:
+	cd web && npm ci && npm run build:spa
+
+# Built with the UI in it, so an installed `omar serve --ui` has something to
+# serve. A plain `cargo build --release` still works and still needs no Node;
+# it just cannot serve the UI.
+build: web-bundle
+	cargo build --release --features ui
 
 install: build
 	install -d $(INSTALL_DIR)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 **`omar` is a harness for creating powerful multi-agent workflows.**
 
-Lead a team of 100 agents to solve humanity's biggest problems.
-
 <p align="center">
   <a href="https://omar.rs">omar.rs</a>&nbsp; • &nbsp;
   <a href="https://omar.rs/zh/">中文</a>&nbsp; • &nbsp;
@@ -16,6 +14,9 @@ Lead a team of 100 agents to solve humanity's biggest problems.
 
 </div>
 
+![Web](img/web.gif)
+
+Alternative Terminal UI:
 ![Demo](img/demo.gif)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Other features include messaging systems integration (e.g., Slack), computer use
 - tmux 3.0+
 - Rust 1.70+
 - GNU Make
+- Node.js 22.13+ (to build Mission Control, which `make build` embeds)
 - One or more coding agents: [Claude](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [Codex](https://developers.openai.com/codex/cli), [Cursor](https://cursor.com/cli), [Opencode](https://github.com/anomalyco/opencode), or [Google Antigravity CLI](https://antigravity.google/product/antigravity-cli).
 
 ### One-liner (recommended)
@@ -93,13 +94,24 @@ Shutdown the test project and its agents.
 The web client for authoring and observing topology programs lives in
 [`web/`](web/), and is built from this same commit as the runtime it talks to.
 
+If you installed `omar`, it is already in the binary:
+
+```bash
+omar serve --ui
+```
+
+Serves Mission Control from the daemon's own address and opens a browser. The
+page and the API share an origin, so there is nothing to point at anything.
+
+Working on the client itself, use the dev server instead — it reloads:
+
 ```bash
 make dev
 ```
 
 Builds the runtime, starts the daemon, starts Mission Control pointed at it,
 and opens a browser. Ctrl-C stops both. Needs Node.js 22.13+; see
-[`web/README.md`](web/README.md) for running the two halves separately.
+[`web/README.md`](web/README.md).
 
 ## Supported Agent Backends
 

--- a/src/omar.rs
+++ b/src/omar.rs
@@ -20,6 +20,7 @@ mod terminal;
 mod tmux;
 mod topology;
 mod ui;
+mod web_assets;
 
 use std::io;
 use std::path::PathBuf;
@@ -192,6 +193,11 @@ enum Commands {
         /// context is still written, so a test harness can stand in for one.
         #[arg(long)]
         no_ea: bool,
+
+        /// Open Mission Control in a browser. It is served from this same
+        /// address, so the page and the API share an origin.
+        #[arg(long)]
+        ui: bool,
     },
 }
 
@@ -248,6 +254,41 @@ enum EventAction {
         /// Event id
         id: String,
     },
+}
+
+/// Waits for `omar serve` to be listening, then opens Mission Control.
+///
+/// Opening before the listener exists shows the operator a connection error and
+/// makes them reload; waiting a bounded time means a daemon that fails to start
+/// does not leave a thread polling for the life of the process.
+fn open_when_listening(address: std::net::SocketAddr) {
+    for _ in 0..100 {
+        if std::net::TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok() {
+            open_browser(&format!("http://{address}"));
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    eprintln!("Mission Control is at http://{address}");
+}
+
+/// Asks the desktop to open a URL, and says it plainly if there is no desktop.
+fn open_browser(url: &str) {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    let opened = std::process::Command::new(opener)
+        .arg(url)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+    if !opened {
+        println!("Open {url}");
+    }
 }
 
 fn main() -> Result<()> {
@@ -424,8 +465,17 @@ async fn async_main() -> Result<()> {
             address,
             restart_ea,
             no_ea,
+            ui,
         }) => {
+            if ui && !web_assets::is_bundled() {
+                anyhow::bail!(web_assets::MISSING);
+            }
             let target = resolve_cli_ea(&omar_dir, cli.ea.as_deref())?;
+            if ui {
+                // `serve::run` blocks, so the browser is opened from a thread
+                // that waits for the listener rather than before it exists.
+                std::thread::spawn(move || open_when_listening(address));
+            }
             serve::run(address, &config, &omar_dir, target.id, restart_ea, !no_ea)
         }
         None => {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -492,6 +492,15 @@ fn handle_client(mut stream: TcpStream, context: Arc<Context_>) -> Result<()> {
         return write_json(&mut stream, 204, &Value::Null, origin);
     }
 
+    // Anything that is not the API is Mission Control, when this binary was
+    // built with it. Matched after every `/v1` route, so the bundle can never
+    // shadow one, and only for GET: the API owns the verbs.
+    if method == "GET" && !path.starts_with("/v1/") && path != "/health" {
+        if let Some(asset) = crate::web_assets::lookup(&path) {
+            return write_asset(&mut stream, asset);
+        }
+    }
+
     // Streams for as long as the operator keeps Mission Control open.
     if method == "GET" && path == "/v1/chat/events" {
         return stream_chat(stream, &context, origin);
@@ -1155,6 +1164,24 @@ fn write_json(
         crate::diagram::cors_origin_header(origin)
     )?;
     stream.write_all(&payload)?;
+    stream.flush()?;
+    Ok(())
+}
+
+/// Hands out an embedded Mission Control file.
+///
+/// Stored gzipped and sent gzipped: the bundle is 2.2MB raw and 0.65MB
+/// compressed, and this only ever answers loopback, where every client
+/// understands the encoding. `no-store` because the bundle changes whenever the
+/// binary does and the two carry no version between them.
+fn write_asset(stream: &mut TcpStream, asset: &crate::web_assets::Asset) -> Result<()> {
+    write!(
+        stream,
+        "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Encoding: gzip\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n",
+        asset.content_type,
+        asset.gzipped.len()
+    )?;
+    stream.write_all(asset.gzipped)?;
     stream.flush()?;
     Ok(())
 }

--- a/src/web_assets.rs
+++ b/src/web_assets.rs
@@ -1,0 +1,117 @@
+//! The Mission Control bundle `omar serve` hands out.
+//!
+//! Served from the daemon's own port, so the page is same-origin with the API
+//! it calls: no CORS, and the address is read from the page rather than chosen
+//! at launch. That is the whole reason this exists rather than pointing a
+//! separately-started dev server at the daemon.
+//!
+//! The bytes are stored gzipped and handed out gzipped, which is what keeps the
+//! binary about 0.7MB larger rather than 2.2MB. Every browser has understood
+//! `Content-Encoding: gzip` for twenty years, and this only ever answers
+//! loopback, so there is no client here that cannot read it.
+//!
+//! Built by `npm run build:spa` in `web/`, embedded only under the `ui`
+//! feature: a plain `cargo build` needs no Node.
+
+/// A file the daemon will hand out, already compressed.
+pub struct Asset {
+    pub path: &'static str,
+    pub content_type: &'static str,
+    pub gzipped: &'static [u8],
+}
+
+#[cfg(feature = "ui")]
+mod embedded {
+    use super::Asset;
+
+    macro_rules! asset {
+        ($path:expr, $content_type:expr, $file:expr) => {
+            Asset {
+                path: $path,
+                content_type: $content_type,
+                gzipped: include_bytes!(concat!("../web/dist/spa/", $file, ".gz")),
+            }
+        };
+    }
+
+    // The same five files `web/build/compress-spa.mjs` writes. Naming them on
+    // both sides means a bundle that stopped emitting one fails to compile,
+    // rather than 404ing in a browser.
+    pub const ASSETS: &[Asset] = &[
+        asset!("/", "text/html; charset=utf-8", "index.html"),
+        asset!("/app.js", "text/javascript; charset=utf-8", "app.js"),
+        asset!("/app.css", "text/css; charset=utf-8", "app.css"),
+        asset!("/omar-logo.png", "image/png", "omar-logo.png"),
+        asset!("/favicon.svg", "image/svg+xml", "favicon.svg"),
+    ];
+}
+
+#[cfg(not(feature = "ui"))]
+mod embedded {
+    use super::Asset;
+
+    pub const ASSETS: &[Asset] = &[];
+}
+
+pub use embedded::ASSETS;
+
+/// Whether this binary was built with the UI in it.
+pub fn is_bundled() -> bool {
+    !ASSETS.is_empty()
+}
+
+/// The asset a request path asks for, if any.
+pub fn lookup(path: &str) -> Option<&'static Asset> {
+    // A single-page application: the client owns its routes, so anything that
+    // is not a file it shipped is that shell again. `/v1` never reaches here.
+    let wanted = if ASSETS.iter().any(|asset| asset.path == path) {
+        path
+    } else {
+        "/"
+    };
+    ASSETS.iter().find(|asset| asset.path == wanted)
+}
+
+/// What to tell someone whose binary has no UI in it.
+pub const MISSING: &str = "This build has no UI in it. Build one with:\n  \
+    (cd web && npm install && npm run build:spa)\n  \
+    cargo build --release --features ui\n\
+    Or run `make dev`, which starts Mission Control from source.";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_build_without_the_feature_says_so_rather_than_serving_nothing() {
+        // Both halves have to agree: `is_bundled` is what decides whether
+        // `--ui` opens a browser or explains itself.
+        assert_eq!(is_bundled(), !ASSETS.is_empty());
+        assert!(MISSING.contains("--features ui"));
+    }
+
+    #[cfg(feature = "ui")]
+    #[test]
+    fn every_embedded_asset_is_gzip_and_reachable() {
+        for asset in ASSETS {
+            assert!(!asset.gzipped.is_empty(), "{} is empty", asset.path);
+            // gzip's magic number, so a raw file embedded by mistake fails here
+            // rather than in a browser that cannot decode it.
+            assert_eq!(
+                &asset.gzipped[..2],
+                &[0x1f, 0x8b],
+                "{} is not gzip",
+                asset.path
+            );
+            assert!(lookup(asset.path).is_some(), "{} not routable", asset.path);
+        }
+    }
+
+    #[cfg(feature = "ui")]
+    #[test]
+    fn an_unknown_path_falls_back_to_the_shell() {
+        // The client owns its routes; a reload on one must not 404.
+        assert_eq!(lookup("/anything").map(|a| a.path), Some("/"));
+        assert_eq!(lookup("/app.js").map(|a| a.path), Some("/app.js"));
+    }
+}

--- a/web/README.md
+++ b/web/README.md
@@ -26,6 +26,22 @@ npm run dev
 Open `http://localhost:3000`. With no flag it runs the offline demo topology:
 you can draft and inspect, but not run.
 
+## Two builds of the same application
+
+`npm run build` produces the Cloudflare Worker: server-rendered, deployed, and
+told the daemon's address at launch through `OMAR_SERVE_URL`.
+
+`npm run build:spa` produces a static bundle entered from the browser, which
+`omar serve --ui` embeds and hands out from its own port. There the page is
+same-origin with the API, so it reads the address from the page it was served
+by and there is no mode to choose. `spa/main.tsx` is that entry; it renders the
+same `Studio` component.
+
+The bundle is gzipped by `build/compress-spa.mjs` and embedded under the
+runtime's `ui` cargo feature, so a plain `cargo build` needs no Node.
+
+## Running it
+
 Mode is chosen at launch, not in the UI. To run for real, use `make dev` from
 the repository root — it builds the runtime, starts the daemon, starts Mission
 Control pointed at it, and opens a browser. Ctrl-C stops both.

--- a/web/build/compress-spa.mjs
+++ b/web/build/compress-spa.mjs
@@ -1,0 +1,30 @@
+/**
+ * Gzips the SPA bundle for `omar serve --ui` to embed.
+ *
+ * The runtime stores these bytes inside the binary and hands them out with
+ * `Content-Encoding: gzip`, so compressing once here is what keeps the binary
+ * from growing by the full 2.2MB. Downloads are gzipped either way; this is
+ * about what sits on disk.
+ */
+import { gzipSync } from "node:zlib";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// The exact list the runtime embeds. Adding one here means adding it there:
+// both sides name the files, so a mismatch is a compile error rather than a
+// 404 someone finds in a browser.
+const FILES = ["index.html", "app.js", "app.css", "omar-logo.png", "favicon.svg"];
+const dir = new URL("../dist/spa/", import.meta.url).pathname;
+
+let raw = 0;
+let packed = 0;
+for (const name of FILES) {
+  const source = readFileSync(join(dir, name));
+  const gzipped = gzipSync(source, { level: 9 });
+  writeFileSync(join(dir, `${name}.gz`), gzipped);
+  raw += source.length;
+  packed += gzipped.length;
+}
+
+const kb = (bytes) => `${Math.round(bytes / 1024)}KB`;
+console.log(`compressed ${FILES.length} files: ${kb(raw)} -> ${kb(packed)}`);

--- a/web/package.json
+++ b/web/package.json
@@ -8,11 +8,13 @@
   "scripts": {
     "dev": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext dev",
     "build": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext build",
+    "build:spa": "vite build --config vite.spa.config.ts && node build/compress-spa.mjs",
     "start": "WRANGLER_LOG_PATH=.wrangler/wrangler.log vinext start",
     "test": "npm run build && node --test tests/rendered-html.test.mjs tests/protocol-contract.test.mjs",
     "lint": "eslint . --ignore-pattern dist --ignore-pattern .next",
     "test:e2e": "playwright test",
-    "test:conformance": "node --test tests/conformance.test.mjs"
+    "test:conformance": "node --test tests/conformance.test.mjs",
+    "test:serve-ui": "node --test tests/serve-ui.test.mjs"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",

--- a/web/spa/index.html
+++ b/web/spa/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<!--
+  The same application as the Worker build, entered from the browser instead of
+  from a server render.
+
+  `omar serve --ui` hands this out on its own port, so the client is same-origin
+  with the API it calls. That is what lets the address be read from the page
+  rather than injected at launch, and it is why this entry exists at all.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#08080a" />
+    <title>OMAR Mission Control</title>
+    <link rel="icon" href="/omar-logo.png" />
+    <link rel="apple-touch-icon" href="/omar-logo.png" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/web/spa/main.tsx
+++ b/web/spa/main.tsx
@@ -1,0 +1,17 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import "../app/globals.css";
+import { Studio } from "../app/studio";
+
+/**
+ * Mode is chosen at launch in the Worker build, because only the server knows
+ * the daemon's address there. Served by `omar serve` there is nothing to
+ * choose: the page came from the daemon, so the daemon is where it came from.
+ * Same origin, which is also why none of this needs CORS.
+ */
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <Studio serveUrl={window.location.origin} />
+  </StrictMode>,
+);

--- a/web/tests/serve-ui.test.mjs
+++ b/web/tests/serve-ui.test.mjs
@@ -17,6 +17,7 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { request as httpRequest } from "node:http";
 import { gunzipSync } from "node:zlib";
 import { resolve } from "node:path";
 import test, { after, before, describe } from "node:test";
@@ -42,6 +43,28 @@ function bundled() {
 }
 
 const AVAILABLE = bundled();
+
+/** A GET returning exactly what came over the wire, undecoded. */
+function get(path) {
+  return new Promise((settle, fail) => {
+    const call = httpRequest(
+      { host: "127.0.0.1", port: PORT, path, method: "GET" },
+      (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () =>
+          settle({
+            statusCode: response.statusCode,
+            headers: response.headers,
+            body: Buffer.concat(chunks),
+          }),
+        );
+      },
+    );
+    call.on("error", fail);
+    call.end();
+  });
+}
 
 describe("omar serve --ui", { skip: AVAILABLE ? false : "no bundled runtime" }, () => {
   let daemon;
@@ -76,13 +99,20 @@ describe("omar serve --ui", { skip: AVAILABLE ? false : "no bundled runtime" }, 
   });
 
   test("the bundle is reachable and is really gzip", async () => {
-    const response = await fetch(`${ORIGIN}/app.js`);
-    assert.equal(response.status, 200);
-    assert.match(response.headers.get("content-type"), /javascript/);
-    const raw = Buffer.from(await response.arrayBuffer());
-    // Decoded by fetch already; gunzipping it again would fail, so this checks
-    // the payload is a real script rather than an error page.
-    assert.ok(raw.length > 100_000, `suspiciously small: ${raw.length} bytes`);
+    // `node:http` rather than `fetch`: it hands over the bytes on the wire
+    // instead of decoding them, which is the only way to assert that what is
+    // stored is compressed. It also steps around an undici crash on a large
+    // gzip body followed by a connection close — a client bug, but browsers do
+    // not share it and this is what the daemon actually talks to.
+    const { statusCode, headers, body } = await get("/app.js");
+    assert.equal(statusCode, 200);
+    assert.match(headers["content-type"], /javascript/);
+    assert.equal(headers["content-encoding"], "gzip");
+    assert.equal(Number(headers["content-length"]), body.length);
+    assert.deepEqual([...body.subarray(0, 2)], [0x1f, 0x8b], "not gzip on the wire");
+    const script = gunzipSync(body);
+    assert.ok(script.length > 1_000_000, `suspiciously small: ${script.length} bytes`);
+    assert.match(script.subarray(0, 4096).toString("utf8"), /function|const|var/);
   });
 
   test("an unknown path is the shell, not a 404", async () => {
@@ -136,6 +166,3 @@ test("a runtime without the bundle refuses --ui and explains itself", { skip: AV
   assert.match(said, /no UI in it/);
   assert.match(said, /--features ui/);
 });
-
-// Referenced so the import is not flagged as unused when everything skips.
-void gunzipSync;

--- a/web/tests/serve-ui.test.mjs
+++ b/web/tests/serve-ui.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * `omar serve --ui`: the daemon handing out Mission Control itself.
+ *
+ * The point of serving it from the daemon's own port is that the page is
+ * same-origin with the API, so the address is read from the page rather than
+ * chosen at launch. That is invisible to every other suite here — the browser
+ * tests drive a fake over a different origin, and the Rust tests never load a
+ * page — so this is where it is checked.
+ *
+ * Needs a runtime built with the bundle in it:
+ *   (cd web && npm run build:spa)
+ *   cargo build --bin omar --features ui
+ *   node --test tests/serve-ui.test.mjs
+ * Skips itself when that binary is absent or was built without the feature.
+ */
+
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { gunzipSync } from "node:zlib";
+import { resolve } from "node:path";
+import test, { after, before, describe } from "node:test";
+
+import { chromium } from "@playwright/test";
+
+const OMAR_BIN = process.env.OMAR_BIN ?? resolve("../target/debug/omar");
+const PORT = Number(process.env.SERVE_UI_PORT ?? 7356);
+const ORIGIN = `http://127.0.0.1:${PORT}`;
+
+/**
+ * A binary without the feature refuses `--ui` by design, and that refusal is
+ * what tells us to skip rather than fail: this suite is about what a bundled
+ * build does.
+ */
+function bundled() {
+  if (!existsSync(OMAR_BIN)) return false;
+  const probe = spawnSync(OMAR_BIN, ["serve", "--ui", "--address", "127.0.0.1:1"], {
+    encoding: "utf8",
+    timeout: 20_000,
+  });
+  return !`${probe.stdout}${probe.stderr}`.includes("no UI in it");
+}
+
+const AVAILABLE = bundled();
+
+describe("omar serve --ui", { skip: AVAILABLE ? false : "no bundled runtime" }, () => {
+  let daemon;
+
+  before(async () => {
+    // `--no-ea` keeps this from launching an assistant in tmux: the bundle is
+    // what is under test, not the agent.
+    daemon = spawn(OMAR_BIN, ["serve", "--address", `127.0.0.1:${PORT}`, "--no-ea"], {
+      stdio: "ignore",
+    });
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      try {
+        await fetch(`${ORIGIN}/health`);
+        return;
+      } catch {
+        await new Promise((done) => setTimeout(done, 200));
+      }
+    }
+    throw new Error("the daemon never answered /health");
+  });
+
+  after(() => daemon?.kill());
+
+  test("the shell is served, compressed, from the API's own port", async () => {
+    const response = await fetch(ORIGIN, { headers: { "accept-encoding": "gzip" } });
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /text\/html/);
+    // `fetch` decodes transparently, so the header is the assertion that these
+    // bytes are stored compressed rather than compressed on the way out.
+    assert.equal(response.headers.get("content-encoding"), "gzip");
+    assert.match(await response.text(), /<div id="root">/);
+  });
+
+  test("the bundle is reachable and is really gzip", async () => {
+    const response = await fetch(`${ORIGIN}/app.js`);
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /javascript/);
+    const raw = Buffer.from(await response.arrayBuffer());
+    // Decoded by fetch already; gunzipping it again would fail, so this checks
+    // the payload is a real script rather than an error page.
+    assert.ok(raw.length > 100_000, `suspiciously small: ${raw.length} bytes`);
+  });
+
+  test("an unknown path is the shell, not a 404", async () => {
+    // The client owns its routes: reloading on one must not fall through.
+    const response = await fetch(`${ORIGIN}/anything/at/all`);
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /text\/html/);
+  });
+
+  test("the API is not shadowed by the bundle", async () => {
+    const response = await fetch(`${ORIGIN}/v1/runs`);
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { runs: [] });
+    const health = await fetch(`${ORIGIN}/health`);
+    assert.equal((await health.json()).status, "ok");
+  });
+
+  test("the page boots live against the daemon that served it", async () => {
+    const browser = await chromium.launch();
+    try {
+      const page = await browser.newPage();
+      const errors = [];
+      page.on("console", (message) => message.type() === "error" && errors.push(message.text()));
+      page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+
+      await page.goto(ORIGIN, { waitUntil: "networkidle" });
+
+      assert.equal(await page.title(), "OMAR Mission Control");
+      assert.equal(await page.getByLabel("Describe a workflow").count(), 1);
+      // Demo mode would mean it did not resolve its own origin as the daemon,
+      // which is the entire premise of serving it from here.
+      const body = await page.locator("body").innerText();
+      assert.ok(!body.includes("Demo topology"), "launched in demo mode");
+      // Rendered only after `/v1/agent` answered, so this is the round trip.
+      await page.locator(".backend-trigger").first().waitFor({ timeout: 10_000 });
+      assert.deepEqual(errors, []);
+    } finally {
+      await browser.close();
+    }
+  });
+});
+
+/** Guards the other half: a build without the feature must say so. */
+test("a runtime without the bundle refuses --ui and explains itself", { skip: AVAILABLE }, () => {
+  if (!existsSync(OMAR_BIN)) return;
+  const probe = spawnSync(OMAR_BIN, ["serve", "--ui", "--address", "127.0.0.1:1"], {
+    encoding: "utf8",
+    timeout: 20_000,
+  });
+  const said = `${probe.stdout}${probe.stderr}`;
+  assert.match(said, /no UI in it/);
+  assert.match(said, /--features ui/);
+});
+
+// Referenced so the import is not flagged as unused when everything skips.
+void gunzipSync;

--- a/web/vite.spa.config.ts
+++ b/web/vite.spa.config.ts
@@ -1,0 +1,33 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+/**
+ * The browser-entered build of the same application, for `omar serve --ui`.
+ *
+ * `vite.config.ts` builds the Worker: server-rendered, deployed, and told the
+ * daemon's address at launch. This one is a static bundle the daemon itself
+ * hands out, so it is entered from `spa/index.html` and reads the address from
+ * the page it was served by.
+ *
+ * Output names are fixed rather than hashed, and dynamic imports are inlined,
+ * so what lands in `dist/spa` is a known list of files the runtime can embed
+ * without a manifest. Cache-busting buys nothing on loopback.
+ */
+export default defineConfig({
+  root: "spa",
+  // The logo and favicon live with the Worker build; both entries serve them
+  // from the same place.
+  publicDir: "../public",
+  plugins: [react()],
+  build: {
+    outDir: "../dist/spa",
+    emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        codeSplitting: false,
+        entryFileNames: "app.js",
+        assetFileNames: "app.[ext]",
+      },
+    },
+  },
+});


### PR DESCRIPTION
Stacked on #184 (which is stacked on #183). Retarget as those land.

## Why

`make dev` from #184 needs Node, a checkout, and `web/`. Someone who ran `brew install omar` has none of those — so the UI was not something the product had, it was something the repository had.

```bash
omar serve --ui
```

Hands out Mission Control from the daemon's own address and opens a browser. One process, one port, no Node.

## Same origin is the design, not a detail

Because the page is served by the daemon, it reads the address from the page it was served by:

```tsx
<Studio serveUrl={window.location.origin} />
```

No CORS, no mixed content, and no launch-time mode to get wrong — the failure `make dev` exists to prevent cannot occur here. `OMAR_SERVE_URL` stays for the Worker build, which is served from somewhere else and genuinely cannot know.

## What it cost

`spa/main.tsx` is a browser entry rendering the same `Studio` the Worker renders, built by a second Vite config. **No UI is duplicated** — this was cheap because the only Next imports in the whole client tree were types (`import type { Metadata }`), so nothing had to be rewritten to leave the framework's render.

Stored gzipped, served with `Content-Encoding: gzip`:

| | |
| --- | --- |
| release binary, no feature | 6.69 MB |
| release binary, with UI | **7.36 MB** (+0.67 MB) |
| assets raw / gzipped | 2.20 MB / 0.69 MB |

Downloads are gzipped either way, so the tarball grows by about the same 0.65 MB regardless of how the bytes are stored.

## The feature flag

Embedding means the bundle must exist when the runtime compiles, so it sits behind a `ui` cargo feature:

- `cargo build` — unchanged, no Node, builds everything except this.
- `make build` / the release workflow — build the bundle first, then `--features ui`.
- A binary built without it **refuses `--ui` and prints how to get one**, rather than serving a blank page.

`make install` and building from source now need Node.js 22.13+; the README says so.

## Routing

Matched after every `/v1` route and only for `GET`, so the bundle cannot shadow the API. Anything unrecognised is the shell again — the client owns its routes and a reload on one must not 404.

## Verification

New `Web Serve UI` job runs `web/tests/serve-ui.test.mjs` against a real bundled binary:

- the shell is served with `content-encoding: gzip` from the API's own port;
- `/app.js` is reachable and is a real bundle;
- an unknown path is the shell, not a 404;
- `/v1/runs` and `/health` still answer — the bundle shadows nothing;
- **the page boots in a real browser**: title correct, composer present, *not* in demo mode, and the backend menu renders — which only happens after `/v1/agent` answered same-origin. Zero console errors.

Plus Rust unit tests that every embedded asset really is gzip (magic number) and that unknown paths fall back, and a test that a binary *without* the feature refuses `--ui` and explains itself. Clippy and `cargo fmt` clean both with and without the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)