### PR TITLE
Point the Homebrew update at the tap's current home

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,10 +137,16 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          # The tap moved to the org. Cloning followed the redirect, so this
-          # got as far as committing and then failed to push against a token
-          # scoped to a path that no longer exists.
-          git clone https://x-access-token:${GH_TOKEN}@github.com/omar-os/homebrew-omar.git
+          # The tap moved to the org. This still cloned the old path, and
+          # cloning follows the redirect without auth — which is why v0.4.0 got
+          # as far as committing and then failed to push against a token scoped
+          # to a path that no longer exists.
+          #
+          # The tap is public, so the clone needs no credential at all, and not
+          # giving it one keeps the token out of `.git/config` where it would
+          # otherwise sit for the rest of the job. It is supplied to the push,
+          # and to that alone.
+          git clone https://github.com/omar-os/homebrew-omar.git
           cd homebrew-omar
 
           python3 -c "
@@ -174,4 +180,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/omar.rb
           git commit -m "update omar to ${VERSION}"
-          git push
+          git push "https://x-access-token:${GH_TOKEN}@github.com/omar-os/homebrew-omar.git" HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,10 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          git clone https://x-access-token:${GH_TOKEN}@github.com/lsk567/homebrew-omar.git
+          # The tap moved to the org. Cloning followed the redirect, so this
+          # got as far as committing and then failed to push against a token
+          # scoped to a path that no longer exists.
+          git clone https://x-access-token:${GH_TOKEN}@github.com/omar-os/homebrew-omar.git
           cd homebrew-omar
 
           python3 -c "


### PR DESCRIPTION
`v0.4.0` published its artifacts and then failed to update the formula:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/lsk567/homebrew-omar.git/'
```

The tap moved to the org — `lsk567/homebrew-omar` now redirects to `omar-os/homebrew-omar`. The workflow still cloned the old path. Cloning follows the redirect without auth, which is why it got as far as rewriting the formula and committing `update omar to 0.4.0` before failing on the push.

The error reads like an expired token and is not necessarily one: a token scoped to the old path grants nothing on the new one, and GitHub reports that the same way.

## Whether the token also needs replacing

Unknown until the next release, and worth not pre-emptively rotating:

- a **classic** PAT with `repo` scope still works for any repo its owner can write, so this URL change is the whole fix;
- a **fine-grained** PAT scoped to `lsk567` as the resource owner cannot reach an `omar-os` repo whatever the URL says, and must be reissued against `omar-os/homebrew-omar` with Contents: read and write.

`HOMEBREW_TAP_TOKEN` was last set 2026-03-10 and worked at v0.3.3 on July 11, so it was valid until the move.

## v0.4.0 itself

Already published and correct; only the tap is stale, so `brew install` still serves 0.3.3. Fixable now by hand rather than by re-cutting the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)