### PR TITLE
Bump to 0.4.0, and keep Bureau out of the live suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "bridges/slack", "bridges/computer"]
 
 [package]
 name = "omar"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 description = "Agent dashboard for tmux"
 license = "MIT"

--- a/tests/topology/README.md
+++ b/tests/topology/README.md
@@ -27,7 +27,8 @@ Coverage:
 - `Cadence.omar`: one-shot timers opening three rounds and a deadline, with a
   chair whose four prompts share one agent memory. Claude Code.
 - `Bureau.omar`: four levels of containment and 32 agents — the heaviest case
-  here. Claude Code.
+  here. Claude Code. Compiled and checked, not run: eight sequential stages of
+  live agents is not something the release gate should be finding out about.
 - `Heartbeat.omar`: a periodic timer driving a program that never finishes.
   Compiled and checked, never run: `run_local.sh` waits for a completion
   marker this program does not produce.

--- a/tests/topology/run_local.sh
+++ b/tests/topology/run_local.sh
@@ -300,16 +300,15 @@ run_case Nested Nested run.summary --input run.brief='hierarchy'
 run_case Timer Timer beacon.note
 # Four one-shot timers opening three rounds and a deadline, on Claude Code.
 run_case Cadence Cadence chair.report
-# Four levels of containment and 32 agents: the heaviest case in the corpus.
-run_case Bureau Bureau audit.ruling \
-  --input bureau.topic='Whether on-device LLM inference will displace cloud APIs as the default for consumer applications within three years'
 run_case SameAgentSerial SameAgentSerial serial.result \
   --input serial.request='serialize these reactions'
 run_case SuperdenseTime SuperdenseTime time.fixed_result,time.connected_result \
   --input time.start=7
-# `Heartbeat` is deliberately absent: its timer has a non-zero period, so the
-# program never finishes and has no completion marker to wait for. It is
-# compiled and checked like every other source, just never run here.
+# `Heartbeat` and `Bureau` are deliberately absent. `Heartbeat`'s timer has a
+# non-zero period, so the program never finishes and has no completion marker to
+# wait for. `Bureau` is 32 agents across eight sequential stages, and a release
+# gate is not the place to discover whether that fits in a case timeout. Both are
+# compiled and backend-checked like every other source, just never run here.
 
 if ((passed_cases + failed_cases == 0)); then
   printf 'No topology case named %s\n' "$case_filter" >&2


### PR DESCRIPTION
The first release with Mission Control in it.

Since v0.3.3:

- **Mission Control lives in this repository** (#183) — the web client moved under `web/`, and the conformance check that catches protocol drift now runs on every pull request instead of nightly against whatever `main` happened to be.
- **`omar serve --ui`** (#185) — the client is compiled into the binary and served from the daemon's own port, same-origin with the API. **This is the first release that carries it**; v0.3.3 refuses the flag.
- **`make dev`** (#186) — daemon and client from source, pointed at each other, one command.
- **Nested teams** (#181) — a team can instantiate another team, and the containers nest in the diagram.
- **Timers** (#180) — a trigger the runtime fires from its own clock, so a program can start with no input.
- **Backends are checked against what each source declares** (#182), rather than the corpus being required to agree on Codex.
- Quick Start leads with the web UI (#188); the serve context is written before the address is announced (#187).

Version only; `Cargo.lock` is not tracked.

## Bureau comes out of the live suite

`Bureau` is 32 agents across eight sequential stages and **has never been run end to end**. The authenticated suite is the gate every release depends on, with a 900s per-case timeout — not the place to find out whether a program that size finishes, and not something worth paying for on every future release either.

It stays in the corpus, compiled and backend-checked like every other source. `Cadence` still exercises timers against live agents, and it has been run end to end.

## After this merges

Tagging `v0.4.0` runs the release gate, publishes the artifacts, and auto-updates the Homebrew formula. Two things about this release are unproven:

- the release workflow now builds the SPA and passes `--features ui`, a path no PR CI exercises;
- `Cadence` is new to the gate, though it has completed a live run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)