### PR TITLE
Stop gating releases on a suite of live agents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,13 @@ permissions:
   contents: write
 
 jobs:
-  topology-ci-test:
-    name: Topology CI Test
-    uses: ./.github/workflows/topology-ci-test.yml
-    secrets:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-
+  # The live topology suite used to gate this. It runs real agents against real
+  # models, which made every release wait on a long, paid, model-dependent run
+  # that failed for reasons no change in the release introduced. It is still
+  # here — `Topology Release Gate`, run it from the Actions tab — just not
+  # between a tag and its artifacts.
   build:
     name: Build (${{ matrix.suffix }})
-    needs: topology-ci-test
     strategy:
       matrix:
         include:

--- a/.github/workflows/topology-ci-test.yml
+++ b/.github/workflows/topology-ci-test.yml
@@ -1,6 +1,10 @@
 name: Topology Release Gate
 
+# Run on demand, from the Actions tab. It drives every registered program with
+# live agents, so it is slow, paid, and only as reliable as the models behind
+# it — worth running deliberately, and no longer worth blocking a release on.
 on:
+  workflow_dispatch:
   workflow_call:
     secrets:
       OPENAI_API_KEY:

--- a/tests/topology/README.md
+++ b/tests/topology/README.md
@@ -60,12 +60,15 @@ It runs every case even if an earlier case fails. Each case must compile, exit
 successfully after completing all effect contracts, print its completion marker,
 and produce every declared output expected by the test.
 
-The authenticated suite runs only as the first gate in the tag-triggered
-`Release` GitHub Actions workflow. Every release build depends on this gate, so
-a topology failure prevents artifact publication and the Homebrew update. It
-does not run for pull requests, ordinary `main` pushes, or on a schedule. The
-release workflow supplies the `OPENAI_API_KEY` and `ANTHROPIC_API_KEY`
-repository secrets explicitly.
+The authenticated suite runs on demand: `Topology Release Gate` in the Actions
+tab, which supplies the `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` repository
+secrets. It does not run for pull requests, ordinary `main` pushes, or on a
+schedule.
+
+It used to gate every release. Driving real agents against real models made a
+release wait on a long, paid run that could fail for reasons nothing in the
+release introduced, so publishing no longer depends on it. What that costs is
+worth naming: nothing between a tag and its artifacts exercises a live agent.
 
 The runner prints per-case duration and assertion counts, followed by an
 aggregate PASS/FAIL verdict. It exits nonzero if any case fails. Logs and a


### PR DESCRIPTION
Every release waited on the topology suite driving real agents against real models: slow, paid, and able to fail for reasons nothing in the release introduced. A gate that stops artifacts publishing should be about the artifacts.

## What changes

`Release` no longer calls `Topology Release Gate`, and `build` no longer needs it. Tagging goes straight to building, publishing, and updating the Homebrew formula.

## The suite is not deleted

It had **only** a `workflow_call` trigger, so removing its caller would have left a workflow nothing could ever run. It gains `workflow_dispatch` and is run from the Actions tab when someone wants it — same secrets, same corpus, same runner.

## What this costs

Named plainly in `tests/topology/README.md` rather than left to be discovered: **nothing between a tag and its artifacts exercises a live agent.** What still runs on every pull request is the login-free half — the compiler over the whole corpus, the bytecode layout and declared-backend checks, the Rust VM tests, and the web conformance suite against a real `omar serve` driven by stub agents.

If that trade needs narrowing later, the obvious middle ground is a nightly or weekly run of the gate rather than a per-release one.

## Context

Cut while v0.4.0 was in flight: the tagged run was cancelled, and `v0.4.0` will be re-cut from `main` once this lands so the release does not go out through a path we have just decided not to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)