### PR TITLE
Point the release smoke test at ports that exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,14 +67,17 @@ jobs:
       - name: Build
         run: cargo build --release --features ui --target ${{ matrix.target }}
 
+      # `direct_run.omar` instantiates its team in a `main` block, so its ports
+      # are named for the instance. CI was updated when that changed and this
+      # was not, so every release since has failed here.
       - name: Verify direct source execution
         env:
           OMARC_BIN: ${{ github.workspace }}/lang/.lake/build/bin/omarc
         run: |
           output=$(target/${{ matrix.target }}/release/omar run \
-            tests/ci/direct_run.omar --input request=hello --replace)
+            tests/ci/direct_run.omar --input run.request=hello --replace)
           echo "$output"
-          grep -Fq 'Output result = "hello"' <<<"$output"
+          grep -Fq 'Output run.result = "hello"' <<<"$output"
 
       - name: Package
         run: |


### PR DESCRIPTION
**v0.4.0 failed to publish.** Not the new UI build — that succeeded on all four targets. The step after it did:

```
Error: unknown input port 'request'
```

`tests/ci/direct_run.omar` instantiates its team in a `main` block, so its ports are named for the instance — `run.request`, `run.result`. `ci.yml` was updated when that changed. `release.yml` was not, and still asks for `request`.

One matrix leg failing cancels the rest, so all four builds were thrown away and `Publish Release` and `Update Homebrew Formula` were skipped. Nothing was published, and nothing was half-published.

## Confirmed locally

```
$ omar run tests/ci/direct_run.omar --input run.request=hello --replace
Topology 'direct_run' completed
Output run.result = "hello"
```

Which is exactly what the workflow greps for.

## What this says

The same three lines are duplicated in `ci.yml` and `release.yml` and drifted apart. CI runs on every pull request; the release path runs a few times a year, so it sat broken until someone cut a tag. Worth factoring into one place — deliberately left out of this change so the fix that unblocks the release is three characters.

## After this lands

`v0.4.0` gets re-cut from `main`. The tag currently points at a commit whose release cannot succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)