### PR TITLE
Deploy without deciding what to feed it, and edit the program where you read it

### DIFF
--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -278,6 +278,12 @@ pub trait TopologyObserver: Send + Sync {
         _writes: &BTreeMap<String, Value>,
     ) {
     }
+    /// The run has nothing left to do until the operator sets one of these.
+    ///
+    /// Distinct from finishing: a program with an open input is not over, it is
+    /// waiting, and a client that cannot tell the two apart shows a run as
+    /// complete when nothing has happened yet.
+    fn awaiting_input(&self, _ports: &[String]) {}
     fn run_completed(&self, _outputs: &BTreeMap<String, Value>) {}
     fn run_failed(&self, _message: &str) {}
 }
@@ -339,6 +345,17 @@ impl DiagramPublisher {
 impl TopologyObserver for DiagramPublisher {
     fn run_started(&self) {
         self.publish_status("run_started", "running", json!({}));
+    }
+
+    fn awaiting_input(&self, ports: &[String]) {
+        // Named in the event as well as the status: the client draws a panel
+        // over exactly these, and deriving them from the graph would mean
+        // re-deciding what "open" means in two places.
+        self.publish_status(
+            "awaiting_input",
+            "awaiting_input",
+            json!({ "ports": ports }),
+        );
     }
 
     fn tag_advanced(&self, timestamp: u64, microstep: u64, ports: &BTreeMap<String, Value>) {

--- a/src/omar.rs
+++ b/src/omar.rs
@@ -457,6 +457,9 @@ async fn async_main() -> Result<()> {
                     timeout: Duration::from_secs(timeout_seconds),
                     diagram_address: diagram_server.then_some(diagram_address),
                     diagram_ready: None,
+                    // `omar run` is not interactive: every open input is on the
+                    // command line, and the run finishes when the queue drains.
+                    inbox: None,
                 },
             )
         }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -77,6 +77,20 @@ fn default_timeout_seconds() -> u64 {
 
 type Runs = Arc<Mutex<BTreeMap<String, RunRecord>>>;
 
+/// Where a live run takes operator input.
+///
+/// Held apart from `RunRecord` because a record is serialised to callers and a
+/// channel is not. Dropped when the run ends, which is also what tells a late
+/// sender the run is over.
+struct Inbox {
+    sender: mpsc::Sender<BTreeMap<String, Value>>,
+    /// The open inputs and their types. Kept here so a value can be checked
+    /// against the port it is for without recompiling the program per request.
+    open: BTreeMap<String, String>,
+}
+
+type Inboxes = Arc<Mutex<BTreeMap<String, Inbox>>>;
+
 /// One entry in the operator/EA conversation. `design` is set only on
 /// proposals, and carries a program the operator has *not* yet approved.
 #[derive(Debug, Clone, Serialize)]
@@ -141,6 +155,7 @@ struct Context_ {
     default_workdir: String,
     health_idle_warning: i64,
     runs: Runs,
+    inboxes: Inboxes,
     chat: Arc<Mutex<Chat>>,
     /// Authenticates the EA's MCP sidecar on the agent-only endpoints.
     agent_token: String,
@@ -231,6 +246,7 @@ impl Serve {
             default_workdir: config.agent.default_workdir.clone(),
             health_idle_warning: config.health.idle_warning,
             runs: Runs::default(),
+            inboxes: Inboxes::default(),
             chat: Arc::new(Mutex::new(Chat::default())),
             agent_token: agent_token.clone(),
             command: Arc::new(Mutex::new(config.agent.default_command.clone())),
@@ -557,6 +573,16 @@ fn handle_client(mut stream: TcpStream, context: Arc<Context_>) -> Result<()> {
         ("GET", "/v1/runs") => {
             let runs = context.runs.lock().expect("serve runs poisoned");
             (200, json!({"runs": runs.values().collect::<Vec<_>>()}))
+        }
+        ("POST", rest) if rest.starts_with("/v1/runs/") && rest.ends_with("/inputs") => {
+            let id = rest
+                .trim_start_matches("/v1/runs/")
+                .trim_end_matches("/inputs");
+            if content_length > MAX_BODY_BYTES {
+                (413, json!({"error": "inputs too large"}))
+            } else {
+                send_run_inputs(&context, id, &read_body(content_length)?)
+            }
         }
         ("GET", rest) if rest.starts_with("/v1/runs/") => {
             let id = rest.trim_start_matches("/v1/runs/");
@@ -1006,7 +1032,10 @@ fn start_run(context: &Arc<Context_>, body: &[u8]) -> (u16, Value) {
         Ok(inputs) => inputs,
         Err(error) => return (400, json!({"error": format!("{error:#}")})),
     };
-    if let Err(error) = topology::parse_inputs(&state, &inputs) {
+    // Only what was supplied is checked. Deploying is not the same act as
+    // deciding what to feed the program: the rest arrive over
+    // `POST /v1/runs/{id}/inputs`, and until they do the run waits.
+    if let Err(error) = topology::parse_partial_inputs(&state, &inputs) {
         return (400, json!({"error": format!("{error:#}")}));
     }
 
@@ -1041,7 +1070,31 @@ fn start_run(context: &Arc<Context_>, body: &[u8]) -> (u16, Value) {
         .insert(run_id.clone(), record);
 
     let (ready_sender, ready_receiver) = mpsc::channel();
-    spawn_run_thread(context, &run_id, bytecode, inputs, &request, ready_sender);
+    let (input_sender, input_receiver) = mpsc::channel();
+    let open = topology::open_inputs(&state)
+        .into_iter()
+        .filter_map(|name| state.ports.get(&name).map(|port| (name, port.ty.clone())))
+        .collect();
+    context
+        .inboxes
+        .lock()
+        .expect("serve inboxes poisoned")
+        .insert(
+            run_id.clone(),
+            Inbox {
+                sender: input_sender,
+                open,
+            },
+        );
+    spawn_run_thread(
+        context,
+        &run_id,
+        bytecode,
+        inputs,
+        &request,
+        ready_sender,
+        input_receiver,
+    );
 
     match ready_receiver.recv_timeout(DIAGRAM_READY_TIMEOUT) {
         Ok(diagram_address) => {
@@ -1066,6 +1119,73 @@ fn start_run(context: &Arc<Context_>, body: &[u8]) -> (u16, Value) {
     }
 }
 
+/// Values the operator set, on their way to a live run.
+#[derive(Debug, Deserialize)]
+struct RunInputs {
+    values: BTreeMap<String, Value>,
+}
+
+/// Push a batch of operator-set inputs into a running topology.
+///
+/// Everything in one request lands at one tag, which is the point of batching
+/// them: a reaction reading two of these ports sees both together rather than
+/// firing once per value. Values are checked against the port types here, so a
+/// mistyped one is a 400 rather than a run that fails later for a reason the
+/// caller cannot connect to what they sent.
+fn send_run_inputs(context: &Arc<Context_>, run_id: &str, body: &[u8]) -> (u16, Value) {
+    let request: RunInputs = match serde_json::from_slice(body) {
+        Ok(request) => request,
+        Err(error) => return (400, json!({"error": format!("invalid request: {error}")})),
+    };
+    if request.values.is_empty() {
+        return (400, json!({"error": "no values to send"}));
+    }
+
+    let state = {
+        let runs = context.runs.lock().expect("serve runs poisoned");
+        match runs.get(run_id) {
+            None => return (404, json!({"error": "unknown run"})),
+            Some(record) if !is_active(&record.status) => {
+                return (409, json!({"error": format!("run is {}", record.status)}))
+            }
+            Some(record) => record.team.clone(),
+        }
+    };
+
+    let sender = {
+        let inboxes = context.inboxes.lock().expect("serve inboxes poisoned");
+        let inbox = match inboxes.get(run_id) {
+            Some(inbox) => inbox,
+            // The record is still active but the run has let go of its inbox,
+            // so it is on its way down.
+            None => return (409, json!({"error": "run is no longer taking input"})),
+        };
+        for (name, value) in &request.values {
+            // Only open inputs: everything else takes its value from a
+            // connection, and writing one from outside would be a second
+            // writer the program does not describe.
+            let Some(ty) = inbox.open.get(name) else {
+                return (
+                    400,
+                    json!({"error": format!("'{name}' is not an open input of this run")}),
+                );
+            };
+            if let Err(error) = topology::validate_value(ty, value) {
+                return (400, json!({"error": format!("{name}: {error:#}")}));
+            }
+        }
+        inbox.sender.clone()
+    };
+
+    match sender.send(request.values.clone()) {
+        Ok(()) => (
+            202,
+            json!({"run_id": run_id, "team": state, "sent": request.values.keys().collect::<Vec<_>>()}),
+        ),
+        Err(_) => (409, json!({"error": "run is no longer taking input"})),
+    }
+}
+
 fn spawn_run_thread(
     context: &Arc<Context_>,
     run_id: &str,
@@ -1073,6 +1193,7 @@ fn spawn_run_thread(
     inputs: Vec<String>,
     request: &StartRunRequest,
     ready_sender: mpsc::Sender<SocketAddr>,
+    input_receiver: mpsc::Receiver<BTreeMap<String, Value>>,
 ) {
     let context = context.clone();
     let run_id = run_id.to_string();
@@ -1093,8 +1214,14 @@ fn spawn_run_thread(
                 timeout,
                 diagram_address: Some(diagram_address),
                 diagram_ready: Some(ready_sender),
+                inbox: Some(input_receiver),
             },
         );
+        context
+            .inboxes
+            .lock()
+            .expect("serve inboxes poisoned")
+            .remove(&run_id);
         let mut runs = context.runs.lock().expect("serve runs poisoned");
         if let Some(record) = runs.get_mut(&run_id) {
             record.finished_at = Some(now_unix());

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -570,6 +570,13 @@ fn handle_client(mut stream: TcpStream, context: Arc<Context_>) -> Result<()> {
                 agent_proposal(&context, &read_body(content_length)?)
             }
         }
+        ("POST", "/v1/programs/check") => {
+            if content_length > MAX_BODY_BYTES {
+                (413, json!({"error": "program too large"}))
+            } else {
+                check_program(&read_body(content_length)?)
+            }
+        }
         ("GET", "/v1/runs") => {
             let runs = context.runs.lock().expect("serve runs poisoned");
             (200, json!({"runs": runs.values().collect::<Vec<_>>()}))
@@ -1115,6 +1122,74 @@ fn start_run(context: &Arc<Context_>, body: &[u8]) -> (u16, Value) {
                 .and_then(|record| record.error.clone())
                 .unwrap_or_else(|| "run did not start".to_string());
             (500, json!({"error": message, "run_id": run_id}))
+        }
+    }
+}
+
+/// A program to compile, and what to call it while doing so.
+#[derive(Debug, Deserialize)]
+struct CheckRequest {
+    program: String,
+    /// Shown in errors, so a message names the file the operator is editing.
+    /// Must end in `.omar`, which is the compiler's own rule.
+    #[serde(default)]
+    filename: Option<String>,
+}
+
+/// Compile a program and say whether it holds together, without running it.
+///
+/// The editor asks this on every pause in typing. It is the same compiler and
+/// the same verifier a deploy would use — checking with anything less would
+/// mean a program that passes here and is refused a moment later.
+fn check_program(body: &[u8]) -> (u16, Value) {
+    let request: CheckRequest = match serde_json::from_slice(body) {
+        Ok(request) => request,
+        Err(error) => return (400, json!({"error": format!("invalid request: {error}")})),
+    };
+
+    let name = request.filename.as_deref().unwrap_or("program.omar");
+    // The compiler rejects any other extension, and doing that here names the
+    // problem as the filename rather than as a compile failure.
+    if !name.ends_with(".omar") || name.contains('/') || name.contains('\\') {
+        return (
+            200,
+            json!({"ok": false, "errors": [format!("'{name}' is not a program file name: it must be a plain name ending in .omar")]}),
+        );
+    }
+
+    // Its own directory per check, so the file can carry the operator's name
+    // without two checks colliding over it. Removed on the way out.
+    let directory = match crate::paths::private_temp_dir()
+        .map(|root| root.join(format!("omar-check-{}", Uuid::new_v4())))
+        .and_then(|directory| fs::create_dir_all(&directory).map(|_| directory))
+    {
+        Ok(directory) => directory,
+        Err(error) => return (500, json!({"error": format!("{error}")})),
+    };
+    let path = directory.join(name);
+    if let Err(error) = fs::write(&path, &request.program) {
+        let _ = fs::remove_dir_all(&directory);
+        return (500, json!({"error": format!("{error}")}));
+    }
+
+    // Compiling is half of it: `verify` is what catches a program that parses
+    // and still cannot run, which is most of what an editor should say early.
+    let outcome = topology::load_program(&path).and_then(|bytecode| topology::verify(&bytecode));
+    let _ = fs::remove_dir_all(&directory);
+    match outcome {
+        Ok(state) => (
+            200,
+            json!({
+                "ok": true,
+                "team": state.team,
+                "open_inputs": topology::open_inputs(&state),
+            }),
+        ),
+        Err(error) => {
+            // The compiler names the file it was given, which is a scratch path
+            // nobody asked about. Say the name the operator is looking at.
+            let message = format!("{error:#}").replace(&format!("{}/", directory.display()), "");
+            (200, json!({"ok": false, "errors": [message]}))
         }
     }
 }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -815,7 +815,12 @@ fn validate_invocation_owner(team: &str, agent: &str, invocation: &InvocationRec
     Ok(())
 }
 
-fn validate_value(ty: &str, value: &Value) -> Result<()> {
+/// Whether a value is usable as a port of this type.
+///
+/// Public because `omar serve` checks what the operator sends before it reaches
+/// a run: a mistyped value is a rejected request, not a run that fails later
+/// for a reason nobody can trace back to what they typed.
+pub fn validate_value(ty: &str, value: &Value) -> Result<()> {
     if let Some(inner) = generic_inner(ty, "list") {
         let values = value
             .as_array()
@@ -1050,6 +1055,13 @@ pub struct TopologyRunConfig<'a> {
     /// Receives the bound diagram address once the server is up. `omar serve`
     /// needs it while the run is still in flight; `omar run` prints it instead.
     pub diagram_ready: Option<mpsc::Sender<std::net::SocketAddr>>,
+    /// Values the operator sends after the run has started.
+    ///
+    /// Present, the run may be deployed before anyone has decided what to feed
+    /// it: open inputs need not be supplied up front, and the loop waits for
+    /// them rather than finishing. Absent — `omar run` — every open input is
+    /// required at the command line, as it always was.
+    pub inbox: Option<mpsc::Receiver<BTreeMap<String, Value>>>,
 }
 
 pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Result<()> {
@@ -1088,7 +1100,13 @@ pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Resul
     let prepared = (|| -> Result<(InvocationServer, BTreeMap<String, Value>)> {
         let invocation_server = InvocationServer::start()?;
         spawn_topology_agents(&state, &client, &runtime_dir, &invocation_server, &config)?;
-        let inputs = parse_inputs(&state, config.inputs)?;
+        // Agents are up either way. What differs is whether the program can
+        // start: with an inbox the operator supplies open inputs afterwards.
+        let inputs = if config.inbox.is_some() {
+            parse_partial_inputs(&state, config.inputs)?
+        } else {
+            parse_inputs(&state, config.inputs)?
+        };
         Ok((invocation_server, inputs))
     })();
     let (invocation_server, inputs) = match prepared {
@@ -1104,13 +1122,14 @@ pub fn run_topology(bytecode: &Bytecode, config: TopologyRunConfig<'_>) -> Resul
         registry: invocation_server.registry.clone(),
         timeout: config.timeout,
     };
-    let outputs = match run_event_loop_observed(&state, inputs, &executor, observer) {
-        Ok(outputs) => outputs,
-        Err(error) => {
-            observer.run_failed(&error.to_string());
-            return Err(error);
-        }
-    };
+    let outputs =
+        match run_event_loop_fed(&state, inputs, &executor, observer, config.inbox.as_ref()) {
+            Ok(outputs) => outputs,
+            Err(error) => {
+                observer.run_failed(&error.to_string());
+                return Err(error);
+            }
+        };
     observer.run_completed(&outputs);
     write_json_atomic(&runtime_dir.join("state.json"), &state)?;
     println!("Topology '{}' completed", state.team);
@@ -1184,7 +1203,47 @@ fn spawn_topology_agents(
     Ok(())
 }
 
+/// Input ports nothing inside the topology writes to.
+///
+/// These are the operator's to set; every other input takes its value from a
+/// connection. A program whose open inputs are unset and whose timers have not
+/// fired has nothing that can advance it — which is the point: it is waiting,
+/// not finished.
+pub fn open_inputs(state: &VmState) -> Vec<String> {
+    state
+        .ports
+        .iter()
+        .filter(|(name, port)| {
+            port.kind == PortKind::Input
+                && !state
+                    .connections
+                    .iter()
+                    .any(|connection| connection.target == **name)
+        })
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
+/// Every open input must be supplied: the run starts and finishes in one go.
 pub fn parse_inputs(state: &VmState, raw_inputs: &[String]) -> Result<BTreeMap<String, Value>> {
+    parse_inputs_inner(state, raw_inputs, true)
+}
+
+/// Only what is supplied is checked. The rest are left for the operator to send
+/// once the run is up, which is how a run can be deployed before anyone has
+/// decided what to feed it.
+pub fn parse_partial_inputs(
+    state: &VmState,
+    raw_inputs: &[String],
+) -> Result<BTreeMap<String, Value>> {
+    parse_inputs_inner(state, raw_inputs, false)
+}
+
+fn parse_inputs_inner(
+    state: &VmState,
+    raw_inputs: &[String],
+    require_all: bool,
+) -> Result<BTreeMap<String, Value>> {
     let mut inputs = BTreeMap::new();
     for raw in raw_inputs {
         let (name, raw_value) = raw
@@ -1207,16 +1266,14 @@ pub fn parse_inputs(state: &VmState, raw_inputs: &[String]) -> Result<BTreeMap<S
         validate_value(&port.ty, &value)?;
         inputs.insert(name.to_string(), value);
     }
-    for (name, port) in &state.ports {
-        // An input fed by a connection gets its value from inside the topology,
-        // so the operator has nothing to supply. Supplying one anyway is still
-        // allowed: that is how a feedback loop is seeded.
-        let connected = state
-            .connections
-            .iter()
-            .any(|connection| connection.target == *name);
-        if port.kind == PortKind::Input && !connected && !inputs.contains_key(name) {
-            bail!("missing input '{name}'");
+    if require_all {
+        for name in open_inputs(state) {
+            // An input fed by a connection gets its value from inside the
+            // topology, so the operator has nothing to supply. Supplying one
+            // anyway is still allowed: that is how a feedback loop is seeded.
+            if !inputs.contains_key(&name) {
+                bail!("missing input '{name}'");
+            }
         }
     }
     Ok(inputs)
@@ -1297,15 +1354,33 @@ fn run_event_loop<E: ReactionExecutor>(
     inputs: BTreeMap<String, Value>,
     executor: &E,
 ) -> Result<BTreeMap<String, Value>> {
-    run_event_loop_observed(state, inputs, executor, &NoopTopologyObserver)
+    run_event_loop_fed(state, inputs, executor, &NoopTopologyObserver, None)
 }
 
-fn run_event_loop_observed<E: ReactionExecutor>(
+/// The event loop, optionally fed by the operator while it runs.
+///
+/// Without an `inbox` this is what it always was: seed the queue, drain it,
+/// return. With one, a drained queue is not the end — a program with an open
+/// input nobody has set yet is waiting rather than finished, and this blocks
+/// until someone sets it. Everything sent in one message lands at one tag, so
+/// reactions reading several of those ports see them together rather than
+/// firing once per value.
+fn run_event_loop_fed<E: ReactionExecutor>(
     state: &VmState,
     inputs: BTreeMap<String, Value>,
     executor: &E,
     observer: &dyn TopologyObserver,
+    inbox: Option<&mpsc::Receiver<BTreeMap<String, Value>>>,
 ) -> Result<BTreeMap<String, Value>> {
+    // What the operator still owes the program. Seeded with whatever came in at
+    // admission, so a run given everything up front never waits.
+    let mut unset: BTreeSet<String> = open_inputs(state)
+        .into_iter()
+        .filter(|name| !inputs.contains_key(name))
+        .collect();
+    // Where injected values land: after everything already seen, so they cannot
+    // arrive at a tag the run has moved past.
+    let mut frontier = Tag::START;
     let mut queue = BTreeMap::from([(Tag::START, inputs)]);
     // Arm every timer for its first firing. A timer's value is the timestamp it
     // fired at, which is what makes `$(t)` in a prompt worth reading.
@@ -1321,7 +1396,29 @@ fn run_event_loop_observed<E: ReactionExecutor>(
     let mut outputs = BTreeMap::new();
     let mut steps = 0usize;
 
-    while let Some((tag, events)) = queue.pop_first() {
+    loop {
+        let Some((tag, events)) = queue.pop_first() else {
+            // Nothing to do at any tag. Whether that is the end depends on
+            // whether anyone can still make something happen.
+            let Some(inbox) = inbox else { break };
+            if unset.is_empty() {
+                break;
+            }
+            let pending: Vec<String> = unset.iter().cloned().collect();
+            observer.awaiting_input(&pending);
+            let Ok(values) = inbox.recv() else { break };
+            let arrival = Tag {
+                timestamp: frontier.timestamp.saturating_add(1),
+                microstep: 0,
+            };
+            let slot = queue.entry(arrival).or_default();
+            for (name, value) in values {
+                unset.remove(&name);
+                slot.insert(name, value);
+            }
+            continue;
+        };
+        frontier = tag;
         observer.tag_advanced(tag.timestamp, tag.microstep, &events);
         steps += 1;
         if steps > 1024 {
@@ -2114,6 +2211,209 @@ mod tests {
         .unwrap();
         let error = verify(&orphan).unwrap_err().to_string();
         assert!(error.contains("undeclared parent 'b'"), "{error}");
+    }
+
+    /// A two-input program with nothing feeding it: exactly the shape that has
+    /// to sit still until the operator sends something.
+    fn open_input_bytecode() -> Bytecode {
+        serde_json::from_str(
+            r#"{
+              "version": 1,
+              "team": "Desk",
+              "instructions": [
+                {"op":"begin_plan","team":"Desk"},
+                {"op":"spawn_agent","name":"clerk","backend":"Codex"},
+                {"op":"define_port","kind":"input","name":"topic","type":"string"},
+                {"op":"define_port","kind":"input","name":"depth","type":"int"},
+                {"op":"define_port","kind":"output","name":"memo","type":"string"},
+                {"op":"install_reaction","id":"reaction.0","agent":"clerk",
+                 "triggers":["topic","depth"],"effects":["memo"],
+                 "contract":"memo","prompt":"p"},
+                {"op":"commit_plan"}
+              ]
+            }"#,
+        )
+        .unwrap()
+    }
+
+    /// Records which triggers arrived together, which is how a batch sent at
+    /// one tag is told apart from values dribbled in one at a time.
+    struct BatchExecutor {
+        seen: Mutex<Vec<Vec<String>>>,
+    }
+
+    impl ReactionExecutor for BatchExecutor {
+        fn invoke(&self, invocation: InvocationSpec) -> Result<BTreeMap<String, Value>> {
+            self.seen
+                .lock()
+                .unwrap()
+                .push(invocation.trigger_values.keys().cloned().collect());
+            let writes = BTreeMap::from([("memo".into(), json!("done"))]);
+            validate_contract(&invocation.contract, &writes)?;
+            Ok(writes)
+        }
+    }
+
+    #[test]
+    fn open_inputs_are_the_ones_nothing_writes_to() {
+        let state = verify(&open_input_bytecode()).unwrap();
+        assert_eq!(open_inputs(&state), vec!["depth", "topic"]);
+
+        // An input a connection targets belongs to the topology, not to the
+        // operator, so it is not theirs to set.
+        let state = verify(&program()).unwrap();
+        for name in open_inputs(&state) {
+            assert!(
+                !state.connections.iter().any(|c| c.target == name),
+                "{name} is fed by a connection"
+            );
+        }
+    }
+
+    #[test]
+    fn a_run_with_an_unset_open_input_waits_instead_of_finishing() {
+        let state = verify(&open_input_bytecode()).unwrap();
+        let executor = BatchExecutor {
+            seen: Mutex::new(Vec::new()),
+        };
+        let (sender, receiver) = mpsc::channel();
+
+        // Everything the operator owes, in one message: the reaction must see
+        // both triggers in one invocation rather than firing twice.
+        sender
+            .send(BTreeMap::from([
+                ("topic".to_string(), json!("nesting")),
+                ("depth".to_string(), json!(3)),
+            ]))
+            .unwrap();
+        drop(sender);
+
+        let outputs = run_event_loop_fed(
+            &state,
+            BTreeMap::new(),
+            &executor,
+            &NoopTopologyObserver,
+            Some(&receiver),
+        )
+        .unwrap();
+
+        let seen = executor.seen.lock().unwrap().clone();
+        assert_eq!(seen, vec![vec!["depth".to_string(), "topic".to_string()]]);
+        assert_eq!(outputs.get("memo"), Some(&json!("done")));
+    }
+
+    #[test]
+    fn a_partly_fed_run_keeps_waiting_for_the_rest() {
+        let state = verify(&open_input_bytecode()).unwrap();
+        let executor = BatchExecutor {
+            seen: Mutex::new(Vec::new()),
+        };
+        let (sender, receiver) = mpsc::channel();
+
+        // One port now, the other later: two tags, so the reaction runs twice.
+        sender
+            .send(BTreeMap::from([("topic".to_string(), json!("nesting"))]))
+            .unwrap();
+        sender
+            .send(BTreeMap::from([("depth".to_string(), json!(3))]))
+            .unwrap();
+        drop(sender);
+
+        run_event_loop_fed(
+            &state,
+            BTreeMap::new(),
+            &executor,
+            &NoopTopologyObserver,
+            Some(&receiver),
+        )
+        .unwrap();
+
+        let seen = executor.seen.lock().unwrap().clone();
+        assert_eq!(
+            seen,
+            vec![vec!["topic".to_string()], vec!["depth".to_string()]],
+            "each send is its own tag"
+        );
+    }
+
+    #[test]
+    fn a_run_given_everything_up_front_never_waits() {
+        // The inbox is present but empty and never dropped. If the loop waited
+        // on it this test would hang rather than fail, so it is also the guard
+        // against waiting when there is nothing left to wait for.
+        let state = verify(&open_input_bytecode()).unwrap();
+        let executor = BatchExecutor {
+            seen: Mutex::new(Vec::new()),
+        };
+        let (_sender, receiver) = mpsc::channel();
+
+        let outputs = run_event_loop_fed(
+            &state,
+            BTreeMap::from([
+                ("topic".to_string(), json!("nesting")),
+                ("depth".to_string(), json!(3)),
+            ]),
+            &executor,
+            &NoopTopologyObserver,
+            Some(&receiver),
+        )
+        .unwrap();
+
+        assert_eq!(outputs.get("memo"), Some(&json!("done")));
+    }
+
+    #[test]
+    fn an_operator_value_lands_after_everything_already_run() {
+        // The injected tag is placed past the frontier, so a value the operator
+        // sends cannot arrive at a tag the run has already moved through.
+        struct TagRecorder {
+            tags: Mutex<Vec<(u64, u64)>>,
+        }
+        impl TopologyObserver for TagRecorder {
+            fn tag_advanced(
+                &self,
+                timestamp: u64,
+                microstep: u64,
+                _ports: &BTreeMap<String, Value>,
+            ) {
+                self.tags.lock().unwrap().push((timestamp, microstep));
+            }
+        }
+
+        let state = verify(&open_input_bytecode()).unwrap();
+        let executor = BatchExecutor {
+            seen: Mutex::new(Vec::new()),
+        };
+        let observer = TagRecorder {
+            tags: Mutex::new(Vec::new()),
+        };
+        let (sender, receiver) = mpsc::channel();
+        sender
+            .send(BTreeMap::from([
+                ("topic".to_string(), json!("a")),
+                ("depth".to_string(), json!(1)),
+            ]))
+            .unwrap();
+        drop(sender);
+
+        run_event_loop_fed(
+            &state,
+            BTreeMap::new(),
+            &executor,
+            &observer,
+            Some(&receiver),
+        )
+        .unwrap();
+
+        let tags = observer.tags.lock().unwrap().clone();
+        // Tag 0 is the empty start; the batch lands at 1, and the memo it
+        // produces at the microstep after.
+        assert_eq!(tags[0], (0, 0));
+        assert_eq!(tags[1], (1, 0));
+        assert!(
+            tags.iter().all(|(timestamp, _)| *timestamp <= 1),
+            "nothing ran before the batch: {tags:?}"
+        );
     }
 
     /// Records the tag every invocation arrived at, so a timer's schedule can

--- a/web/app/diagram/diagram-canvas.tsx
+++ b/web/app/diagram/diagram-canvas.tsx
@@ -991,12 +991,17 @@ export function DiagramCanvas({
   selection = [],
   onToggleComponent,
   onOpenTerminal,
+  openInputs,
+  onSetInput,
 }: {
   snapshot: DiagramSnapshot;
   selection?: string[];
   onToggleComponent?: (component: string) => void;
   /** Given only while agents are actually running and can be attached to. */
   onOpenTerminal?: (agent: string) => void;
+  /** Port ids the operator may set: inputs nothing in the topology writes to. */
+  openInputs?: ReadonlySet<string>;
+  onSetInput?: (portId: string) => void;
 }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const [layout, setLayout] = useState<Layout | null>(null);
@@ -1408,8 +1413,26 @@ export function DiagramCanvas({
               {layout.ports.map((port) => (
                 <g
                   key={port.id}
-                  {...selectable(port.id, `omar-port-group ${port.kind}`)}
+                  {...selectable(
+                    port.id,
+                    `omar-port-group ${port.kind}${
+                      openInputs?.has(port.id) ? " open-input" : ""
+                    }`,
+                  )}
                   transform={`translate(${port.center.x},${port.center.y})`}
+                  // An open input is the operator's to set, so clicking it
+                  // opens the panel on that port rather than only selecting it.
+                  onClickCapture={
+                    openInputs?.has(port.id) && onSetInput
+                      ? (event) => {
+                          event.stopPropagation();
+                          // The id, not the drawn name: the label is
+                          // stripped of its instance prefix and the runtime
+                          // wants the qualified port.
+                          onSetInput(port.id);
+                        }
+                      : undefined
+                  }
                 >
                   <polygon className="omar-port" points={portTriangle(ORIGIN)} />
                   {/* Sits above the connection line so routing never crosses text. */}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1437,6 +1437,147 @@ h2 {
 
 /* A terminal attached to a running agent. It sits over the studio rather than
    in a separate window so the diagram stays behind it for context. */
+/* Set values for open input ports.
+
+   Slides in over the diagram rather than replacing it: the operator picked
+   these ports by clicking them, and a list of qualified names is much easier to
+   place when the drawing is still behind it. */
+.input-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 35;
+  width: min(420px, 92vw);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px;
+  background: var(--panel);
+  border-left: 1px solid var(--line);
+  box-shadow: -24px 0 60px rgba(0, 0, 0, 0.5);
+  animation: input-panel-in 160ms ease-out;
+}
+
+@keyframes input-panel-in {
+  from {
+    transform: translateX(16px);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .input-panel {
+    animation: none;
+  }
+}
+
+.input-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.input-panel-head h2 {
+  margin: 2px 0 0;
+  font-size: 15px;
+}
+
+.input-panel-close {
+  border: 0;
+  background: transparent;
+  color: #9d97a8;
+  font-size: 11px;
+  text-decoration: underline;
+}
+
+.input-panel-close:hover {
+  color: #d8caff;
+}
+
+.input-panel-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+/* Scrolls on its own: a program can have more open inputs than fit. */
+.input-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.input-port {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 8px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-2);
+}
+
+/* The one the operator clicked on the diagram. */
+.input-port.focused {
+  border-color: var(--purple);
+  box-shadow: 0 0 0 1px var(--purple-soft);
+}
+
+.input-port-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.input-port-type {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.input-port input {
+  grid-column: 1 / -1;
+  width: 100%;
+  padding: 7px 9px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--ink);
+  color: var(--text);
+  font-size: 13px;
+}
+
+.input-port input:focus {
+  outline: none;
+  border-color: var(--purple);
+}
+
+.input-panel-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+/* An open input is the operator's to set, so it reads as actionable rather
+   than as one more thing the drawing happens to contain. */
+.omar-port-group.open-input {
+  cursor: pointer;
+}
+
+.omar-port-group.open-input .omar-port {
+  stroke: var(--purple);
+  stroke-width: 1.5;
+}
+
+.omar-port-group.open-input:hover .omar-port {
+  fill: var(--purple);
+}
+
 .terminal-overlay {
   position: fixed;
   inset: 0;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1149,6 +1149,90 @@ h2 {
   white-space: pre-wrap;
 }
 
+/* The editable source: a transparent textarea over the highlighted text.
+
+   Every metric that decides where a glyph lands has to match between the two,
+   or the caret drifts from the colours behind it. They share one font
+   shorthand, one padding, and one wrapping rule; the pair below is the place to
+   change any of them. */
+.source-editor {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: grid;
+}
+
+.source-editor > .source-code,
+.source-input {
+  grid-area: 1 / 1;
+  margin: 0;
+  padding: 16px;
+  border: 0;
+  font: 10.5px/1.75 ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  tab-size: 2;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  overflow: auto;
+}
+
+.source-input {
+  resize: none;
+  background: transparent;
+  /* Transparent text over the highlighting, with a visible caret. */
+  color: transparent;
+  caret-color: #d8caff;
+  outline: none;
+}
+
+.source-input::selection {
+  background: var(--purple-soft);
+}
+
+.source-name {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  padding: 2px 6px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+
+.source-name:hover {
+  border-color: var(--line);
+}
+
+.source-name:focus {
+  outline: none;
+  border-color: var(--purple);
+  background: var(--ink);
+}
+
+/* What the compiler said. It is the same compiler a deploy would use, so this
+   is not advice — it is the reason a deploy would be refused. */
+.source-errors {
+  flex: none;
+  max-height: 30%;
+  overflow-y: auto;
+  padding: 10px 16px;
+  border-top: 1px solid var(--line);
+  background: rgba(194, 96, 122, 0.08);
+  color: #e7a9b8;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.source-errors p {
+  margin: 0 0 6px;
+  overflow-wrap: anywhere;
+}
+
+.source-errors p:last-child {
+  margin-bottom: 0;
+}
+
 .event-strip {
   flex: 1;
   min-height: 0;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1398,7 +1398,11 @@ h2 {
    the nodes drawn on it, since a node's box is mostly the gap between its
    glyph and its label. Events fall through to the canvas, which still pans. */
 .omar-team-body,
-.omar-team-title {
+.omar-team-title,
+/* The shadow is drawn past the container's edge, which is exactly where a
+   port sits, so left hit-testable it swallows clicks on the ports it is
+   behind. */
+.omar-team-shadow {
   pointer-events: none;
 }
 
@@ -1555,6 +1559,18 @@ h2 {
 .input-port input:focus {
   outline: none;
   border-color: var(--purple);
+}
+
+/* Typed text that cannot be read as the port's type. Caught here rather than
+   by the run refusing the batch. */
+.input-port.invalid input {
+  border-color: #c2607a;
+}
+
+.input-port-problem {
+  grid-column: 1 / -1;
+  color: #d98aa0;
+  font-size: 11px;
 }
 
 .input-panel-empty {

--- a/web/app/input-panel.tsx
+++ b/web/app/input-panel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { FormEvent, useEffect, useRef, useState } from "react";
+
+import type { DiagramPort } from "./lib/protocol";
+
+/**
+ * The ports the operator sets, and the one act of setting them.
+ *
+ * Deploying a program and deciding what to feed it are separate: the run comes
+ * up, spawns its agents, and then sits at its first tag with nothing to do. This
+ * is where that changes. Everything typed here is sent in one message and lands
+ * at one tag, so a reaction reading several of these ports sees them together
+ * rather than firing once per value — which is why there is a Send button
+ * rather than a field that commits on blur.
+ *
+ * It slides in over the diagram rather than replacing it: the operator picked
+ * these ports by clicking them, and losing sight of where they are would make
+ * a long list of qualified names hard to place.
+ */
+export function InputPanel({
+  ports,
+  focused,
+  pending,
+  onClose,
+  onSend,
+}: {
+  ports: DiagramPort[];
+  /** The id of the port the operator clicked, scrolled to and highlighted. */
+  focused: string | null;
+  pending: boolean;
+  onClose: () => void;
+  onSend: (values: Record<string, string>) => void;
+}) {
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const focusedRef = useRef<HTMLInputElement | null>(null);
+
+  // Clicking a port on the diagram while the panel is open moves the focus
+  // here rather than opening a second panel, so a long list stays navigable.
+  useEffect(() => {
+    if (!focused) return;
+    focusedRef.current?.scrollIntoView({ block: "nearest" });
+    focusedRef.current?.focus();
+  }, [focused]);
+
+  useEffect(() => {
+    const dismiss = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", dismiss);
+    return () => window.removeEventListener("keydown", dismiss);
+  }, [onClose]);
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    // Only what was typed. An untouched port stays unset, and the run keeps
+    // waiting for it, which is what an open input means.
+    const values = Object.fromEntries(
+      Object.entries(draft).filter(([, value]) => value.trim() !== ""),
+    );
+    if (Object.keys(values).length === 0) return;
+    onSend(values);
+    setDraft({});
+  }
+
+  const filled = Object.values(draft).filter((value) => value.trim() !== "").length;
+
+  return (
+    <aside className="input-panel" role="dialog" aria-label="Set input ports">
+      <div className="input-panel-head">
+        <div>
+          <span className="eyebrow">INPUT PORTS</span>
+          <h2>Set values</h2>
+        </div>
+        <button type="button" className="input-panel-close" onClick={onClose}>
+          Close
+        </button>
+      </div>
+
+      <p className="input-panel-note">
+        Nothing runs until these arrive. Everything you send goes in at the same
+        tag.
+      </p>
+
+      <form className="input-panel-body" onSubmit={submit}>
+        {ports.map((port) => (
+          <label
+            key={port.id}
+            className={["input-port", port.id === focused ? "focused" : ""]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            <span className="input-port-name">{port.name}</span>
+            <span className="input-port-type">{port.type}</span>
+            <input
+              ref={port.id === focused ? focusedRef : undefined}
+              value={draft[port.name] ?? ""}
+              onChange={(event) =>
+                setDraft((current) => ({ ...current, [port.name]: event.target.value }))
+              }
+              // The value already carried is what the run has, so a port that
+              // has been set once reads as set rather than empty.
+              placeholder={port.value === null ? port.type : String(port.value)}
+              aria-label={`${port.name} (${port.type})`}
+            />
+          </label>
+        ))}
+        {ports.length === 0 ? (
+          <p className="input-panel-empty">
+            This program has no open inputs. It starts on its own, or on a timer.
+          </p>
+        ) : null}
+        <button type="submit" className="primary-button" disabled={pending || filled === 0}>
+          {pending ? "Sending…" : `Send ${filled || ""}`.trim()}
+        </button>
+      </form>
+    </aside>
+  );
+}

--- a/web/app/input-panel.tsx
+++ b/web/app/input-panel.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useEffect, useRef, useState } from "react";
 
-import type { DiagramPort } from "./lib/protocol";
+import { parseInputValue, type DiagramPort } from "./lib/protocol";
 
 /**
  * The ports the operator sets, and the one act of setting them.
@@ -30,7 +30,7 @@ export function InputPanel({
   focused: string | null;
   pending: boolean;
   onClose: () => void;
-  onSend: (values: Record<string, string>) => void;
+  onSend: (values: Record<string, unknown>) => void;
 }) {
   const [draft, setDraft] = useState<Record<string, string>>({});
   const focusedRef = useRef<HTMLInputElement | null>(null);
@@ -51,19 +51,30 @@ export function InputPanel({
     return () => window.removeEventListener("keydown", dismiss);
   }, [onClose]);
 
+  /**
+   * What is typed, read as the type each port declares.
+   *
+   * The runtime checks a value against its port before it reaches the run, and
+   * wants JSON — a number for an `int`, not the characters `3`. Doing that here
+   * means a value that cannot be read is a field the operator can see is wrong,
+   * rather than a batch the run refuses.
+   */
+  const typed = ports.flatMap((port) => {
+    const text = draft[port.name] ?? "";
+    if (text.trim() === "") return [];
+    return [{ port, value: parseInputValue(port.type, text) }];
+  });
+  const bad = typed.filter((entry) => entry.value === undefined).map((entry) => entry.port.name);
+  const ready = typed.filter((entry) => entry.value !== undefined);
+
   function submit(event: FormEvent) {
     event.preventDefault();
     // Only what was typed. An untouched port stays unset, and the run keeps
     // waiting for it, which is what an open input means.
-    const values = Object.fromEntries(
-      Object.entries(draft).filter(([, value]) => value.trim() !== ""),
-    );
-    if (Object.keys(values).length === 0) return;
-    onSend(values);
+    if (ready.length === 0 || bad.length > 0) return;
+    onSend(Object.fromEntries(ready.map((entry) => [entry.port.name, entry.value])));
     setDraft({});
   }
-
-  const filled = Object.values(draft).filter((value) => value.trim() !== "").length;
 
   return (
     <aside className="input-panel" role="dialog" aria-label="Set input ports">
@@ -86,7 +97,11 @@ export function InputPanel({
         {ports.map((port) => (
           <label
             key={port.id}
-            className={["input-port", port.id === focused ? "focused" : ""]
+            className={[
+              "input-port",
+              port.id === focused ? "focused" : "",
+              bad.includes(port.name) ? "invalid" : "",
+            ]
               .filter(Boolean)
               .join(" ")}
           >
@@ -102,7 +117,11 @@ export function InputPanel({
               // has been set once reads as set rather than empty.
               placeholder={port.value === null ? port.type : String(port.value)}
               aria-label={`${port.name} (${port.type})`}
+              aria-invalid={bad.includes(port.name) || undefined}
             />
+            {bad.includes(port.name) ? (
+              <span className="input-port-problem">not a {port.type}</span>
+            ) : null}
           </label>
         ))}
         {ports.length === 0 ? (
@@ -110,8 +129,12 @@ export function InputPanel({
             This program has no open inputs. It starts on its own, or on a timer.
           </p>
         ) : null}
-        <button type="submit" className="primary-button" disabled={pending || filled === 0}>
-          {pending ? "Sending…" : `Send ${filled || ""}`.trim()}
+        <button
+          type="submit"
+          className="primary-button"
+          disabled={pending || ready.length === 0 || bad.length > 0}
+        >
+          {pending ? "Sending…" : `Send ${ready.length || ""}`.trim()}
         </button>
       </form>
     </aside>

--- a/web/app/lib/protocol.ts
+++ b/web/app/lib/protocol.ts
@@ -113,6 +113,50 @@ export function openInputs(snapshot: DiagramSnapshot): DiagramPort[] {
   return snapshot.ports.filter((port) => port.kind === "input" && !fed.has(port.id));
 }
 
+/**
+ * Turn what the operator typed into a value of the port's type.
+ *
+ * The runtime checks a sent value against the port before it reaches the run,
+ * and it wants JSON: a number for `int`, a boolean for `bool`, null for a
+ * signal. Sending the raw text would fail every port that is not a string, with
+ * an error about a type the operator never chose.
+ *
+ * Returns `undefined` when the text cannot be read as the type, which is what
+ * the panel shows as a problem with that field rather than sending and having
+ * the run refuse the batch.
+ */
+export function parseInputValue(type: string, text: string): unknown | undefined {
+  const trimmed = text.trim();
+  switch (type) {
+    case "string":
+    case "path":
+    case "bytes":
+      // Not trimmed: whitespace can be part of what was meant.
+      return text;
+    case "signal":
+      return null;
+    case "bool":
+      if (trimmed === "true") return true;
+      if (trimmed === "false") return false;
+      return undefined;
+    case "int": {
+      if (!/^-?\d+$/.test(trimmed)) return undefined;
+      return Number(trimmed);
+    }
+    case "float": {
+      const value = Number(trimmed);
+      return Number.isFinite(value) ? value : undefined;
+    }
+    default:
+      // `list<int>`, `option<string>` and friends are given as JSON.
+      try {
+        return JSON.parse(trimmed);
+      } catch {
+        return undefined;
+      }
+  }
+}
+
 export type DiagramEvent = {
   protocol_version: number;
   sequence: number;
@@ -121,6 +165,7 @@ export type DiagramEvent = {
   kind:
     | "run_started"
     | "tag_advanced"
+    | "awaiting_input"
     | "reaction_started"
     | "reaction_completed"
     | "run_completed"

--- a/web/app/lib/protocol.ts
+++ b/web/app/lib/protocol.ts
@@ -83,7 +83,12 @@ export type DiagramSnapshot = {
   protocol_version: number;
   team: string;
   sequence: number;
-  status: "ready" | "running" | "completed" | "failed";
+  /**
+   * `awaiting_input` is not a kind of finished: the program has nothing left to
+   * do until the operator sets an open input. A client that collapses it into
+   * `completed` shows a run as over before anything has happened.
+   */
+  status: "ready" | "running" | "awaiting_input" | "completed" | "failed";
   current_tag: DiagramTag | null;
   /** Containers to draw. Empty means the runtime predates instances, and the
       program is drawn as one box named after itself. */
@@ -95,6 +100,18 @@ export type DiagramSnapshot = {
   reactions: DiagramReaction[];
   edges: DiagramEdge[];
 };
+
+/**
+ * The ports the operator is expected to set: inputs nothing inside the topology
+ * writes to. Everything else takes its value from a connection, and setting one
+ * from outside would be a second writer the program does not describe.
+ */
+export function openInputs(snapshot: DiagramSnapshot): DiagramPort[] {
+  const fed = new Set(
+    snapshot.edges.filter((edge) => edge.kind === "connection").map((edge) => edge.target),
+  );
+  return snapshot.ports.filter((port) => port.kind === "input" && !fed.has(port.id));
+}
 
 export type DiagramEvent = {
   protocol_version: number;
@@ -173,7 +190,12 @@ export type RunRecord = {
 
 export type RunRequest = {
   program: string;
-  inputs: Record<string, unknown>;
+  /**
+   * Seeds, not requirements. Deploying and deciding what to feed a program are
+   * separate acts: anything omitted is set afterwards over
+   * `POST /v1/runs/{id}/inputs`, and until then the run waits.
+   */
+  inputs?: Record<string, unknown>;
 };
 
 export function isRunFinished(status: RunRecord["status"]): boolean {

--- a/web/app/lib/runtime-client.ts
+++ b/web/app/lib/runtime-client.ts
@@ -173,6 +173,31 @@ export async function startRun(
   return assertRunRecord(await response.json());
 }
 
+/**
+ * Send operator-set values into a live run.
+ *
+ * Everything here lands at one tag, which is why the panel batches rather than
+ * sending on each keystroke: a reaction reading two of these ports sees both in
+ * one invocation instead of firing twice.
+ */
+export async function sendRunInputs(
+  serveUrl: string,
+  runId: string,
+  values: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<void> {
+  const base = normalizeRuntimeUrl(serveUrl);
+  const response = await fetch(`${base}/v1/runs/${encodeURIComponent(runId)}/inputs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ values }),
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(await readError(response));
+  }
+}
+
 export async function fetchRun(
   serveUrl: string,
   runId: string,

--- a/web/app/lib/runtime-client.ts
+++ b/web/app/lib/runtime-client.ts
@@ -155,6 +155,39 @@ export async function checkServeHealth(
  * Hand a confirmed design to `omar serve`, which compiles it and starts the
  * run. The returned `diagram_address` is where that run's live topology lives.
  */
+/** What the compiler says about a program nobody has deployed. */
+export type ProgramCheck = {
+  ok: boolean;
+  team?: string;
+  open_inputs?: string[];
+  errors?: string[];
+};
+
+/**
+ * Compile a program without running it.
+ *
+ * The same compiler and verifier a deploy would use, so a program that passes
+ * here is not refused a moment later.
+ */
+export async function checkProgram(
+  serveUrl: string,
+  program: string,
+  filename: string,
+  signal?: AbortSignal,
+): Promise<ProgramCheck> {
+  const base = normalizeRuntimeUrl(serveUrl);
+  const response = await fetch(`${base}/v1/programs/check`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ program, filename }),
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(await readError(response));
+  }
+  return (await response.json()) as ProgramCheck;
+}
+
 export async function startRun(
   serveUrl: string,
   request: RunRequest,

--- a/web/app/lib/runtime-client.ts
+++ b/web/app/lib/runtime-client.ts
@@ -247,6 +247,9 @@ export function subscribeToDiagram(
   const kinds: DiagramEvent["kind"][] = [
     "run_started",
     "tag_advanced",
+    // Without this a run that stalls waiting for input never reaches the
+    // client, which goes on showing whatever it saw last.
+    "awaiting_input",
     "reaction_started",
     "reaction_completed",
     "run_completed",

--- a/web/app/omar-source.tsx
+++ b/web/app/omar-source.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef, useState } from "react";
 import { tokenizeOmar } from "./lib/omar-syntax";
 
 /** Highlighted OMAR source. Tokenizing is pure, so it is memoised per program. */
@@ -16,5 +16,108 @@ export function OmarSource({ source }: { source: string }) {
         ))}
       </code>
     </pre>
+  );
+}
+
+/**
+ * The same source, editable, checked by the compiler as it is typed.
+ *
+ * A textarea laid transparently over the highlighted text: the operator types
+ * into the textarea and reads the colours behind it, which keeps the
+ * highlighting without reimplementing a text editor. The two must agree on
+ * every metric that decides where a glyph lands, so they share a font, a line
+ * height and a padding, and scroll together.
+ *
+ * Checking is the runtime's own compiler and verifier rather than an
+ * approximation of them here: a program this calls valid is one the daemon
+ * accepts, and there is no second opinion to keep in step.
+ */
+export function OmarEditor({
+  source,
+  filename,
+  status,
+  errors,
+  checking,
+  onSourceChange,
+  onFilenameChange,
+}: {
+  source: string;
+  filename: string;
+  /** What the run is doing, or "draft" before there is one. */
+  status: string;
+  errors: string[];
+  checking: boolean;
+  onSourceChange: (source: string) => void;
+  onFilenameChange: (filename: string) => void;
+}) {
+  const tokens = useMemo(() => tokenizeOmar(source), [source]);
+  const behind = useRef<HTMLPreElement | null>(null);
+  // Null until the operator types: the name shown is the one they were given
+  // until it is the one they are writing. Derived rather than synchronised, so
+  // a rename in progress is never overwritten by a re-render.
+  const [edited, setEdited] = useState<string | null>(null);
+  const name = edited ?? filename;
+
+  function commit() {
+    setEdited(null);
+    onFilenameChange(name);
+  }
+
+  return (
+    <>
+      <div className="source-title">
+        <input
+          className="source-name"
+          value={name}
+          spellCheck={false}
+          aria-label="Program file name"
+          onChange={(event) => setEdited(event.target.value)}
+          onBlur={commit}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              commit();
+              (event.target as HTMLInputElement).blur();
+            }
+          }}
+        />
+        <span>{checking ? "checking…" : status}</span>
+      </div>
+
+      <div className="source-editor">
+        <pre className="source-code" ref={behind} aria-hidden="true">
+          <code>
+            {tokens.map((token, index) => (
+              <span key={index} className={`omar-tok-${token.kind}`}>
+                {token.text}
+              </span>
+            ))}
+            {/* Keeps the last line reachable when it is the one being typed. */}
+            {"\n"}
+          </code>
+        </pre>
+        <textarea
+          className="source-input"
+          value={source}
+          spellCheck={false}
+          aria-label="OMAR program"
+          onChange={(event) => onSourceChange(event.target.value)}
+          onScroll={(event) => {
+            const pre = behind.current;
+            if (!pre) return;
+            pre.scrollTop = event.currentTarget.scrollTop;
+            pre.scrollLeft = event.currentTarget.scrollLeft;
+          }}
+        />
+      </div>
+
+      {errors.length > 0 ? (
+        <div className="source-errors" role="alert">
+          {errors.map((error) => (
+            <p key={error}>{error}</p>
+          ))}
+        </div>
+      ) : null}
+    </>
   );
 }

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -123,7 +123,7 @@ export function Studio({
   );
 
   /** Send what the operator typed, as one batch at one tag. */
-  async function pushInputs(values: Record<string, string>) {
+  async function pushInputs(values: Record<string, unknown>) {
     if (!run) return;
     setSendingInputs(true);
     setError("");

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -6,7 +6,7 @@ import { AgentTerminal } from "./agent-terminal";
 import { InputPanel } from "./input-panel";
 import { BackendMenu } from "./backend-menu";
 import { DiagramCanvas } from "./diagram/diagram-canvas";
-import { OmarSource } from "./omar-source";
+import { OmarEditor } from "./omar-source";
 import { Resizer } from "./resizer";
 import { Waiting } from "./waiting";
 import {
@@ -31,6 +31,7 @@ import {
   diagramUrlFor,
   fetchDiagram,
   fetchRun,
+  checkProgram,
   sendRunInputs,
   startRun,
   subscribeToDiagram,
@@ -86,6 +87,14 @@ export function Studio({
     isDemo ? reviewWorkflow : null,
   );
   const [source, setSource] = useState(isDemo ? reviewProgram : "");
+  /** What the program is called. Named for the team it declares until the
+      operator says otherwise. */
+  const [filename, setFilename] = useState(
+    isDemo ? `${reviewWorkflow.team}.omar` : "program.omar",
+  );
+  /** What the compiler said about the source as it stands. */
+  const [sourceErrors, setSourceErrors] = useState<string[]>([]);
+  const [checking, setChecking] = useState(false);
   // Chat gets the whole width until there is a design to look at. The operator
   // can flip back and forth once there is.
   const [tab, setTab] = useState<"source" | "events">("source");
@@ -191,6 +200,8 @@ export function Studio({
         setConfirming(false);
         setDesign(message.design);
         setSource(message.design.program);
+        setSourceErrors([]);
+        setFilename(`${message.design.preview.team}.omar`);
         // Show the proposed topology, not whatever was on screen before.
         setSnapshot(message.design.preview);
         if (!arrangedRef.current) {
@@ -311,7 +322,9 @@ export function Studio({
       // Deployed, not started: the agents come up and the program waits at
       // its first tag until the operator sets its open inputs. A program with a
       // timer still moves on its own, which is what a timer is for.
-      const record = await startRun(serveUrl, { program: design.program });
+      // The source, not the design: the operator may have edited it, and what
+      // they are looking at is what they are deploying.
+      const record = await startRun(serveUrl, { program: source });
       setSnapshot((current) => (current ? { ...current, team: record.team } : current));
       setRun(record);
       setPhase("observing");
@@ -342,6 +355,8 @@ export function Studio({
     // Discarding puts the studio back where it was before the proposal —
     // leaving the topology on screen implies a design is still in play.
     setSnapshot(isDemo ? reviewWorkflow : null);
+    setFilename(isDemo ? `${reviewWorkflow.team}.omar` : "program.omar");
+    setSourceErrors([]);
     setSource(isDemo ? reviewProgram : "");
     arrangedRef.current = isDemo;
     setPhase("idle");
@@ -352,6 +367,40 @@ export function Studio({
     ? `${snapshot.current_tag.timestamp}:${snapshot.current_tag.microstep}`
     : "—";
   const canRun = daemon.state === "live";
+
+  /**
+   * Check the edited program, a moment after typing stops.
+   *
+   * Debounced because the compiler runs per request and the operator is
+   * mid-sentence for most of them; aborted on the next keystroke so a slow
+   * check cannot land after a newer one and report on text that is gone.
+   */
+  useEffect(() => {
+    const abort = new AbortController();
+    const timer = setTimeout(() => {
+      // Nothing to check against, or nothing to check: clear rather than leave
+      // an error standing for text that is gone.
+      if (!canRun || source.trim() === "") {
+        setSourceErrors([]);
+        return;
+      }
+      setChecking(true);
+      checkProgram(serveUrl, source, filename, abort.signal)
+        .then((result) => setSourceErrors(result.ok ? [] : (result.errors ?? [])))
+        .catch((cause) => {
+          if (abort.signal.aborted) return;
+          setSourceErrors([cause instanceof Error ? cause.message : String(cause)]);
+        })
+        .finally(() => {
+          if (!abort.signal.aborted) setChecking(false);
+        });
+    }, 400);
+    return () => {
+      clearTimeout(timer);
+      abort.abort();
+    };
+  }, [source, filename, serveUrl, canRun]);
+
   const isDeployed = run !== null;
 
   // Widths are clamped against the workspace so the diagram always keeps a
@@ -655,13 +704,15 @@ export function Studio({
           </div>
 
           {tab === "source" ? (
-            <>
-              <div className="source-title">
-                <span>{`${snapshot.team}.omar`}</span>
-                <span>{run ? run.status : "draft"}</span>
-              </div>
-              <OmarSource source={source} />
-            </>
+            <OmarEditor
+              source={source}
+              filename={filename}
+              status={run ? run.status : "draft"}
+              errors={sourceErrors}
+              checking={checking}
+              onSourceChange={setSource}
+              onFilenameChange={setFilename}
+            />
           ) : (
             <div className="event-strip" role="tabpanel">
               {events.length ? (

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChatMessage as ChatMessageView } from "./chat-message";
 import { AgentTerminal } from "./agent-terminal";
+import { InputPanel } from "./input-panel";
 import { BackendMenu } from "./backend-menu";
 import { DiagramCanvas } from "./diagram/diagram-canvas";
 import { OmarSource } from "./omar-source";
@@ -17,6 +18,7 @@ import { reviewProgram, reviewWorkflow } from "./lib/fixtures";
 import {
   applyDiagramEvent,
   isRunFinished,
+  openInputs,
   type ChatMessage,
   type DiagramEvent,
   type DiagramSnapshot,
@@ -29,6 +31,7 @@ import {
   diagramUrlFor,
   fetchDiagram,
   fetchRun,
+  sendRunInputs,
   startRun,
   subscribeToDiagram,
 } from "./lib/runtime-client";
@@ -110,6 +113,29 @@ export function Studio({
   const [selection, setSelection] = useState<string[]>([]);
   /** The agent whose terminal is open, if any. */
   const [terminalAgent, setTerminalAgent] = useState<string | null>(null);
+  /** The open input the operator clicked, which also opens the panel. */
+  const [focusedInput, setFocusedInput] = useState<string | null>(null);
+  const [sendingInputs, setSendingInputs] = useState(false);
+  const settable = useMemo(() => (snapshot ? openInputs(snapshot) : []), [snapshot]);
+  const settableIds = useMemo(
+    () => new Set(settable.map((port) => port.id)),
+    [settable],
+  );
+
+  /** Send what the operator typed, as one batch at one tag. */
+  async function pushInputs(values: Record<string, string>) {
+    if (!run) return;
+    setSendingInputs(true);
+    setError("");
+    try {
+      await sendRunInputs(serveUrl, run.run_id, values);
+      setFocusedInput(null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setSendingInputs(false);
+    }
+  }
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [events, setEvents] = useState<DiagramEvent[]>([]);
   const disconnectRef = useRef<null | (() => void)>(null);
@@ -282,10 +308,10 @@ export function Studio({
     setPhase("spawning");
     setError("");
     try {
-      const record = await startRun(serveUrl, {
-        program: design.program,
-        inputs: design.inputs,
-      });
+      // Deployed, not started: the agents come up and the program waits at
+      // its first tag until the operator sets its open inputs. A program with a
+      // timer still moves on its own, which is what a timer is for.
+      const record = await startRun(serveUrl, { program: design.program });
       setSnapshot((current) => (current ? { ...current, team: record.team } : current));
       setRun(record);
       setPhase("observing");
@@ -582,6 +608,10 @@ export function Studio({
             // Agents outlive the run that spawned them, so a finished run can
             // still be opened; before a run there is nothing behind the node.
             onOpenTerminal={canRun && run ? setTerminalAgent : undefined}
+            // Only while a run can actually take them: before deploy there is
+            // nothing to send to, and after it ends nothing is listening.
+            openInputs={run && !isRunFinished(run.status) ? settableIds : undefined}
+            onSetInput={run && !isRunFinished(run.status) ? setFocusedInput : undefined}
           />
         </section>
         ) : null}
@@ -649,6 +679,16 @@ export function Studio({
         </aside>
         ) : null}
       </section>
+
+      {focusedInput && snapshot ? (
+        <InputPanel
+          ports={settable}
+          focused={focusedInput}
+          pending={sendingInputs}
+          onClose={() => setFocusedInput(null)}
+          onSend={(values) => void pushInputs(values)}
+        />
+      ) : null}
 
       {terminalAgent ? (
         <AgentTerminal

--- a/web/tests/conformance.test.mjs
+++ b/web/tests/conformance.test.mjs
@@ -430,6 +430,69 @@ describe(
       assert.equal(latest.status, "completed", JSON.stringify(latest));
       assert.equal(latest.error, null);
     });
+
+    test("deployed without inputs, it waits until the operator sends them", async () => {
+      // Deploying and deciding what to feed a program are separate acts. With
+      // no inputs the run comes up, spawns its agents, and stops at its first
+      // tag — which is a state the old admission path could not even express,
+      // because it refused a program whose open inputs were unset.
+      const created = await fetch(`${real.url}/v1/runs`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ program: STUB_FLOW }),
+      });
+      const raw = await created.text();
+      assert.equal(created.status, 201, raw);
+      const record = JSON.parse(raw);
+
+      const diagram = async () =>
+        (await fetch(`http://${record.diagram_address}/v1/diagram`)).json();
+
+      // It is waiting, not finished, and nothing has advanced.
+      const deadline = Date.now() + 15_000;
+      let snapshot;
+      do {
+        snapshot = await diagram();
+        if (snapshot.status === "awaiting_input") break;
+        await new Promise((wait) => setTimeout(wait, 200));
+      } while (Date.now() < deadline);
+      assert.equal(snapshot.status, "awaiting_input", JSON.stringify(snapshot.status));
+      assert.deepEqual(snapshot.current_tag, { timestamp: 0, microstep: 0 });
+      assert.equal(
+        snapshot.ports.find((port) => port.name === "flow.blurb")?.value ?? null,
+        null,
+        "nothing ran",
+      );
+
+      const send = (values) =>
+        fetch(`${real.url}/v1/runs/${record.run_id}/inputs`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ values }),
+        });
+
+      // A port the topology feeds is not the operator's to set, and a value of
+      // the wrong type is refused before it can reach the run.
+      const closed = await send({ "flow.draft": "no" });
+      assert.equal(closed.status, 400, await closed.text());
+
+      const accepted = await send({ "flow.topic": "release notes" });
+      assert.equal(accepted.status, 202, await accepted.text());
+
+      // Fed, it runs to completion on its own.
+      const done = Date.now() + 30_000;
+      let latest;
+      do {
+        latest = await (await fetch(`${real.url}/v1/runs/${record.run_id}`)).json();
+        if (latest.status === "completed") break;
+        await new Promise((wait) => setTimeout(wait, 200));
+      } while (Date.now() < done);
+      assert.equal(latest.status, "completed", JSON.stringify(latest));
+
+      // And sending to a run that is over is refused rather than silently lost.
+      const late = await send({ "flow.topic": "again" });
+      assert.equal(late.status, 409, await late.text());
+    });
   },
 );
 

--- a/web/tests/e2e/flow.spec.ts
+++ b/web/tests/e2e/flow.spec.ts
@@ -37,6 +37,31 @@ async function deploy(page: import("@playwright/test").Page) {
   await page.getByRole("button", { name: "Confirm deploy" }).click();
 }
 
+/**
+ * Set every open input, which is what makes a deployed program start.
+ *
+ * Deploying brings the agents up and leaves the program at its first tag; a
+ * test that wants a run in motion has to do this too. Tests specifically about
+ * the waiting state drive the panel themselves.
+ */
+async function feedOpenInputs(page: import("@playwright/test").Page) {
+  const glyphs = page.locator(".omar-port-group.open-input .omar-port");
+  // Waited for rather than counted: the diagram arrives a moment after the run
+  // is admitted, and a helper that quietly did nothing would leave the run
+  // waiting and the failure would surface somewhere else entirely.
+  await glyphs.first().waitFor({ state: "visible", timeout: 15_000 });
+  await glyphs.first().click();
+  const panel = page.getByRole("dialog", { name: "Set input ports" });
+  await expect(panel).toBeVisible();
+  for (const field of await panel.locator("input").all()) {
+    const label = (await field.getAttribute("aria-label")) ?? "";
+    // Typed as the port declares, or the runtime refuses the batch.
+    await field.fill(label.includes("(int)") ? "1" : "go");
+  }
+  await panel.getByRole("button", { name: /^Send/ }).click();
+  await expect(panel).toBeHidden();
+}
+
 /** Drag a divider horizontally by `dx` pixels. */
 async function dragDivider(
   page: import("@playwright/test").Page,
@@ -93,12 +118,18 @@ test("prompt to finished run, gated on an explicit confirmation", async ({ page 
   await page.getByRole("button", { name: "Deploy", exact: true }).click();
   await page.getByRole("button", { name: "Confirm deploy" }).click();
 
-  // 4. The run is spawned and observed over the event stream.
+  // 4. Deployed is not started: the agents are up and the program waits at its
+  //    first tag for the port nobody has set.
+  await expect(page.locator(".run-stats")).toContainText("awaiting_input");
+  await expect(page.locator(".event-strip")).not.toContainText("reaction started");
+  await feedOpenInputs(page);
+
+  // 5. Fed, it runs, and is observed over the event stream.
   await expect(phase).toContainText("observing");
   await expect(page.locator(".event-strip")).toContainText("run started");
   await expect(page.locator(".event-strip")).toContainText("reaction started");
 
-  // 5. It finishes successfully.
+  // 6. It finishes successfully.
   await expect(phase).toContainText("finished", { timeout: 30_000 });
   await expect(page.locator(".event-strip")).toContainText("run completed");
   // The run's recorded status lives with the source; the tabs switch back.
@@ -110,6 +141,7 @@ test("the diagram reflects live reaction state from the run", async ({ page }) =
   await useFakeServe(page);
   await draftUntilProposed(page);
   await deploy(page);
+  await feedOpenInputs(page);
   await expect(page.locator(".connection")).toContainText("finished", {
     timeout: 30_000,
   });
@@ -198,7 +230,9 @@ test("discarding a design leaves the gate without running anything", async ({
   await useFakeServe(page);
   let admissions = 0;
   page.on("request", (request) => {
-    if (request.method() === "POST" && request.url().includes("/v1/runs")) {
+    // Admissions only. `/v1/runs/{id}/inputs` is also a POST under this path
+    // and is not one, so match the endpoint rather than a prefix of it.
+    if (request.method() === "POST" && new URL(request.url()).pathname === "/v1/runs") {
       admissions += 1;
     }
   });
@@ -244,6 +278,7 @@ test("a design the compiler rejects is reported and stays unconfirmed", async ({
       body: JSON.stringify({ error: "omarc failed: expected identifier" }),
     });
   });
+  // No run is admitted, so nothing below feeds one.
 
   await deploy(page);
 
@@ -300,7 +335,9 @@ test("deploying is armed, reversible, and only then shows events", async ({
   await useFakeServe(page);
   let admissions = 0;
   page.on("request", (request) => {
-    if (request.method() === "POST" && request.url().includes("/v1/runs")) {
+    // Admissions only. `/v1/runs/{id}/inputs` is also a POST under this path
+    // and is not one, so match the endpoint rather than a prefix of it.
+    if (request.method() === "POST" && new URL(request.url()).pathname === "/v1/runs") {
       admissions += 1;
     }
   });
@@ -324,6 +361,7 @@ test("deploying is armed, reversible, and only then shows events", async ({
   expect(admissions).toBe(0);
 
   await deploy(page);
+  await feedOpenInputs(page);
   expect(admissions).toBe(1);
 
   // Deployed: events exist, and the view moves to them.
@@ -552,6 +590,13 @@ test("a zoomed diagram stays put while the run updates it", async ({ page }) => 
 
   const view = page.locator(".diagram-canvas > g");
   await expect(view).toBeVisible();
+
+  // Deploy and feed before zooming: setting an input means clicking a port,
+  // and a zoomed diagram is exactly the state where that is awkward. What is
+  // under test is what the run does to the view afterwards.
+  await deploy(page);
+  await feedOpenInputs(page);
+
   // Zoom in deliberately, the way an operator inspecting a reaction would.
   await page.getByRole("button", { name: "Zoom in" }).click();
   await page.getByRole("button", { name: "Zoom in" }).click();
@@ -559,7 +604,6 @@ test("a zoomed diagram stays put while the run updates it", async ({ page }) => 
 
   // The run republishes the snapshot on every event; none of that should
   // reclaim the view.
-  await deploy(page);
   await expect(page.locator(".connection")).toContainText("finished", {
     timeout: 30_000,
   });
@@ -729,6 +773,7 @@ test("a finished run leaves nothing running and still opens a terminal", async (
   await page.getByLabel("Draft workflow").click();
   await page.getByRole("button", { name: "Deploy", exact: true }).click();
   await page.getByRole("button", { name: "Confirm deploy" }).click();
+  await feedOpenInputs(page);
   await expect(page.locator(".connection")).toContainText("finished");
 
   // The per-run diagram server dies with the run, so the refetch that follows
@@ -1079,6 +1124,93 @@ test("an edge into a reaction actually reaches it", async ({ page }) => {
       expect(line.y).toBeLessThanOrEqual(box.y + box.height + 2);
     }
   }
+});
+
+test("an open input opens a panel, and sending it starts the run", async ({ page }) => {
+  // Deploying and deciding what to feed a program are separate acts. The run
+  // comes up waiting, and this is the whole way out of that state.
+  await useFakeServe(page);
+  await page.getByLabel("Describe a workflow").fill("Review the release plan");
+  await page.getByLabel("Draft workflow").click();
+  await page.getByLabel("Describe a workflow").fill("The planner");
+  await page.getByLabel("Draft workflow").click();
+  await page.getByRole("button", { name: "Deploy", exact: true }).click();
+  await page.getByRole("button", { name: "Confirm deploy" }).click();
+
+  // Nothing ran: the program is waiting for the port nobody has set.
+  await expect(page.locator(".run-stats")).toContainText("awaiting_input");
+
+  const panel = page.getByRole("dialog", { name: "Set input ports" });
+  await expect(panel).toBeHidden();
+
+  // The glyph, not the group: a group's box is mostly the gap between its
+  // triangle and its label, so its centre is empty space.
+  await page.locator(".omar-port-group.open-input .omar-port").first().click();
+  await expect(panel).toBeVisible();
+  await expect(panel).toContainText("flow.request");
+  await expect(panel).toContainText("string");
+
+  // Nothing to send until something is typed.
+  const send = panel.getByRole("button", { name: /^Send/ });
+  await expect(send).toBeDisabled();
+
+  await panel.getByLabel("flow.request (string)").fill("ship it");
+  await expect(send).toBeEnabled();
+  await send.click();
+
+  // Fed, it runs — and the panel gets out of the way.
+  await expect(panel).toBeHidden();
+  await expect(page.locator(".run-stats")).toContainText("running", { timeout: 15_000 });
+  await expect(page.locator(".omar-reaction.running").first()).toBeVisible({
+    timeout: 15_000,
+  });
+});
+
+test("a value that is not of the port's type is caught before it is sent", async ({
+  page,
+}) => {
+  // The runtime checks a value against its port and refuses the whole batch.
+  // Reading the text as the declared type here means the operator sees which
+  // field is wrong rather than a send that fails.
+  await fake.close();
+  fake = (await startFakeServe({
+    stepMs: 30,
+    port: FAKE_SERVE_PORT,
+    // Two open inputs, one of them an int.
+    snapshot: "diagram-grand-test.v1.json",
+  })) as FakeServe;
+  await useFakeServe(page);
+  await page.getByLabel("Describe a workflow").fill("Review the release plan");
+  await page.getByLabel("Draft workflow").click();
+  await page.getByLabel("Describe a workflow").fill("The planner");
+  await page.getByLabel("Draft workflow").click();
+  await page.getByRole("button", { name: "Deploy", exact: true }).click();
+  await page.getByRole("button", { name: "Confirm deploy" }).click();
+
+  await page.locator(".omar-port-group.open-input .omar-port").first().click();
+  const panel = page.getByRole("dialog", { name: "Set input ports" });
+  await expect(panel).toBeVisible();
+
+  const rounds = panel.getByLabel("coord.max_rounds (int)");
+  const send = panel.getByRole("button", { name: /^Send/ });
+
+  await rounds.fill("three");
+  await expect(panel.locator(".input-port.invalid")).toContainText("not a int");
+  await expect(send).toBeDisabled();
+
+  // A value that reads as the type clears it, and is sent as a number rather
+  // than as the characters that were typed.
+  await rounds.fill("3");
+  await expect(panel.locator(".input-port.invalid")).toHaveCount(0);
+  await expect(send).toBeEnabled();
+
+  const sent = page.waitForRequest(
+    (request) => request.url().includes("/inputs") && request.method() === "POST",
+  );
+  await send.click();
+  expect(JSON.parse((await sent).postData() ?? "{}")).toEqual({
+    values: { "coord.max_rounds": 3 },
+  });
 });
 
 test("the assistant's terminal opens from the wait, not from a menu", async ({

--- a/web/tests/e2e/flow.spec.ts
+++ b/web/tests/e2e/flow.spec.ts
@@ -1126,6 +1126,59 @@ test("an edge into a reaction actually reaches it", async ({ page }) => {
   }
 });
 
+test("the program can be edited, and the compiler answers as you type", async ({
+  page,
+}) => {
+  // The source view is where a program is read; making it the place a program
+  // is corrected means the compiler has to say what is wrong before a deploy
+  // is refused for the same reason.
+  await useFakeServe(page);
+  await draftUntilProposed(page);
+  await page.getByRole("button", { name: "Show the source pane" }).click();
+
+  const editor = page.getByLabel("OMAR program");
+  await expect(editor).toBeVisible();
+  await expect(editor).toHaveValue(/team ReviewFlow\[/);
+
+  // A name is a name, and the compiler only accepts one kind.
+  const name = page.getByLabel("Program file name");
+  await expect(name).toHaveValue("ReviewFlow.omar");
+  await name.fill("ReviewFlow.txt");
+  await name.blur();
+  await expect(page.getByRole("alert")).toContainText("must be a plain name ending in .omar");
+
+  await name.fill("Release.omar");
+  await name.blur();
+  await expect(page.getByRole("alert")).toBeHidden();
+
+  // A program the compiler rejects says so where it is being written.
+  await editor.fill("team Broken {");
+  await expect(page.getByRole("alert")).toContainText("expected identifier");
+
+  // And correcting it clears the error rather than needing a deploy to find out.
+  await editor.fill("team Fixed[a : Codex] {}\nmain Fixed { f = Fixed() }");
+  await expect(page.getByRole("alert")).toBeHidden();
+});
+
+test("what is deployed is what the editor shows", async ({ page }) => {
+  await useFakeServe(page);
+  await draftUntilProposed(page);
+  await page.getByRole("button", { name: "Show the source pane" }).click();
+
+  const edited = "team Edited[a : Codex] {}\nmain Edited { e = Edited() }";
+  await page.getByLabel("OMAR program").fill(edited);
+  await expect(page.getByRole("alert")).toBeHidden();
+
+  const admitted = page.waitForRequest(
+    (request) =>
+      request.method() === "POST" && new URL(request.url()).pathname === "/v1/runs",
+  );
+  await deploy(page);
+
+  // The design the assistant proposed is not what was on screen by the end.
+  expect(JSON.parse((await admitted).postData() ?? "{}").program).toBe(edited);
+});
+
 test("an open input opens a panel, and sending it starts the run", async ({ page }) => {
   // Deploying and deciding what to feed a program are separate acts. The run
   // comes up waiting, and this is the whole way out of that state.

--- a/web/tests/fake-serve.mjs
+++ b/web/tests/fake-serve.mjs
@@ -59,6 +59,9 @@ export async function startFakeServe({
     if (request.method === "GET" && url.pathname === "/health") {
       return json(response, 200, { status: "ok", protocol_version: 1 });
     }
+    if (request.method === "POST" && url.pathname === "/v1/programs/check") {
+      return readBody(request).then((body) => checkProgram(body, response));
+    }
     if (request.method === "POST" && url.pathname === "/v1/runs") {
       return readBody(request).then((body) => admit(body, response));
     }
@@ -306,6 +309,48 @@ export async function startFakeServe({
 
   function latest() {
     return [...runs.values()].at(-1);
+  }
+
+  /**
+   * What the real daemon does with `POST /v1/programs/check`.
+   *
+   * The real one runs omarc; this recognises the same shapes the browser tests
+   * need — a name that is not a program file, and the marker the suite already
+   * uses to mean "omarc rejects this".
+   */
+  function checkProgram(body, response) {
+    let request;
+    try {
+      request = JSON.parse(body);
+    } catch {
+      return json(response, 400, { error: "invalid request: not JSON" });
+    }
+    const filename = request.filename ?? "program.omar";
+    if (!filename.endsWith(".omar") || filename.includes("/")) {
+      return json(response, 200, {
+        ok: false,
+        errors: [
+          `'${filename}' is not a program file name: it must be a plain name ending in .omar`,
+        ],
+      });
+    }
+    if (typeof request.program !== "string" || request.program.trim() === "") {
+      return json(response, 200, { ok: false, errors: [`${filename}: empty program`] });
+    }
+    // Not a compiler: two shapes it recognises, so a test can write source that
+    // reads like source instead of a marker string. Anything else is accepted,
+    // and the conformance suite is what checks the real compiler's verdicts.
+    const opens = (request.program.match(/{/g) ?? []).length;
+    const closes = (request.program.match(/}/g) ?? []).length;
+    if (request.program.includes(INVALID_MARKER) || opens !== closes) {
+      return json(response, 200, {
+        ok: false,
+        errors: [
+          `omarc failed: ${filename}: expected identifier, found some (Omar.Token.sym "{")`,
+        ],
+      });
+    }
+    return json(response, 200, { ok: true, team: "ReviewFlow", open_inputs: [] });
   }
 
   function admit(body, response) {

--- a/web/tests/fake-serve.mjs
+++ b/web/tests/fake-serve.mjs
@@ -67,6 +67,14 @@ export async function startFakeServe({
         runs: [...runs.values()].map((entry) => entry.record),
       });
     }
+    if (
+      request.method === "POST" &&
+      url.pathname.startsWith("/v1/runs/") &&
+      url.pathname.endsWith("/inputs")
+    ) {
+      const runId = url.pathname.slice("/v1/runs/".length, -"/inputs".length);
+      return readBody(request).then((body) => sendInputs(runId, body, response));
+    }
     if (request.method === "GET" && url.pathname.startsWith("/v1/runs/")) {
       const entry = runs.get(url.pathname.slice("/v1/runs/".length));
       return entry
@@ -320,7 +328,12 @@ export async function startFakeServe({
     const runId = randomUUID();
     const address = `${host}:${server.address().port}`;
     const snapshot = structuredClone(golden);
-    snapshot.status = "running";
+    // Deploying no longer starts the program: with an open input unset the run
+    // comes up and waits, which is the state the panel exists to resolve.
+    const openInputs = openInputsOf(snapshot);
+    const seeded = request.inputs ?? {};
+    const unset = openInputs.filter((port) => !(port.name in seeded));
+    snapshot.status = unset.length > 0 ? "awaiting_input" : "running";
     const requested = request.inputs?.["flow.request"];
     for (const port of snapshot.ports) {
       if (port.name === "flow.request" && typeof requested === "string") {
@@ -341,6 +354,7 @@ export async function startFakeServe({
       subscribers: new Set(),
       sequence: 0,
       driving: false,
+      unset: new Set(unset.map((port) => port.name)),
     };
     runs.set(runId, entry);
     json(response, 201, entry.record);
@@ -362,10 +376,80 @@ export async function startFakeServe({
     // The real diagram server does not replay history, and a real run lasts far
     // longer than a subscriber takes to attach. Only start driving once someone
     // is listening, so the test can never lose the race and hang.
-    if (!entry.driving) {
-      entry.driving = true;
-      void driveRun(entry);
+    maybeDrive(entry);
+  }
+
+  /**
+   * Start the run once nothing is holding it back.
+   *
+   * Two things hold it: an open input nobody has set, and nobody listening. The
+   * second is not the real daemon's rule — it is here so a test can never lose
+   * the race between subscribing and the first event.
+   */
+  function maybeDrive(entry) {
+    if (entry.driving) return;
+    if (entry.unset.size > 0) return;
+    if (entry.subscribers.size === 0) return;
+    entry.driving = true;
+    void driveRun(entry);
+  }
+
+  /** Inputs nothing in the topology writes to: the operator's to set. */
+  function openInputsOf(snapshot) {
+    const fed = new Set(
+      snapshot.edges.filter((edge) => edge.kind === "connection").map((edge) => edge.target),
+    );
+    return snapshot.ports.filter((port) => port.kind === "input" && !fed.has(port.id));
+  }
+
+  /** What the real daemon does with `POST /v1/runs/{id}/inputs`. */
+  function sendInputs(runId, body, response) {
+    const entry = runs.get(runId);
+    if (!entry) return json(response, 404, { error: "unknown run" });
+    let request;
+    try {
+      request = JSON.parse(body);
+    } catch {
+      return json(response, 400, { error: "invalid request: not JSON" });
     }
+    const values = request.values ?? {};
+    if (Object.keys(values).length === 0) {
+      return json(response, 400, { error: "no values to send" });
+    }
+    const open = new Map(openInputsOf(entry.snapshot).map((port) => [port.name, port]));
+    for (const [name, value] of Object.entries(values)) {
+      const port = open.get(name);
+      if (!port) {
+        return json(response, 400, {
+          error: `'${name}' is not an open input of this run`,
+        });
+      }
+      // The real daemon checks the value against the port's type before it
+      // reaches the run, and the client is expected to have parsed it.
+      if (port.type === "int" && !Number.isInteger(value)) {
+        return json(response, 400, { error: `${name}: expected int, got ${JSON.stringify(value)}` });
+      }
+      if (port.type === "string" && typeof value !== "string") {
+        return json(response, 400, {
+          error: `${name}: expected string, got ${JSON.stringify(value)}`,
+        });
+      }
+    }
+
+    for (const [name, value] of Object.entries(values)) {
+      entry.unset.delete(name);
+      const port = entry.snapshot.ports.find((candidate) => candidate.name === name);
+      if (port) port.value = value;
+    }
+
+    // Fed everything it was waiting for, it runs — as the real loop does when
+    // its queue stops being empty.
+    if (entry.unset.size === 0) {
+      entry.snapshot.status = "running";
+      entry.record.status = "running";
+      maybeDrive(entry);
+    }
+    return json(response, 202, { run_id: runId, sent: Object.keys(values) });
   }
 
   function publish(entry, kind, payload, tag = null) {

--- a/web/tests/protocol-contract.test.mjs
+++ b/web/tests/protocol-contract.test.mjs
@@ -149,9 +149,11 @@ test("a run drives to completion over the event stream", async () => {
       await fetch(`${fake.url}/v1/runs`, {
         method: "POST",
         headers: { "content-type": "application/json" },
+        // Seeded at admission, so this run never waits. Deploying without
+        // inputs and feeding afterwards is covered by the browser suite.
         body: JSON.stringify({
           program: "team ReviewFlow {} main ReviewFlow { flow = ReviewFlow() }",
-          inputs: {},
+          inputs: { "flow.request": "review the release plan" },
         }),
       })
     ).json();


### PR DESCRIPTION
Pressing **Deploy** both started the agents and started the program, because admission demanded every open input up front. Those are different acts: an operator who knows which team they want does not yet know what to hand it — and the diagram they are looking at is what tells them which ports are theirs to set.

## Deployed is not started

A run may be admitted with **no inputs at all**. The agents come up and the program stops at its first tag. That is what an unset open input means, and the old path could not express it: it refused the program outright.

`awaiting_input` is that state. It is **not a kind of finished** — a client that collapses the two shows a run as over before anything has happened. A timer still fires on its own, so a program that starts itself is unaffected.

`POST /v1/runs/{id}/inputs` is where values arrive. **Everything in one request lands at one tag**, so a reaction reading several of those ports sees them together rather than firing once per value — which is why the panel has a Send button rather than committing a field at a time. Values are checked against the port before they reach the run.

Verified against the real daemon:

```
1. deploy without inputs -> 201 running
2. diagram status -> awaiting_input | tag: {'timestamp': 0, 'microstep': 0}
3. closed port -> 400 "'flow.draft' is not an open input of this run"
4. wrong type  -> 400 "flow.depth: expected int, got \"deep\""
5. send batch  -> 202 {'sent': ['flow.depth', 'flow.topic']}
6. after feeding -> completed
```

In Mission Control, an open input is drawn as something you can act on and opens a panel listing every port the operator owes, each with its type and a box to type in.

## Editing the program

The source view showed a program and nothing else. Correcting one meant going back to the assistant, describing the change, and waiting for a new draft — for a typo the operator could see.

It is now editable, with the file name alongside it, and **what is deployed is what the editor shows**.

`POST /v1/programs/check` compiles a program without running it, and the editor asks on every pause in typing. It is the runtime's own compiler and verifier — a program it calls valid is one the daemon accepts, with no second opinion to keep in step. Errors name the operator's file rather than the scratch path it was compiled at:

```
omarc failed: Review.omar: expected identifier, found none
'Review.txt' is not a program file name: it must be a plain name ending in .omar
```

The editor is a transparent textarea over the highlighted text, which keeps the highlighting without writing a text editor.

## Review

Three of Copilot's four findings were real and are fixed:

- **`awaiting_input` never reached the client.** The daemon published it; `subscribeToDiagram` registered every kind except that one, so a stalled run went on reading as whatever was last seen.
- **Every value was sent as text.** The runtime wants JSON, so an `int` port typed as `3` was refused for being the characters `3`. Typed text is now read as the port's declared type, and a value that cannot be read marks that field instead of failing the batch.
- **The panel had no browser coverage.** `fake-serve` now implements the endpoint and waits when an open input is unset.

The fourth — that the panel sends unqualified names — is a false positive; `DiagramPort.name` **is** the qualified name, and the canvas comment it refers to is about the ELK layout node, which is a different object. [Answered on the thread](https://github.com/omar-os/omar/pull/189#discussion_r3729304791), and the new test asserts the wire payload is `{"coord.max_rounds": 3}` on an instance-prefixed fixture.

Writing those tests found two more bugs: the container's drop shadow is drawn past its edge — where the ports are — and swallowed clicks meant for them; and the walkthrough tests deployed and expected a run to move, which is no longer what deploying does.

## Verification

- 326 Rust tests, clippy and `cargo fmt` clean. Five cover the new lifecycle, including that a run given everything up front never waits — it would hang rather than fail if the loop waited wrongly.
- 13/13 conformance against a real `omar serve`, including deploy-with-no-inputs → `awaiting_input` at tag 0 → reject a closed port → send → complete → 409 on a late send.
- 44 browser tests, 12 unit, lint clean.

## Still open

- No way to reopen the panel except by clicking a port; a button in the run header is the obvious follow-up.
- The file name is presentational — it names the file the compiler is given and appears in errors, but the run is still identified by its `main` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)