### PR TITLE
Start people on Mission Control, not on tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ omar serve --ui
 ```
 
 Serves the web UI from the daemon's own address and opens it in your browser.
-The page and the API share an origin, so there is nothing to point at anything.
+The page and the API share an origin, so you don’t need to configure a URL.
 
 > The bundle is compiled into the binary, so this needs an `omar` built with it.
 > Releases carry it from the next tag onward; before that, `make install`. A

--- a/README.md
+++ b/README.md
@@ -78,18 +78,13 @@ $ omar serve --ui
 ```
 
 Serves the web UI from the daemon's own address and opens it in your browser.
-The page and the API share an origin, so you don’t need to configure a URL.
-
-> The bundle is compiled into the binary, so this needs an `omar` built with it.
-> Releases carry it from the next tag onward; before that, `make install`. A
-> binary without it refuses `--ui` and says so rather than serving a blank page.
 
 #### Step 2: Describe a workflow
 
 Type what the team should do. The assistant drafts an OMAR program and shows you
-the topology it compiles to. Nothing runs until you press **Confirm deploy** —
-then the diagram goes live: ports carry values, reactions light up as their
-agents work, and you can open any agent's terminal by double-clicking it.
+the topology it compiles to.
+Nothing runs until you press **Confirm deploy**,
+then the diagram goes live.
 
 ### Terminal UI
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ cd omar && make install
 
 ## Quick Start
 
+#### Step 1: Launch Mission Control
+
+```bash
+$ omar serve --ui
+```
+
+Serves the web UI from the daemon's own address and opens it in your browser.
+The page and the API share an origin, so there is nothing to point at anything.
+
+> The bundle is compiled into the binary, so this needs an `omar` built with it.
+> Releases carry it from the next tag onward; before that, `make install`. A
+> binary without it refuses `--ui` and says so rather than serving a blank page.
+
+#### Step 2: Describe a workflow
+
+Type what the team should do. The assistant drafts an OMAR program and shows you
+the topology it compiles to. Nothing runs until you press **Confirm deploy** —
+then the diagram goes live: ports carry values, reactions light up as their
+agents work, and you can open any agent's terminal by double-clicking it.
+
+### Terminal UI
+
+The same runtime, driven from tmux instead.
+
 #### Step 1: Launch `omar`
 
 ```bash
@@ -97,21 +121,11 @@ Go back to the EA and type in:
 Shutdown the test project and its agents.
 ```
 
-## Mission Control
+## Working on Mission Control
 
-The web client for authoring and observing topology programs lives in
-[`web/`](web/), and is built from this same commit as the runtime it talks to.
-
-If you installed `omar`, it is already in the binary:
-
-```bash
-omar serve --ui
-```
-
-Serves Mission Control from the daemon's own address and opens a browser. The
-page and the API share an origin, so there is nothing to point at anything.
-
-Working on the client itself, use the dev server instead — it reloads:
+The web client lives in [`web/`](web/) and is built from this same commit as the
+runtime it talks to. `omar serve --ui` hands out a bundle compiled into the
+binary; to work on the client itself, use the dev server instead — it reloads:
 
 ```bash
 make dev

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Other features include messaging systems integration (e.g., Slack), computer use
 - Rust 1.70+
 - GNU Make
 - Node.js 22.13+ (to build Mission Control, which `make build` embeds)
-- One or more coding agents: [Claude](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [Codex](https://developers.openai.com/codex/cli), [Cursor](https://cursor.com/cli), [Opencode](https://github.com/anomalyco/opencode), or [Google Antigravity CLI](https://antigravity.google/product/antigravity-cli).
+- One or more coding agents [listed here](#supported-agent-backends).
 
 ### One-liner (recommended)
 
@@ -86,9 +86,9 @@ the topology it compiles to.
 Nothing runs until you press **Confirm deploy**,
 then the diagram goes live.
 
-### Terminal UI
+### Terminal UI (Legacy)
 
-The same runtime, driven from tmux instead.
+Note: The legacy terminal UI does not yet implement the deterministic model in the mission control.
 
 #### Step 1: Launch `omar`
 
@@ -115,20 +115,6 @@ Go back to the EA and type in:
 ```
 Shutdown the test project and its agents.
 ```
-
-## Working on Mission Control
-
-The web client lives in [`web/`](web/) and is built from this same commit as the
-runtime it talks to. `omar serve --ui` hands out a bundle compiled into the
-binary; to work on the client itself, use the dev server instead — it reloads:
-
-```bash
-make dev
-```
-
-Builds the runtime, starts the daemon, starts Mission Control pointed at it,
-and opens a browser. Ctrl-C stops both. Needs Node.js 22.13+; see
-[`web/README.md`](web/README.md).
 
 ## Supported Agent Backends
 


### PR DESCRIPTION
Quick Start opened with `omar`, so the first thing a reader met was the terminal UI — and the web client appeared two sections later, after the backends table. That ordering describes how the project grew, not how it is used now.

## After

**Quick Start**
1. Launch Mission Control — `omar serve --ui`
2. Describe a workflow — what the page actually asks of you, and that nothing runs until **Confirm deploy**

**Terminal UI** — the same runtime from tmux, kept whole: launch, run the test prompt, navigation tips, shutdown.

This is the order the README's own screenshots already use.

The launch instructions leave the old "Mission Control" section, which becomes **"Working on Mission Control"** — `make dev` and `web/`, i.e. developing the client rather than starting it.

## One note added deliberately

> The bundle is compiled into the binary, so this needs an `omar` built with it. Releases carry it from the next tag onward; before that, `make install`.

`omar serve --ui` landed in #185 and no release has been cut since, so anyone who installed via Homebrew or the one-liner has a binary that refuses `--ui`. Without the note, the *first* step of Quick Start would not work for them. It can come out once a release ships — which is worth doing soon for exactly this reason.

Matching change on the website: omar-os/omar.rs#31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)