### PR TITLE
Show what a program will do before it does it

### DIFF
--- a/lang/spec.md
+++ b/lang/spec.md
@@ -189,7 +189,16 @@ begin at `(0, 0)`. Every hop costs one of three things:
 This is Lingua Franca's rule: ports do not introduce delays. What a tag decides,
 it decides completely.
 
+<<<<<<< HEAD
 ### 4.0 Fixpoint at a tag
+=======
+A tag is a moment something is present at. One with no events is not reached:
+no reaction can be enabled there, and no connection, output or timer can move,
+so announcing it would report an advance that did not happen. A program admitted
+with no inputs and no timer therefore passes through no tags at all.
+
+At each tag, the runtime:
+>>>>>>> 26214fc (Do not announce a tag nothing is present at)
 
 A reaction fires at most once per tag, and only once the presence of every one
 of its triggers is decided. Ordering is not something a program asks for; it

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -565,11 +565,11 @@ fn handle_client(mut stream: TcpStream, context: Arc<Context_>) -> Result<()> {
                 agent_proposal(&context, &read_body(content_length)?)
             }
         }
-        ("POST", "/v1/programs/check") => {
+        ("POST", "/v1/programs/project") => {
             if content_length > MAX_BODY_BYTES {
                 (413, json!({"error": "program too large"}))
             } else {
-                check_program(&read_body(content_length)?)
+                project_program(&read_body(content_length)?)
             }
         }
         ("GET", "/v1/runs") => {
@@ -1103,71 +1103,119 @@ fn start_run(context: &Arc<Context_>, body: &[u8]) -> (u16, Value) {
     }
 }
 
+/// How many tags a projection will show before it gives up.
+///
+/// A periodic timer has no end, so a preview has to have one. Large enough that
+/// no terminating program reaches it, small enough to draw.
+const MAX_PROJECTED_STEPS: usize = 128;
+
+/// A program to project, and what is known to be present.
 #[derive(Debug, Deserialize)]
-struct CheckRequest {
+struct ProjectRequest {
     program: String,
-    /// Shown in errors, so a message names the file the operator is editing.
-    /// Must end in `.omar`, which is the compiler's own rule.
     #[serde(default)]
     filename: Option<String>,
+    /// Ports treated as carrying a value at the first tag: what the operator
+    /// has set, or intends to. Everything else is absent, and a program whose
+    /// open inputs are all absent projects nothing — which is the truth about
+    /// what it would do.
+    #[serde(default)]
+    present: Vec<String>,
 }
 
-/// Compile a program and say whether it holds together, without running it.
+/// Work out what a program would do, without running it.
 ///
-/// The runtime's own compiler and verifier, so a program this calls valid is one
-/// the daemon accepts — there is no second opinion to keep in step.
-fn check_program(body: &[u8]) -> (u16, Value) {
-    let request: CheckRequest = match serde_json::from_slice(body) {
+/// The determinism claim made visible: the tags a program passes through and
+/// what fires at each are decided by the program, so they can be shown before
+/// anything is deployed. Agents decide values, not schedule, which is why this
+/// is possible at all.
+fn project_program(body: &[u8]) -> (u16, Value) {
+    let request: ProjectRequest = match serde_json::from_slice(body) {
         Ok(request) => request,
         Err(error) => return (400, json!({"error": format!("invalid request: {error}")})),
     };
 
-    let name = request.filename.as_deref().unwrap_or("program.omar");
-    // The compiler rejects any other extension, and doing that here names the
-    // problem as the filename rather than as a compile failure.
+    let staged = match stage_program(&request.program, request.filename.as_deref()) {
+        Ok(staged) => staged,
+        Err(problem) => return problem,
+    };
+    let outcome =
+        topology::load_program(&staged.path).and_then(|bytecode| topology::verify(&bytecode));
+    let cleaned = staged.finish(outcome);
+
+    match cleaned {
+        Ok(state) => {
+            let present = request.present.into_iter().collect();
+            let (steps, truncated) = topology::project(&state, &present, MAX_PROJECTED_STEPS);
+            (
+                200,
+                json!({
+                    "ok": true,
+                    "team": state.team,
+                    "open_inputs": topology::open_inputs(&state),
+                    "steps": steps,
+                    // Said rather than implied: a timeline that stops is not the
+                    // same as a program that does.
+                    "truncated": truncated,
+                }),
+            )
+        }
+        Err(message) => (200, json!({"ok": false, "errors": [message]})),
+    }
+}
+
+/// A program written where the compiler can be pointed at it.
+///
+/// Its own directory per request, so the file can carry the operator's name
+/// without two of them colliding over it.
+struct StagedProgram {
+    directory: PathBuf,
+    path: PathBuf,
+}
+
+impl StagedProgram {
+    /// Clean up, and say what went wrong in terms of the operator's file.
+    ///
+    /// The compiler names the path it was given, which is a scratch directory
+    /// nobody asked about.
+    fn finish<T>(self, outcome: Result<T>) -> Result<T, String> {
+        let _ = fs::remove_dir_all(&self.directory);
+        outcome.map_err(|error| {
+            format!("{error:#}").replace(&format!("{}/", self.directory.display()), "")
+        })
+    }
+}
+
+/// Write a program out under the name the operator gave it.
+fn stage_program(
+    program: &str,
+    filename: Option<&str>,
+) -> std::result::Result<StagedProgram, (u16, Value)> {
+    let name = filename.unwrap_or("program.omar");
+    // The compiler rejects any other extension, and saying so here names the
+    // problem as the file name rather than as a compile failure.
     if !name.ends_with(".omar") || name.contains('/') || name.contains('\\') {
-        return (
+        return Err((
             200,
-            json!({"ok": false, "errors": [format!("'{name}' is not a program file name: it must be a plain name ending in .omar")]}),
-        );
+            json!({"ok": false, "errors": [format!(
+                "'{name}' is not a program file name: it must be a plain name ending in .omar"
+            )]}),
+        ));
     }
 
-    // Its own directory per check, so the file can carry the operator's name
-    // without two checks colliding over it. Removed on the way out.
     let directory = match crate::paths::private_temp_dir()
         .map(|root| root.join(format!("omar-check-{}", Uuid::new_v4())))
         .and_then(|directory| fs::create_dir_all(&directory).map(|_| directory))
     {
         Ok(directory) => directory,
-        Err(error) => return (500, json!({"error": format!("{error}")})),
+        Err(error) => return Err((500, json!({"error": format!("{error}")}))),
     };
     let path = directory.join(name);
-    if let Err(error) = fs::write(&path, &request.program) {
+    if let Err(error) = fs::write(&path, program) {
         let _ = fs::remove_dir_all(&directory);
-        return (500, json!({"error": format!("{error}")}));
+        return Err((500, json!({"error": format!("{error}")})));
     }
-
-    // Compiling is half of it: `verify` is what catches a program that parses
-    // and still cannot run, which is most of what an editor should say early.
-    let outcome = topology::load_program(&path).and_then(|bytecode| topology::verify(&bytecode));
-    let _ = fs::remove_dir_all(&directory);
-    match outcome {
-        Ok(state) => (
-            200,
-            json!({
-                "ok": true,
-                "team": state.team,
-                // A diagnostic: a program that closes its loop has none.
-                "open_inputs": topology::open_inputs(&state),
-            }),
-        ),
-        Err(error) => {
-            // The compiler names the file it was given, which is a scratch path
-            // nobody asked about. Say the name the operator is looking at.
-            let message = format!("{error:#}").replace(&format!("{}/", directory.display()), "");
-            (200, json!({"ok": false, "errors": [message]}))
-        }
-    }
+    Ok(StagedProgram { directory, path })
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1157,6 +1157,10 @@ fn project_program(body: &[u8]) -> (u16, Value) {
                     // Said rather than implied: a timeline that stops is not the
                     // same as a program that does.
                     "truncated": truncated,
+                    // The topology as edited. An editor whose diagram lags the
+                    // text is showing a program that no longer exists, and the
+                    // client has no compiler of its own to build one with.
+                    "preview": crate::diagram::DiagramSnapshot::from_vm_state(&state),
                 }),
             )
         }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -565,11 +565,11 @@ fn handle_client(mut stream: TcpStream, context: Arc<Context_>) -> Result<()> {
                 agent_proposal(&context, &read_body(content_length)?)
             }
         }
-        ("POST", "/v1/programs/project") => {
+        ("POST", "/v1/programs/check") => {
             if content_length > MAX_BODY_BYTES {
                 (413, json!({"error": "program too large"}))
             } else {
-                project_program(&read_body(content_length)?)
+                check_program(&read_body(content_length)?)
             }
         }
         ("GET", "/v1/runs") => {
@@ -1103,34 +1103,46 @@ fn start_run(context: &Arc<Context_>, body: &[u8]) -> (u16, Value) {
     }
 }
 
-/// How many tags a projection will show before it gives up.
+/// How many tags a timeline will show before it gives up.
 ///
 /// A periodic timer has no end, so a preview has to have one. Large enough that
 /// no terminating program reaches it, small enough to draw.
-const MAX_PROJECTED_STEPS: usize = 128;
+const MAX_TIMELINE_STEPS: usize = 128;
 
-/// A program to project, and what is known to be present.
+/// A program to check, and how much to say about it.
 #[derive(Debug, Deserialize)]
-struct ProjectRequest {
+struct CheckRequest {
     program: String,
+    /// Shown in errors, so a message names the file the operator is editing.
+    /// Must end in `.omar`, which is the compiler's own rule.
     #[serde(default)]
     filename: Option<String>,
-    /// Ports treated as carrying a value at the first tag: what the operator
-    /// has set, or intends to. Everything else is absent, and a program whose
-    /// open inputs are all absent projects nothing — which is the truth about
-    /// what it would do.
+    /// Whether to work out the tags the program would pass through.
+    ///
+    /// Off by default: a caller that only wants to know whether a program holds
+    /// together should not be handed a timeline to ignore. The editor asks for
+    /// one, because it draws it.
+    #[serde(default)]
+    timeline: bool,
+    /// Ports to treat as carrying a value at the first tag: the inputs a run
+    /// would be admitted with. Timers are seeded regardless — they are what
+    /// starts a program that starts itself. Only read when `timeline` is set.
     #[serde(default)]
     present: Vec<String>,
 }
 
-/// Work out what a program would do, without running it.
+/// Compile a program and say whether it holds together, without running it.
 ///
-/// The determinism claim made visible: the tags a program passes through and
-/// what fires at each are decided by the program, so they can be shown before
-/// anything is deployed. Agents decide values, not schedule, which is why this
-/// is possible at all.
-fn project_program(body: &[u8]) -> (u16, Value) {
-    let request: ProjectRequest = match serde_json::from_slice(body) {
+/// The runtime's own compiler and verifier, so a program this calls valid is one
+/// the daemon accepts — there is no second opinion to keep in step.
+///
+/// With `timeline`, it also says what the program would do. That is a second
+/// question, which is why it is asked for rather than assumed — but it is asked
+/// of the same compile, because an editor wants both on the same keystroke and
+/// two round trips would let the answers disagree about which text they are
+/// about.
+fn check_program(body: &[u8]) -> (u16, Value) {
+    let request: CheckRequest = match serde_json::from_slice(body) {
         Ok(request) => request,
         Err(error) => return (400, json!({"error": format!("invalid request: {error}")})),
     };
@@ -1141,28 +1153,28 @@ fn project_program(body: &[u8]) -> (u16, Value) {
     };
     let outcome =
         topology::load_program(&staged.path).and_then(|bytecode| topology::verify(&bytecode));
-    let cleaned = staged.finish(outcome);
 
-    match cleaned {
+    match staged.finish(outcome) {
         Ok(state) => {
-            let present = request.present.into_iter().collect();
-            let (steps, truncated) = topology::project(&state, &present, MAX_PROJECTED_STEPS);
-            (
-                200,
-                json!({
-                    "ok": true,
-                    "team": state.team,
-                    "open_inputs": topology::open_inputs(&state),
-                    "steps": steps,
-                    // Said rather than implied: a timeline that stops is not the
-                    // same as a program that does.
-                    "truncated": truncated,
-                    // The topology as edited. An editor whose diagram lags the
-                    // text is showing a program that no longer exists, and the
-                    // client has no compiler of its own to build one with.
-                    "preview": crate::diagram::DiagramSnapshot::from_vm_state(&state),
-                }),
-            )
+            let mut answer = json!({
+                "ok": true,
+                "team": state.team,
+                // A diagnostic: a program that closes its loop has none.
+                "open_inputs": topology::open_inputs(&state),
+                // The topology as edited. An editor whose diagram lags the text
+                // is showing a program that no longer exists, and the client has
+                // no compiler of its own to build one with.
+                "preview": crate::diagram::DiagramSnapshot::from_vm_state(&state),
+            });
+            if request.timeline {
+                let present = request.present.into_iter().collect();
+                let (steps, truncated) = topology::timeline(&state, &present, MAX_TIMELINE_STEPS);
+                answer["steps"] = json!(steps);
+                // Said rather than implied: a timeline that stops is not the
+                // same as a program that does.
+                answer["truncated"] = json!(truncated);
+            }
+            (200, answer)
         }
         Err(message) => (200, json!({"ok": false, "errors": [message]})),
     }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -2021,6 +2021,16 @@ fn run_event_loop_observed<E: ReactionExecutor>(
     let layers = precedence_layers(state)?;
 
     while let Some((tag, events)) = queue.pop_first() {
+        // A tag nothing is present at is not a moment the run passed through.
+        // No reaction can fire at one -- enabling asks whether any trigger is
+        // in `events`, which is false for every reaction when it is empty --
+        // and no connection, output or timer can move either. Announcing it
+        // would tell a client the run had advanced when nothing had. The only
+        // way to reach one is a program admitted with no inputs, which seeds
+        // the start tag with an empty map.
+        if events.is_empty() {
+            continue;
+        }
         // Everything this tag knows. It grows as the tag settles: an
         // instantaneous connection or a reaction's effect joins it rather than
         // landing on a later tag, and the reactions downstream read it before
@@ -2963,16 +2973,8 @@ mod tests {
             timestamp: u64,
             microstep: u64,
             _lag: u64,
-            ports: &BTreeMap<String, Value>,
+            _ports: &BTreeMap<String, Value>,
         ) {
-            // Only tags where something is present. The loop seeds the start
-            // tag whether or not anything was supplied, so a program with no
-            // inputs passes through an empty (0, 0) that carries no event and
-            // fires no reaction. The timeline does not draw it, and a test that
-            // counted it would be asserting an artefact rather than agreement.
-            if ports.is_empty() {
-                return;
-            }
             self.tags.lock().unwrap().push((timestamp, microstep));
         }
     }
@@ -3001,6 +3003,29 @@ mod tests {
             .iter()
             .map(|step| (step.timestamp, step.microstep))
             .collect()
+    }
+
+    #[test]
+    fn a_run_nothing_can_start_reaches_no_tag_at_all() {
+        // The counterpart to the timeline showing nothing: a tag nothing is
+        // present at is not a moment the run passed through, so the run does
+        // not announce one. It used to announce (0, 0) — the start tag, seeded
+        // whether or not anything was supplied — which told a client the run
+        // had advanced when nothing had.
+        let state = verify(&open_input_bytecode()).unwrap();
+        let observer = RunTags {
+            tags: Mutex::new(Vec::new()),
+        };
+        let outputs = run_event_loop_observed(
+            &state,
+            BTreeMap::new(),
+            &SilentExecutor,
+            &observer,
+            Pace::Fast,
+        )
+        .unwrap();
+        assert!(observer.tags.lock().unwrap().is_empty(), "announced a tag");
+        assert!(outputs.is_empty());
     }
 
     #[test]

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -1827,6 +1827,137 @@ fn precedence_layers(state: &VmState) -> Result<Vec<Vec<String>>> {
     Ok(layers)
 }
 
+/// One logical tag of a projected run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectedStep {
+    pub timestamp: u64,
+    pub microstep: u64,
+    /// Ports and timers carrying a value at this tag, in name order.
+    pub events: Vec<String>,
+    /// Reactions whose triggers are present, in the order they would run.
+    pub reactions: Vec<String>,
+}
+
+/// What a program would do, worked out without running it.
+///
+/// This is the determinism claim made visible: given which inputs are present,
+/// the tags a program passes through and what fires at each are decided by the
+/// program, not by what the agents happen to say. So they can be shown before
+/// anything is deployed.
+///
+/// Values are not projected, only presence — an agent's answer is the one thing
+/// here that is not determined. Two consequences worth knowing:
+///
+/// - a reaction whose contract offers alternatives (`-> (x|y)`) is projected as
+///   writing *both*, because which one it picks is the agent's to decide. The
+///   projection is an over-approximation, never a missed step;
+/// - it cannot know a value that decides a delay, and nothing in the language
+///   has one, which is why this works at all.
+///
+/// Scheduling is not re-implemented here. `settle_connections`, `deliver` and
+/// `precedence_layers` are the same ones the event loop walks, so what settles
+/// at a tag — and which tag it settles at — cannot drift between what is shown
+/// and what runs.
+pub fn project(
+    state: &VmState,
+    present: &BTreeSet<String>,
+    max_steps: usize,
+) -> (Vec<ProjectedStep>, bool) {
+    let seed: BTreeMap<String, Value> = present
+        .iter()
+        .filter(|name| state.ports.contains_key(*name))
+        .map(|name| (name.clone(), Value::Null))
+        .collect();
+    let mut queue = BTreeMap::from([(Tag::START, seed)]);
+    for (name, timer) in &state.timers {
+        queue
+            .entry(Tag {
+                timestamp: timer.offset,
+                microstep: 0,
+            })
+            .or_default()
+            .insert(name.clone(), Value::Null);
+    }
+
+    // A program with a causality loop has no order to project; `verify` refuses
+    // it before a run, and there is nothing to show for one here either.
+    let Ok(layers) = precedence_layers(state) else {
+        return (Vec::new(), false);
+    };
+
+    let mut steps = Vec::new();
+    while let Some((tag, events)) = queue.pop_first() {
+        if events.is_empty() {
+            continue;
+        }
+        if steps.len() >= max_steps {
+            return (steps, true);
+        }
+
+        let mut events = events;
+        let mut carried = BTreeSet::new();
+        let _ = settle_connections(state, &mut events, &mut queue, tag, &mut carried);
+
+        for (name, timer) in &state.timers {
+            if timer.period > 0 && events.contains_key(name) {
+                let Some(next) = tag.timestamp.checked_add(timer.period) else {
+                    continue;
+                };
+                queue
+                    .entry(Tag {
+                        timestamp: next,
+                        microstep: 0,
+                    })
+                    .or_default()
+                    .insert(name.clone(), Value::Null);
+            }
+        }
+
+        // The same walk down the precedence order the event loop makes, with
+        // every effect taken rather than the one an agent would have picked.
+        let mut fired = Vec::new();
+        for layer in &layers {
+            let mut enabled: Vec<_> = layer
+                .iter()
+                .filter_map(|id| state.reactions.get_key_value(id))
+                .filter(|(_, reaction)| {
+                    reaction
+                        .triggers
+                        .iter()
+                        .any(|trigger| events.contains_key(trigger))
+                })
+                .collect();
+            if enabled.is_empty() {
+                continue;
+            }
+            enabled.sort_by_key(|(_, reaction)| reaction.order);
+            for (id, reaction) in &enabled {
+                fired.push((*id).clone());
+                for effect in &reaction.effects {
+                    let _ = deliver(
+                        state,
+                        &mut events,
+                        &mut queue,
+                        tag,
+                        effect,
+                        Value::Null,
+                        Delay::INSTANT,
+                    );
+                }
+            }
+            let _ = settle_connections(state, &mut events, &mut queue, tag, &mut carried);
+        }
+
+        steps.push(ProjectedStep {
+            timestamp: tag.timestamp,
+            microstep: tag.microstep,
+            events: events.keys().cloned().collect(),
+            reactions: fired,
+        });
+    }
+    (steps, false)
+}
+
 /// How a run's logical clock is held against the wall clock.
 ///
 /// Real time by default: a tag at logical timestamp T does not run before T has
@@ -2793,6 +2924,145 @@ mod tests {
         assert!(outputs.is_empty(), "nothing downstream ran: {outputs:?}");
     }
 
+    /// A two-input program with nothing feeding it: exactly the shape that has
+    /// to sit still until the operator sends something.
+    fn open_input_bytecode() -> Bytecode {
+        serde_json::from_str(
+            r#"{
+              "version": 1,
+              "team": "Desk",
+              "instructions": [
+                {"op":"begin_plan","team":"Desk"},
+                {"op":"spawn_agent","name":"clerk","backend":"Codex"},
+                {"op":"define_port","kind":"input","name":"topic","type":"string"},
+                {"op":"define_port","kind":"input","name":"depth","type":"int"},
+                {"op":"define_port","kind":"output","name":"memo","type":"string"},
+                {"op":"install_reaction","id":"reaction.0","agent":"clerk",
+                 "triggers":["topic","depth"],"effects":["memo"],
+                 "contract":"memo","prompt":"p"},
+                {"op":"commit_plan"}
+              ]
+            }"#,
+        )
+        .unwrap()
+    }
+
+    /// Records which triggers arrived together, which is how a batch sent at
+    /// one tag is told apart from values dribbled in one at a time.
+    struct BatchExecutor {
+        seen: Mutex<Vec<Vec<String>>>,
+    }
+
+    impl ReactionExecutor for BatchExecutor {
+        fn invoke(&self, invocation: InvocationSpec) -> Result<BTreeMap<String, Value>> {
+            self.seen
+                .lock()
+                .unwrap()
+                .push(invocation.trigger_values.keys().cloned().collect());
+            let writes = BTreeMap::from([("memo".into(), json!("done"))]);
+            validate_contract(&invocation.contract, &writes)?;
+            Ok(writes)
+        }
+    }
+
+    /// Records the tags a run actually passed through, so a projection can be
+    /// held against the thing it claims to predict.
+    struct RunTags {
+        tags: Mutex<Vec<(u64, u64)>>,
+    }
+
+    impl TopologyObserver for RunTags {
+        fn tag_advanced(
+            &self,
+            timestamp: u64,
+            microstep: u64,
+            _lag: u64,
+            _ports: &BTreeMap<String, Value>,
+        ) {
+            self.tags.lock().unwrap().push((timestamp, microstep));
+        }
+    }
+
+    fn tags_of_a_real_run<E: ReactionExecutor>(
+        state: &VmState,
+        inputs: BTreeMap<String, Value>,
+        executor: &E,
+    ) -> Vec<(u64, u64)> {
+        let observer = RunTags {
+            tags: Mutex::new(Vec::new()),
+        };
+        // Fast: this compares the tags a run passes through against the
+        // projection of them, and waiting out real delays would say nothing
+        // more about whether the two agree.
+        run_event_loop_observed(state, inputs, executor, &observer, Pace::Fast).unwrap();
+        let tags = observer.tags.lock().unwrap().clone();
+        tags
+    }
+
+    fn projected_tags(state: &VmState, present: &[&str]) -> Vec<(u64, u64)> {
+        let present = present.iter().map(|name| name.to_string()).collect();
+        let (steps, truncated) = project(state, &present, 256);
+        assert!(!truncated, "projection ran out of room");
+        steps
+            .iter()
+            .map(|step| (step.timestamp, step.microstep))
+            .collect()
+    }
+
+    #[test]
+    fn a_program_nobody_has_fed_projects_nothing() {
+        // An open input nobody has set means the program does not move, which
+        // is what the timeline should show before anything is sent.
+        let state = verify(&open_input_bytecode()).unwrap();
+        let (steps, truncated) = project(&state, &BTreeSet::new(), 256);
+        assert!(steps.is_empty(), "{steps:?}");
+        assert!(!truncated);
+
+        // Setting one of the two is enough: the reaction's triggers are an OR,
+        // and the projection has to agree with the loop about that.
+        //
+        // One tag, not two: `memo` is a port, a port costs nothing, and so the
+        // reaction's effect is present at the tag that triggered it.
+        let one = BTreeSet::from(["topic".to_string()]);
+        let (steps, _) = project(&state, &one, 256);
+        assert_eq!(steps.len(), 1, "{steps:?}");
+        assert_eq!(
+            steps[0].events,
+            vec!["memo".to_string(), "topic".to_string()]
+        );
+        assert_eq!(steps[0].reactions, vec!["reaction.0".to_string()]);
+    }
+
+    #[test]
+    fn a_projection_hits_the_tags_the_run_does() {
+        // The claim the timeline makes: what a program does is decided by the
+        // program. If these disagree, one of them is lying to the operator.
+        let state = verify(&open_input_bytecode()).unwrap();
+        let executor = BatchExecutor {
+            seen: Mutex::new(Vec::new()),
+        };
+        let real = tags_of_a_real_run(
+            &state,
+            BTreeMap::from([
+                ("topic".to_string(), json!("nesting")),
+                ("depth".to_string(), json!(3)),
+            ]),
+            &executor,
+        );
+
+        assert_eq!(projected_tags(&state, &["topic", "depth"]), real);
+    }
+
+    #[test]
+    fn a_periodic_projection_stops_rather_than_running_forever() {
+        // A periodic timer has no end. A preview has to have one.
+        let state = verify(&timer_bytecode(0, 10)).unwrap();
+        let (steps, truncated) = project(&state, &BTreeSet::new(), 8);
+        assert!(truncated);
+        assert_eq!(steps.len(), 8);
+        assert_eq!(steps[0].timestamp, 0);
+    }
+
     #[test]
     fn a_client_is_a_backend_however_it_is_spelled() {
         assert!(is_web_backend("Web"));
@@ -3664,6 +3934,19 @@ mod tests {
             *executor.calls.lock().unwrap(),
             vec!["reaction.0", "reaction.1", "reaction.2"]
         );
+
+        // Delays are where a re-implementation would drift first: a fixed port
+        // delay and a connection delay both move a tag, and the projection has
+        // to move it the same way. It shares `enqueue_event` with the loop so
+        // that it cannot, and this is what says so.
+        let real = tags_of_a_real_run(
+            &state,
+            BTreeMap::from([("start".into(), json!(7))]),
+            &SuperdenseExecutor {
+                calls: Mutex::new(Vec::new()),
+            },
+        );
+        assert_eq!(projected_tags(&state, &["start"]), real);
     }
 
     struct OrTriggerExecutor {

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -1827,9 +1827,9 @@ fn precedence_layers(state: &VmState) -> Result<Vec<Vec<String>>> {
     Ok(layers)
 }
 
-/// One logical tag of a projected run.
+/// One logical tag a program would pass through.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ProjectedStep {
+pub struct TimelineStep {
     pub timestamp: u64,
     pub microstep: u64,
     /// Ports and timers carrying a value at this tag, in name order.
@@ -1838,19 +1838,23 @@ pub struct ProjectedStep {
     pub reactions: Vec<String>,
 }
 
-/// What a program would do, worked out without running it.
+/// The tags a program would pass through, worked out without running it.
 ///
-/// This is the determinism claim made visible: given which inputs are present,
-/// the tags a program passes through and what fires at each are decided by the
-/// program, not by what the agents happen to say. So they can be shown before
-/// anything is deployed.
+/// The determinism claim made visible: which tags a program reaches and what
+/// fires at each are decided by the program, not by what the agents happen to
+/// say. So they can be shown before anything is deployed.
 ///
-/// Values are not projected, only presence — an agent's answer is the one thing
-/// here that is not determined. Two consequences worth knowing:
+/// `present` names the ports to treat as carrying a value at the first tag —
+/// the inputs a run would be admitted with. Timers are always seeded; they are
+/// what starts a program that starts itself. Presence is all that is needed:
+/// a reaction fires on a trigger being there, whatever it holds.
 ///
-/// - a reaction whose contract offers alternatives (`-> (x|y)`) is projected as
-///   writing *both*, because which one it picks is the agent's to decide. The
-///   projection is an over-approximation, never a missed step;
+/// Values are not worked out, only presence — an agent's answer is the one
+/// thing here that is not determined. Two consequences worth knowing:
+///
+/// - a reaction whose contract offers alternatives (`-> (x|y)`) is shown as
+///   writing *both*, because which one it picks is the agent's to decide. This
+///   over-approximates, and never misses a step;
 /// - it cannot know a value that decides a delay, and nothing in the language
 ///   has one, which is why this works at all.
 ///
@@ -1858,11 +1862,11 @@ pub struct ProjectedStep {
 /// `precedence_layers` are the same ones the event loop walks, so what settles
 /// at a tag — and which tag it settles at — cannot drift between what is shown
 /// and what runs.
-pub fn project(
+pub fn timeline(
     state: &VmState,
     present: &BTreeSet<String>,
     max_steps: usize,
-) -> (Vec<ProjectedStep>, bool) {
+) -> (Vec<TimelineStep>, bool) {
     let seed: BTreeMap<String, Value> = present
         .iter()
         .filter(|name| state.ports.contains_key(*name))
@@ -1948,7 +1952,7 @@ pub fn project(
             let _ = settle_connections(state, &mut events, &mut queue, tag, &mut carried);
         }
 
-        steps.push(ProjectedStep {
+        steps.push(TimelineStep {
             timestamp: tag.timestamp,
             microstep: tag.microstep,
             events: events.keys().cloned().collect(),
@@ -2947,24 +2951,6 @@ mod tests {
         .unwrap()
     }
 
-    /// Records which triggers arrived together, which is how a batch sent at
-    /// one tag is told apart from values dribbled in one at a time.
-    struct BatchExecutor {
-        seen: Mutex<Vec<Vec<String>>>,
-    }
-
-    impl ReactionExecutor for BatchExecutor {
-        fn invoke(&self, invocation: InvocationSpec) -> Result<BTreeMap<String, Value>> {
-            self.seen
-                .lock()
-                .unwrap()
-                .push(invocation.trigger_values.keys().cloned().collect());
-            let writes = BTreeMap::from([("memo".into(), json!("done"))]);
-            validate_contract(&invocation.contract, &writes)?;
-            Ok(writes)
-        }
-    }
-
     /// Records the tags a run actually passed through, so a projection can be
     /// held against the thing it claims to predict.
     struct RunTags {
@@ -2977,8 +2963,16 @@ mod tests {
             timestamp: u64,
             microstep: u64,
             _lag: u64,
-            _ports: &BTreeMap<String, Value>,
+            ports: &BTreeMap<String, Value>,
         ) {
+            // Only tags where something is present. The loop seeds the start
+            // tag whether or not anything was supplied, so a program with no
+            // inputs passes through an empty (0, 0) that carries no event and
+            // fires no reaction. The timeline does not draw it, and a test that
+            // counted it would be asserting an artefact rather than agreement.
+            if ports.is_empty() {
+                return;
+            }
             self.tags.lock().unwrap().push((timestamp, microstep));
         }
     }
@@ -2999,10 +2993,10 @@ mod tests {
         tags
     }
 
-    fn projected_tags(state: &VmState, present: &[&str]) -> Vec<(u64, u64)> {
+    fn timeline_tags(state: &VmState, present: &[&str]) -> Vec<(u64, u64)> {
         let present = present.iter().map(|name| name.to_string()).collect();
-        let (steps, truncated) = project(state, &present, 256);
-        assert!(!truncated, "projection ran out of room");
+        let (steps, truncated) = timeline(state, &present, 256);
+        assert!(!truncated, "the timeline ran out of room");
         steps
             .iter()
             .map(|step| (step.timestamp, step.microstep))
@@ -3010,54 +3004,35 @@ mod tests {
     }
 
     #[test]
-    fn a_program_nobody_has_fed_projects_nothing() {
-        // An open input nobody has set means the program does not move, which
-        // is what the timeline should show before anything is sent.
+    fn a_program_nothing_can_start_shows_nothing() {
+        // No timer, and every input dangling: there is nothing to begin it, so
+        // the timeline is empty rather than guessing at a first tag.
         let state = verify(&open_input_bytecode()).unwrap();
-        let (steps, truncated) = project(&state, &BTreeSet::new(), 256);
+        let (steps, truncated) = timeline(&state, &BTreeSet::new(), 256);
         assert!(steps.is_empty(), "{steps:?}");
         assert!(!truncated);
-
-        // Setting one of the two is enough: the reaction's triggers are an OR,
-        // and the projection has to agree with the loop about that.
-        //
-        // One tag, not two: `memo` is a port, a port costs nothing, and so the
-        // reaction's effect is present at the tag that triggered it.
-        let one = BTreeSet::from(["topic".to_string()]);
-        let (steps, _) = project(&state, &one, 256);
-        assert_eq!(steps.len(), 1, "{steps:?}");
-        assert_eq!(
-            steps[0].events,
-            vec!["memo".to_string(), "topic".to_string()]
-        );
-        assert_eq!(steps[0].reactions, vec!["reaction.0".to_string()]);
     }
 
     #[test]
-    fn a_projection_hits_the_tags_the_run_does() {
-        // The claim the timeline makes: what a program does is decided by the
-        // program. If these disagree, one of them is lying to the operator.
-        let state = verify(&open_input_bytecode()).unwrap();
-        let executor = BatchExecutor {
-            seen: Mutex::new(Vec::new()),
+    fn the_timeline_hits_the_tags_the_run_does() {
+        // The claim it makes: what a program does is decided by the program. If
+        // these disagree, one of them is lying to the operator. A timer starts
+        // both, which is the only thing that can start either.
+        let state = verify(&timer_bytecode(3, 0)).unwrap();
+        let executor = TimerExecutor {
+            fired: Mutex::new(Vec::new()),
+            stop_after: 0,
         };
-        let real = tags_of_a_real_run(
-            &state,
-            BTreeMap::from([
-                ("topic".to_string(), json!("nesting")),
-                ("depth".to_string(), json!(3)),
-            ]),
-            &executor,
-        );
-
-        assert_eq!(projected_tags(&state, &["topic", "depth"]), real);
+        let real = tags_of_a_real_run(&state, BTreeMap::new(), &executor);
+        assert!(!real.is_empty(), "the run reached no tags");
+        assert_eq!(timeline_tags(&state, &[]), real);
     }
 
     #[test]
     fn a_periodic_projection_stops_rather_than_running_forever() {
         // A periodic timer has no end. A preview has to have one.
         let state = verify(&timer_bytecode(0, 10)).unwrap();
-        let (steps, truncated) = project(&state, &BTreeSet::new(), 8);
+        let (steps, truncated) = timeline(&state, &BTreeSet::new(), 8);
         assert!(truncated);
         assert_eq!(steps.len(), 8);
         assert_eq!(steps[0].timestamp, 0);
@@ -3946,7 +3921,7 @@ mod tests {
                 calls: Mutex::new(Vec::new()),
             },
         );
-        assert_eq!(projected_tags(&state, &["start"]), real);
+        assert_eq!(timeline_tags(&state, &["start"]), real);
     }
 
     struct OrTriggerExecutor {

--- a/web/app/diagram/diagram-canvas.tsx
+++ b/web/app/diagram/diagram-canvas.tsx
@@ -146,8 +146,11 @@ type ReactionView = {
 type EdgeView = {
   id: string;
   kind: string;
-  delayed: boolean;
   path: string;
+  /** The rest of the line, when a delay label breaks it. */
+  tail: string | null;
+  /** The delay, drawn in the break. Null when there is none. */
+  delay: { text: string; at: Point; horizontal: boolean } | null;
 };
 
 type ContainerView = {
@@ -197,6 +200,54 @@ function chevronPoints(width: number, height: number): string {
     `0,${height}`,
     `${CHEVRON_NOTCH},${mid}`,
   ].join(" ");
+}
+
+
+/**
+ * Break a polyline so a label can sit in the gap.
+ *
+ * The alternative is drawing the number over the line and hiding what is behind
+ * it, which needs to know the colour there — and an edge crosses both the
+ * canvas and the containers it passes through, which are different. A real gap
+ * shows whatever is actually behind.
+ *
+ * Broken on the longest segment: the most room, and never on a corner.
+ */
+function breakForLabel(
+  points: Point[],
+  gap: number,
+): { before: Point[]; after: Point[]; at: Point; horizontal: boolean } | null {
+  let index = -1;
+  let longest = -1;
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const length =
+      Math.abs(points[i + 1].x - points[i].x) + Math.abs(points[i + 1].y - points[i].y);
+    if (length > longest) {
+      longest = length;
+      index = i;
+    }
+  }
+  // Not enough line to take a bite out of and still read as a line.
+  if (index < 0 || longest < gap + 20) return null;
+
+  const a = points[index];
+  const b = points[index + 1];
+  const horizontal = Math.abs(b.x - a.x) >= Math.abs(b.y - a.y);
+  const at = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+  const half = gap / 2;
+  const step = horizontal ? Math.sign(b.x - a.x) : Math.sign(b.y - a.y);
+  const stop = horizontal
+    ? { x: at.x - step * half, y: at.y }
+    : { x: at.x, y: at.y - step * half };
+  const resume = horizontal
+    ? { x: at.x + step * half, y: at.y }
+    : { x: at.x, y: at.y + step * half };
+  return {
+    before: [...points.slice(0, index + 1), stop],
+    after: [resume, ...points.slice(index + 1)],
+    at,
+    horizontal,
+  };
 }
 
 /** Right-pointing port triangle, centred on the container boundary. */
@@ -877,12 +928,31 @@ function buildLayout(
 
     const start = sourcePort ? 8 : 0;
     const end = targetPort ? 9 : reactionIds.has(edge.target) ? -CHEVRON_NOTCH : 0;
+    const drawn = adjustEnds(squareOff(routed), start, end);
+    // A delay is a fact about the connection, so it is written on it. Only for
+    // connections: a trigger or an effect is a reaction's own wiring and has
+    // no delay to state.
+    //
+    // A plain connection costs nothing and so says nothing. `after 0` costs a
+    // microstep -- a step in order rather than in time -- which no duration can
+    // spell, so it is named instead of measured.
+    const text =
+      edge.kind !== "connection" || edge.delay === null
+        ? null
+        : edge.delay === 0
+          ? "\u03bcstep"
+          : formatDuration(edge.delay);
+    const split = text ? breakForLabel(drawn, textWidth(text, 5.6) + 8) : null;
     return [
       {
         id: edge.id,
         kind: edge.kind,
-        delayed: edge.delay !== null,
-        path: orthogonalPath(adjustEnds(squareOff(routed), start, end)),
+        path: orthogonalPath(split ? split.before : drawn),
+        tail: split ? orthogonalPath(split.after) : null,
+        delay:
+          text && split
+            ? { text, at: split.at, horizontal: split.horizontal }
+            : null,
       },
     ];
   });
@@ -1305,14 +1375,28 @@ export function DiagramCanvas({
 
             <g className="omar-edges">
               {layout.edges.map((edge) => (
-                <path
-                  key={edge.id}
-                  data-id={edge.id}
-                  className={`omar-edge ${edge.kind}${edge.delayed ? " delayed" : ""}`}
-                  // No arrowhead: the port triangles already point the way,
-                  // and a head on the line repeats it.
-                  d={edge.path}
-                />
+                <g key={edge.id}>
+                  <path
+                    data-id={edge.id}
+                    className={`omar-edge ${edge.kind}`}
+                    // No arrowhead: the port triangles already point the way,
+                    // and a head on the line repeats it.
+                    d={edge.path}
+                  />
+                  {edge.tail ? (
+                    <path className={`omar-edge ${edge.kind}`} d={edge.tail} />
+                  ) : null}
+                  {edge.delay ? (
+                    <text
+                      className="omar-edge-delay"
+                      x={edge.delay.at.x}
+                      y={edge.delay.at.y + (edge.delay.horizontal ? 3 : 3.5)}
+                      textAnchor="middle"
+                    >
+                      {edge.delay.text}
+                    </text>
+                  ) : null}
+                </g>
               ))}
             </g>
 

--- a/web/app/diagram/diagram-canvas.tsx
+++ b/web/app/diagram/diagram-canvas.tsx
@@ -1013,6 +1013,7 @@ export function DiagramCanvas({
   onToggleComponent,
   onOpenTerminal,
   onOpenPanel,
+  highlight,
 }: {
   snapshot: DiagramSnapshot;
   selection?: string[];
@@ -1021,6 +1022,12 @@ export function DiagramCanvas({
   onOpenTerminal?: (agent: string) => void;
   /** A web agent has no pane, so its double-click opens its panel instead. */
   onOpenPanel?: (agent: string) => void;
+  /**
+   * Ids the timeline is pointing at: what carries a value and what fires at
+   * the tag being shown. Separate from selection, which is what the operator
+   * has picked out to talk about.
+   */
+  highlight?: ReadonlySet<string>;
 }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const [layout, setLayout] = useState<Layout | null>(null);
@@ -1043,10 +1050,13 @@ export function DiagramCanvas({
 
   /** Props that make a node selectable, or just its class when selection is off. */
   function selectable(id: string, base: string) {
-    if (!onToggleComponent) return { className: base };
+    // Dimming is a property of the drawing, not of selection, so it applies
+    // whether or not anything is selectable.
+    const lit = highlight ? (highlight.has(id) ? " at-tag" : " off-tag") : "";
+    if (!onToggleComponent) return { className: `${base}${lit}` };
     const component = componentName(id);
     return {
-      className: `${base}${selected.has(component) ? " selected" : ""}`,
+      className: `${base}${lit}${selected.has(component) ? " selected" : ""}`,
       onClick: () => handleNodeClick(component),
       // The canvas resets the view on double click; a node has its own meaning.
       onDoubleClick: (event: { stopPropagation: () => void }) =>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1007,11 +1007,15 @@ h2 {
   stroke-linecap: round;
 }
 
-/* A delayed connection still carries a value; the dashes are longer so it is
-   told apart from the wiring inside a reaction. */
-.omar-edge.delayed {
-  stroke: #7b648f;
-  stroke-dasharray: 8 5;
+/* A delayed connection is a connection: solid, like any other. What it carries
+   is the same, and only the when differs — so the when is written on it rather
+   than encoded in the stroke, which could only ever say "some delay" and never
+   which. The line breaks around the number instead of running through it. */
+.omar-edge-delay {
+  fill: #5f5c66;
+  font: 9px ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
 /* Triggers and effects are a reaction's own wiring, not a path a value travels

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1007,9 +1007,20 @@ h2 {
   stroke-linecap: round;
 }
 
+/* A delayed connection still carries a value; the dashes are longer so it is
+   told apart from the wiring inside a reaction. */
 .omar-edge.delayed {
   stroke: #7b648f;
-  stroke-dasharray: 5 4;
+  stroke-dasharray: 8 5;
+}
+
+/* Triggers and effects are a reaction's own wiring, not a path a value travels
+   between ports. Solid is reserved for connections, which are the edges that
+   move something from one place to another. */
+.omar-edge.trigger,
+.omar-edge.effect {
+  stroke-dasharray: 3 3;
+  opacity: 0.75;
 }
 
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1734,6 +1734,270 @@ h2 {
 
 /* A terminal attached to a running agent. It sits over the studio rather than
    in a separate window so the diagram stays behind it for context. */
+/* The logical timeline: every tag the program passes through.
+
+   Sits under the diagram because it is the same thing on another axis — the
+   drawing is what exists, this is when it happens. */
+.timeline {
+  flex: none;
+  border-top: 1px solid var(--line);
+  background: var(--panel-2);
+  padding: 10px 14px;
+}
+
+.timeline-handle {
+  flex: none;
+  border: 0;
+  border-top: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  padding: 6px 14px;
+  text-align: left;
+}
+
+.timeline-handle:hover {
+  color: #d8caff;
+}
+
+.timeline-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.timeline-controls button {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--ink);
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1;
+  padding: 4px 9px;
+}
+
+.timeline-controls button:disabled {
+  opacity: 0.35;
+}
+
+.timeline-controls input[type="range"] {
+  flex: 1;
+  min-width: 0;
+  accent-color: var(--purple);
+}
+
+.timeline-close {
+  font-size: 11px !important;
+}
+
+.timeline-readout {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.timeline-tag {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-bright, #f5f2fa);
+}
+
+.timeline-mode {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 1px 8px;
+  letter-spacing: 0.04em;
+}
+
+/* Following a run rather than predicting one. */
+.timeline-mode.live {
+  border-color: var(--purple);
+  color: #d8caff;
+}
+
+.timeline-detail,
+.timeline-idle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timeline-truncated {
+  margin: 6px 0 0;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+/* What the tag being shown touches, and what it does not. Dimming the rest is
+   what makes a tag legible on a diagram of any size. */
+.at-tag .omar-port,
+.at-tag .omar-action,
+.at-tag .omar-reaction-body {
+  stroke: var(--purple);
+  stroke-width: 1.6;
+}
+
+.off-tag {
+  opacity: 0.32;
+}
+
+/* Set values for open input ports.
+
+   Slides in over the diagram rather than replacing it: the operator picked
+   these ports by clicking them, and a list of qualified names is much easier to
+   place when the drawing is still behind it. */
+.input-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 35;
+  width: min(420px, 92vw);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px;
+  background: var(--panel);
+  border-left: 1px solid var(--line);
+  box-shadow: -24px 0 60px rgba(0, 0, 0, 0.5);
+  animation: input-panel-in 160ms ease-out;
+}
+
+@keyframes input-panel-in {
+  from {
+    transform: translateX(16px);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .input-panel {
+    animation: none;
+  }
+}
+
+.input-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.input-panel-head h2 {
+  margin: 2px 0 0;
+  font-size: 15px;
+}
+
+.input-panel-close {
+  border: 0;
+  background: transparent;
+  color: #9d97a8;
+  font-size: 11px;
+  text-decoration: underline;
+}
+
+.input-panel-close:hover {
+  color: #d8caff;
+}
+
+.input-panel-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+/* Scrolls on its own: a program can have more open inputs than fit. */
+.input-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.input-port {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 8px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-2);
+}
+
+/* The one the operator clicked on the diagram. */
+.input-port.focused {
+  border-color: var(--purple);
+  box-shadow: 0 0 0 1px var(--purple-soft);
+}
+
+.input-port-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.input-port-type {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.input-port input {
+  grid-column: 1 / -1;
+  width: 100%;
+  padding: 7px 9px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--ink);
+  color: var(--text);
+  font-size: 13px;
+}
+
+.input-port input:focus {
+  outline: none;
+  border-color: var(--purple);
+}
+
+/* Typed text that cannot be read as the port's type. Caught here rather than
+   by the run refusing the batch. */
+.input-port.invalid input {
+  border-color: #c2607a;
+}
+
+.input-port-problem {
+  grid-column: 1 / -1;
+  color: #d98aa0;
+  font-size: 11px;
+}
+
+.input-panel-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+/* An open input is the operator's to set, so it reads as actionable rather
+   than as one more thing the drawing happens to contain. */
+.omar-port-group.open-input {
+  cursor: pointer;
+}
+
+.omar-port-group.open-input .omar-port {
+  stroke: var(--purple);
+  stroke-width: 1.5;
+}
+
+.omar-port-group.open-input:hover .omar-port {
+  fill: var(--purple);
+}
+
 .terminal-overlay {
   position: fixed;
   inset: 0;

--- a/web/app/lib/protocol.ts
+++ b/web/app/lib/protocol.ts
@@ -159,6 +159,21 @@ export type PendingInvocation = {
 };
 
 /**
+ * Inputs nothing inside the topology writes to.
+ *
+ * A diagnostic, matching the daemon's own. A program that closes its loop has
+ * none; one that has some has a port nothing will ever drive. The projection
+ * treats them as arriving, because the question it answers is what the program
+ * would do if they did.
+ */
+export function openInputs(snapshot: DiagramSnapshot): DiagramPort[] {
+  const fed = new Set(
+    snapshot.edges.filter((edge) => edge.kind === "connection").map((edge) => edge.target),
+  );
+  return snapshot.ports.filter((port) => port.kind === "input" && !fed.has(port.id));
+}
+
+/**
  * Turn what an operator typed into a value of the port's type.
  *
  * The runtime checks a value against its port before it reaches the run, and it

--- a/web/app/lib/runtime-client.ts
+++ b/web/app/lib/runtime-client.ts
@@ -156,8 +156,8 @@ export async function checkServeHealth(
  * Hand a confirmed design to `omar serve`, which compiles it and starts the
  * run. The returned `diagram_address` is where that run's live topology lives.
  */
-/** One logical tag of a projected run. */
-export type ProjectedStep = {
+/** One logical tag a program would pass through. */
+export type TimelineStep = {
   timestamp: number;
   microstep: number;
   /** Ports and timers carrying a value at this tag. */
@@ -166,11 +166,13 @@ export type ProjectedStep = {
   reactions: string[];
 };
 
-export type Projection = {
+export type ProgramCheck = {
   ok: boolean;
   team?: string;
+  /** A diagnostic: a program that closes its loop reports none. */
   open_inputs?: string[];
-  steps?: ProjectedStep[];
+  /** Only when `timeline` was asked for. */
+  steps?: TimelineStep[];
   /** The projection stopped early; the program has not. */
   truncated?: boolean;
   /** The topology as compiled, so the drawing can follow the text. */
@@ -179,31 +181,40 @@ export type Projection = {
 };
 
 /**
- * What a program would do, worked out without running it.
+ * Compile a program without running it, and optionally say what it would do.
  *
- * Computed by the runtime rather than here: the rules that decide a tag —
- * fixed port delays, connection delays, superdense microsteps — belong to the
- * event loop, and a second implementation in this language would drift from it
- * silently.
+ * The same compiler and verifier a deploy would use, so a program that passes
+ * here is not refused a moment later.
+ *
+ * The timeline is asked for rather than assumed: a caller that only wants to
+ * know whether a program holds together should not be handed one to ignore.
+ * When it is asked for, it comes off the same compile — the rules that decide a
+ * tag belong to the event loop, and a second implementation in this language
+ * would drift from it silently.
  */
-export async function projectProgram(
+export async function checkProgram(
   serveUrl: string,
   program: string,
   filename: string,
-  present: string[],
+  options: { timeline?: boolean; present?: string[] } = {},
   signal?: AbortSignal,
-): Promise<Projection> {
+): Promise<ProgramCheck> {
   const base = normalizeRuntimeUrl(serveUrl);
-  const response = await fetch(`${base}/v1/programs/project`, {
+  const response = await fetch(`${base}/v1/programs/check`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ program, filename, present }),
+    body: JSON.stringify({
+      program,
+      filename,
+      timeline: options.timeline ?? false,
+      present: options.present ?? [],
+    }),
     signal,
   });
   if (!response.ok) {
     throw new Error(await readError(response));
   }
-  return (await response.json()) as Projection;
+  return (await response.json()) as ProgramCheck;
 }
 
 export async function startRun(

--- a/web/app/lib/runtime-client.ts
+++ b/web/app/lib/runtime-client.ts
@@ -156,6 +156,56 @@ export async function checkServeHealth(
  * Hand a confirmed design to `omar serve`, which compiles it and starts the
  * run. The returned `diagram_address` is where that run's live topology lives.
  */
+/** One logical tag of a projected run. */
+export type ProjectedStep = {
+  timestamp: number;
+  microstep: number;
+  /** Ports and timers carrying a value at this tag. */
+  events: string[];
+  /** Reactions that fire, in the order they would run. */
+  reactions: string[];
+};
+
+export type Projection = {
+  ok: boolean;
+  team?: string;
+  open_inputs?: string[];
+  steps?: ProjectedStep[];
+  /** The projection stopped early; the program has not. */
+  truncated?: boolean;
+  /** The topology as compiled, so the drawing can follow the text. */
+  preview?: DiagramSnapshot;
+  errors?: string[];
+};
+
+/**
+ * What a program would do, worked out without running it.
+ *
+ * Computed by the runtime rather than here: the rules that decide a tag —
+ * fixed port delays, connection delays, superdense microsteps — belong to the
+ * event loop, and a second implementation in this language would drift from it
+ * silently.
+ */
+export async function projectProgram(
+  serveUrl: string,
+  program: string,
+  filename: string,
+  present: string[],
+  signal?: AbortSignal,
+): Promise<Projection> {
+  const base = normalizeRuntimeUrl(serveUrl);
+  const response = await fetch(`${base}/v1/programs/project`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ program, filename, present }),
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(await readError(response));
+  }
+  return (await response.json()) as Projection;
+}
+
 export async function startRun(
   serveUrl: string,
   request: RunRequest,
@@ -172,40 +222,6 @@ export async function startRun(
     throw new Error(await readError(response));
   }
   return assertRunRecord(await response.json());
-}
-
-/** What the compiler says about a program nobody has deployed. */
-export type ProgramCheck = {
-  ok: boolean;
-  team?: string;
-  /** A diagnostic: a program that closes its loop reports none. */
-  open_inputs?: string[];
-  errors?: string[];
-};
-
-/**
- * Compile a program without running it.
- *
- * The same compiler and verifier a deploy would use, so a program that passes
- * here is not refused a moment later.
- */
-export async function checkProgram(
-  serveUrl: string,
-  program: string,
-  filename: string,
-  signal?: AbortSignal,
-): Promise<ProgramCheck> {
-  const base = normalizeRuntimeUrl(serveUrl);
-  const response = await fetch(`${base}/v1/programs/check`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ program, filename }),
-    signal,
-  });
-  if (!response.ok) {
-    throw new Error(await readError(response));
-  }
-  return (await response.json()) as ProgramCheck;
 }
 
 /**

--- a/web/app/omar-source.tsx
+++ b/web/app/omar-source.tsx
@@ -102,6 +102,23 @@ export function OmarEditor({
           spellCheck={false}
           aria-label="OMAR program"
           onChange={(event) => onSourceChange(event.target.value)}
+          onKeyDown={(event) => {
+            // A textarea gives Tab to the browser, which moves focus out of
+            // the editor mid-word. In a code pane it indents.
+            if (event.key !== "Tab" || event.metaKey || event.ctrlKey) return;
+            event.preventDefault();
+            const field = event.currentTarget;
+            const { selectionStart, selectionEnd, value } = field;
+            const indent = "    ";
+            const next = value.slice(0, selectionStart) + indent + value.slice(selectionEnd);
+            onSourceChange(next);
+            // Put the caret after what was inserted; React re-renders from the
+            // value, so this has to happen once that has landed.
+            requestAnimationFrame(() => {
+              field.selectionStart = selectionStart + indent.length;
+              field.selectionEnd = field.selectionStart;
+            });
+          }}
           onScroll={(event) => {
             const pre = behind.current;
             if (!pre) return;

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -501,6 +501,10 @@ export function Studio({
           setSourceErrors(result.ok ? [] : (result.errors ?? []));
           setSteps(result.steps ?? []);
           setTruncated(result.truncated ?? false);
+          // The drawing follows the text. Only while nothing is running: a live
+          // run's diagram is a record of what is happening, not of what has
+          // been typed since.
+          if (result.preview && !run) setSnapshot(result.preview);
           // A recomputed projection replaces the tail, so a hand-held position
           // past its end would be pointing at nothing.
           setStepIndex((current) => Math.min(current, Math.max(0, (result.steps?.length ?? 1) - 1)));
@@ -517,7 +521,11 @@ export function Studio({
       clearTimeout(timer);
       abort.abort();
     };
-  }, [source, filename, serveUrl, canRun, presentKey]);
+    // `run` decides whether the drawing may be replaced, so a run appearing
+    // has to re-run this rather than leave a stale rule in a closure. The key
+    // rather than the array: this effect sets the snapshot `present` is
+    // derived from, so depending on its identity would ask forever.
+  }, [source, filename, serveUrl, canRun, presentKey, run]);
 
   const isDeployed = run !== null;
 

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -28,7 +28,7 @@ import {
   type ProposedDesign,
   type RunRecord,
 } from "./lib/protocol";
-import type { ProjectedStep } from "./lib/runtime-client";
+import type { TimelineStep } from "./lib/runtime-client";
 import {
   answerPanel,
   ASSISTANT,
@@ -37,7 +37,7 @@ import {
   fetchDiagram,
   fetchPanel,
   fetchRun,
-  projectProgram,
+  checkProgram,
   startRun,
   subscribeToDiagram,
 } from "./lib/runtime-client";
@@ -101,7 +101,7 @@ export function Studio({
   const [sourceErrors, setSourceErrors] = useState<string[]>([]);
   const [checking, setChecking] = useState(false);
   /** Every tag the program passes through, projected or observed. */
-  const [steps, setSteps] = useState<ProjectedStep[]>([]);
+  const [steps, setSteps] = useState<TimelineStep[]>([]);
   const [truncated, setTruncated] = useState(false);
   const [stepIndex, setStepIndex] = useState(0);
   const [timelineOpen, setTimelineOpen] = useState(false);
@@ -501,11 +501,17 @@ export function Studio({
       setChecking(true);
       // Checking and projecting are the same question asked twice — is this a
       // program, and what would it do — so they are asked together.
-      projectProgram(
+      // The timeline is asked for because the editor draws it. Both answers
+      // come off one compile, so they cannot disagree about which text they
+      // are describing.
+      checkProgram(
         serveUrl,
         source,
         filename,
-        presentKey ? presentKey.split("\u0000") : [],
+        {
+          timeline: true,
+          present: presentKey ? presentKey.split("\u0000") : [],
+        },
         abort.signal,
       )
         .then((result) => {

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -155,6 +155,22 @@ export function Studio({
     () => (snapshot ? openInputs(snapshot).map((port) => port.name) : []),
     [snapshot],
   );
+  /**
+   * The same list as a value rather than an identity.
+   *
+   * `present` is derived from the snapshot, and the projection sets the
+   * snapshot — so depending on the array itself means every projection asks
+   * for another one, forever. What matters is which ports are in it.
+   */
+  const presentKey = present.join("\u0000");
+  /**
+   * Which check is the current one.
+   *
+   * Aborting a request tells the network to stop; it does not decide whether a
+   * reply that already arrived is still wanted. A reply is applied when it is
+   * the newest one asked for, which is the actual question.
+   */
+  const checkTokenRef = useRef(0);
 
   /**
    * `present` is derived from the snapshot, and a projection sets the snapshot
@@ -480,6 +496,8 @@ export function Studio({
   // stale answer cannot land after a newer one.
   useEffect(() => {
     const abort = new AbortController();
+    const token = ++checkTokenRef.current;
+    const current = () => checkTokenRef.current === token;
     const timer = setTimeout(() => {
       // Nothing to check against, or nothing to check: clear rather than leave
       // an error standing for text that is gone.
@@ -498,34 +516,27 @@ export function Studio({
         abort.signal,
       )
         .then((result) => {
+          if (!current()) return;
           setSourceErrors(result.ok ? [] : (result.errors ?? []));
           setSteps(result.steps ?? []);
           setTruncated(result.truncated ?? false);
-          // The drawing follows the text. Only while nothing is running: a live
-          // run's diagram is a record of what is happening, not of what has
-          // been typed since.
-          if (result.preview && !run) setSnapshot(result.preview);
           // A recomputed projection replaces the tail, so a hand-held position
           // past its end would be pointing at nothing.
           setStepIndex((current) => Math.min(current, Math.max(0, (result.steps?.length ?? 1) - 1)));
         })
         .catch((cause) => {
-          if (abort.signal.aborted) return;
+          if (!current() || abort.signal.aborted) return;
           setSourceErrors([cause instanceof Error ? cause.message : String(cause)]);
         })
         .finally(() => {
-          if (!abort.signal.aborted) setChecking(false);
+          if (current()) setChecking(false);
         });
     }, 400);
     return () => {
       clearTimeout(timer);
       abort.abort();
     };
-    // `run` decides whether the drawing may be replaced, so a run appearing
-    // has to re-run this rather than leave a stale rule in a closure. The key
-    // rather than the array: this effect sets the snapshot `present` is
-    // derived from, so depending on its identity would ask forever.
-  }, [source, filename, serveUrl, canRun, presentKey, run]);
+  }, [source, filename, serveUrl, canRun, presentKey]);
 
   const isDeployed = run !== null;
 

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -173,13 +173,6 @@ export function Studio({
   const checkTokenRef = useRef(0);
 
   /**
-   * `present` is derived from the snapshot, and a projection sets the snapshot
-   * — so depending on the array itself would make every projection ask for
-   * another. The key is what actually changed.
-   */
-  const presentKey = present.join("\u0000");
-
-  /**
    * What the tag being shown touches: the ports carrying a value and the
    * reactions firing. Ids, because that is what the drawing is keyed by.
    */

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChatMessage as ChatMessageView } from "./chat-message";
 import { AgentTerminal } from "./agent-terminal";
+import { Timeline } from "./timeline";
 import { BackendMenu } from "./backend-menu";
 import { DiagramCanvas } from "./diagram/diagram-canvas";
 import { OmarEditor } from "./omar-source";
@@ -19,6 +20,7 @@ import {
   applyDiagramEvent,
   formatDuration,
   isRunFinished,
+  openInputs,
   type ChatMessage,
   type DiagramEvent,
   type DiagramSnapshot,
@@ -26,15 +28,16 @@ import {
   type ProposedDesign,
   type RunRecord,
 } from "./lib/protocol";
+import type { ProjectedStep } from "./lib/runtime-client";
 import {
   answerPanel,
   ASSISTANT,
-  checkProgram,
   checkServeHealth,
   diagramUrlFor,
   fetchDiagram,
   fetchPanel,
   fetchRun,
+  projectProgram,
   startRun,
   subscribeToDiagram,
 } from "./lib/runtime-client";
@@ -97,7 +100,14 @@ export function Studio({
   /** What the compiler said about the source as it stands. */
   const [sourceErrors, setSourceErrors] = useState<string[]>([]);
   const [checking, setChecking] = useState(false);
-  // Chat gets the whole width until there is a design to look at. The operator
+  /** Every tag the program passes through, projected or observed. */
+  const [steps, setSteps] = useState<ProjectedStep[]>([]);
+  const [truncated, setTruncated] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [timelineOpen, setTimelineOpen] = useState(false);
+  /** Following the run rather than being scrubbed by hand. */
+  const [following, setFollowing] = useState(true);
+  /** Ports the operator has set on the live run. */
   // can flip back and forth once there is.
   const [tab, setTab] = useState<"source" | "events">("source");
   /** What the run's web agents are waiting to be given. */
@@ -131,6 +141,53 @@ export function Studio({
       each with its own ports and prompts, so this names one rather than
       merging them into a shared view. */
   const [panelAgent, setPanelAgent] = useState<string | null>(null);
+
+  /**
+   * Which inputs the projection should treat as arriving.
+   *
+   * A closed loop has none, and `project` seeds every timer regardless — so a
+   * timer-driven program projects correctly from an empty set. What is left
+   * here is the dangling case: a port nothing writes would never arrive on its
+   * own, and the question the timeline answers is what the program would do if
+   * it did.
+   */
+  const present = useMemo(
+    () => (snapshot ? openInputs(snapshot).map((port) => port.name) : []),
+    [snapshot],
+  );
+
+  /**
+   * `present` is derived from the snapshot, and a projection sets the snapshot
+   * — so depending on the array itself would make every projection ask for
+   * another. The key is what actually changed.
+   */
+  const presentKey = present.join("\u0000");
+
+  /**
+   * What the tag being shown touches: the ports carrying a value and the
+   * reactions firing. Ids, because that is what the drawing is keyed by.
+   */
+  const highlighted = useMemo(() => {
+    const step = steps[stepIndex];
+    if (!step || !snapshot) return new Set<string>();
+    // Looked up rather than built: an id is not its name with a prefix on it —
+    // a reaction's id carries the instance its name may not — and guessing the
+    // shape would light nothing while looking like it worked.
+    const lit = new Set<string>();
+    const mark = (
+      entities: { id: string; name: string }[],
+      names: string[],
+    ) => {
+      for (const name of names) {
+        const found = entities.find((entity) => entity.name === name);
+        if (found) lit.add(found.id);
+      }
+    };
+    mark(snapshot.ports, step.events);
+    mark(snapshot.timers, step.events);
+    mark(snapshot.reactions, step.reactions);
+    return lit;
+  }, [steps, stepIndex, snapshot]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [events, setEvents] = useState<DiagramEvent[]>([]);
   const disconnectRef = useRef<null | (() => void)>(null);
@@ -308,6 +365,21 @@ export function Studio({
         diagramUrl,
         (event) => {
           setEvents((current) => [event, ...current].slice(0, 8));
+          // A live run walks the same list the projection drew. Matched on the
+          // tag rather than counted, so a run that reaches a tag the projection
+          // did not expect leaves the strip where it was rather than lying
+          // about where the run is.
+          if (event.kind === "tag_advanced" && event.tag) {
+            const tag = event.tag;
+            setSteps((current) => {
+              const at = current.findIndex(
+                (step) =>
+                  step.timestamp === tag.timestamp && step.microstep === tag.microstep,
+              );
+              if (at >= 0) setStepIndex(at);
+              return current;
+            });
+          }
           // Apply first, then refetch. The diagram server shuts down with the
           // run, so the fetch that follows the closing events often loses and
           // the picture would otherwise keep a reaction painted as running.
@@ -416,8 +488,23 @@ export function Studio({
         return;
       }
       setChecking(true);
-      checkProgram(serveUrl, source, filename, abort.signal)
-        .then((result) => setSourceErrors(result.ok ? [] : (result.errors ?? [])))
+      // Checking and projecting are the same question asked twice — is this a
+      // program, and what would it do — so they are asked together.
+      projectProgram(
+        serveUrl,
+        source,
+        filename,
+        presentKey ? presentKey.split("\u0000") : [],
+        abort.signal,
+      )
+        .then((result) => {
+          setSourceErrors(result.ok ? [] : (result.errors ?? []));
+          setSteps(result.steps ?? []);
+          setTruncated(result.truncated ?? false);
+          // A recomputed projection replaces the tail, so a hand-held position
+          // past its end would be pointing at nothing.
+          setStepIndex((current) => Math.min(current, Math.max(0, (result.steps?.length ?? 1) - 1)));
+        })
         .catch((cause) => {
           if (abort.signal.aborted) return;
           setSourceErrors([cause instanceof Error ? cause.message : String(cause)]);
@@ -430,7 +517,7 @@ export function Studio({
       clearTimeout(timer);
       abort.abort();
     };
-  }, [source, filename, serveUrl, canRun]);
+  }, [source, filename, serveUrl, canRun, presentKey]);
 
   const isDeployed = run !== null;
 
@@ -687,11 +774,35 @@ export function Studio({
             onToggleComponent={toggleComponent}
             // Agents outlive the run that spawned them, so a finished run can
             // still be opened; before a run there is nothing behind the node.
+            highlight={timelineOpen ? highlighted : undefined}
             onOpenTerminal={canRun && run ? setTerminalAgent : undefined}
             // A web agent has no pane; double-clicking it opens the panel it is
             // answered through instead, which is the only thing there is.
             onOpenPanel={run ? setPanelAgent : undefined}
           />
+          {timelineOpen ? (
+            <Timeline
+              steps={steps}
+              index={stepIndex}
+              live={following && phase === "observing"}
+              truncated={truncated}
+              onScrub={(next) => {
+                // Scrubbing takes the strip off the run: the operator is
+                // looking at a tag, not at where execution has reached.
+                setFollowing(false);
+                setStepIndex(next);
+              }}
+              onClose={() => setTimelineOpen(false)}
+            />
+          ) : (
+            <button
+              type="button"
+              className="timeline-handle"
+              onClick={() => setTimelineOpen(true)}
+            >
+              ▲ Timeline
+            </button>
+          )}
         </section>
         ) : null}
 

--- a/web/app/timeline.tsx
+++ b/web/app/timeline.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ProjectedStep } from "./lib/runtime-client";
+import type { TimelineStep } from "./lib/runtime-client";
 
 /**
  * The logical timeline of a program: every tag it passes through, in order.
@@ -28,7 +28,7 @@ export function Timeline({
   onScrub,
   onClose,
 }: {
-  steps: ProjectedStep[];
+  steps: TimelineStep[];
   /** Which step is showing; the run's own position when live. */
   index: number;
   /** Following a run rather than being scrubbed by hand. */

--- a/web/app/timeline.tsx
+++ b/web/app/timeline.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import type { ProjectedStep } from "./lib/runtime-client";
+
+/**
+ * The logical timeline of a program: every tag it passes through, in order.
+ *
+ * Before anything is deployed these are projected — worked out from the program
+ * rather than observed, which is possible because what decides a tag is the
+ * program and not what an agent says. Stepping through them is the determinism
+ * claim made checkable: this is what will happen, and here it is before it has.
+ *
+ * Once a run is live the same strip follows it. Same steps, same order; what
+ * changes is that a position is now a fact rather than a prediction, and the
+ * strip moves on its own. That the two are the same list is the point — a live
+ * run that departed from its projection would be visible here as a mismatch,
+ * rather than being invisible because projection and observation were drawn by
+ * different things.
+ *
+ * An input arriving mid-run makes the tail of this wrong, so the projection is
+ * recomputed and the strip redrawn from where the run actually is.
+ */
+export function Timeline({
+  steps,
+  index,
+  live,
+  truncated,
+  onScrub,
+  onClose,
+}: {
+  steps: ProjectedStep[];
+  /** Which step is showing; the run's own position when live. */
+  index: number;
+  /** Following a run rather than being scrubbed by hand. */
+  live: boolean;
+  /** The projection stopped early. The program has not. */
+  truncated: boolean;
+  onScrub: (index: number) => void;
+  onClose: () => void;
+}) {
+  const step = steps[index];
+  const last = steps.length - 1;
+
+  return (
+    <div className="timeline" aria-label="Logical timeline">
+      <div className="timeline-controls">
+        <button
+          type="button"
+          aria-label="Previous tag"
+          disabled={index <= 0}
+          onClick={() => onScrub(Math.max(0, index - 1))}
+        >
+          ‹
+        </button>
+        <input
+          type="range"
+          min={0}
+          max={Math.max(0, last)}
+          value={index}
+          aria-label="Logical tag"
+          disabled={steps.length === 0}
+          onChange={(event) => onScrub(Number(event.target.value))}
+        />
+        <button
+          type="button"
+          aria-label="Next tag"
+          disabled={index >= last}
+          onClick={() => onScrub(Math.min(last, index + 1))}
+        >
+          ›
+        </button>
+        <button type="button" className="timeline-close" onClick={onClose}>
+          Hide
+        </button>
+      </div>
+
+      <div className="timeline-readout">
+        {steps.length === 0 ? (
+          <span className="timeline-idle">
+            Nothing to project: no input is set and no timer fires, so the
+            program does not move.
+          </span>
+        ) : (
+          <>
+            <span className="timeline-tag">
+              {/* The tag itself, which is what "when" means here — there is no
+                  wall clock in it. */}
+              {step.timestamp}:{step.microstep}
+            </span>
+            <span className="timeline-count">
+              {index + 1} of {steps.length}
+              {truncated ? "+" : ""}
+            </span>
+            <span className={live ? "timeline-mode live" : "timeline-mode"}>
+              {live ? "live" : "projected"}
+            </span>
+            <span className="timeline-detail">
+              {step.reactions.length > 0
+                ? `${step.reactions.length} reaction${step.reactions.length > 1 ? "s" : ""} fire`
+                : "no reaction fires"}
+              {step.events.length > 0 ? ` · ${step.events.join(", ")}` : ""}
+            </span>
+          </>
+        )}
+      </div>
+
+      {truncated ? (
+        <p className="timeline-truncated">
+          Stopped after {steps.length} tags. A periodic timer has no end, so a
+          preview has to.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/web/tests/conformance.test.mjs
+++ b/web/tests/conformance.test.mjs
@@ -307,6 +307,40 @@ describe("wire conformance between the fake and the real daemon", { skip: WIRE_S
     }
   });
 
+  test("a projection is what the run then does", async () => {
+    // The timeline's whole claim. If the projection and the run disagree, the
+    // operator is being shown a prediction of a different program.
+    const project = async (present) =>
+      (
+        await fetch(`${real.url}/v1/programs/project`, {
+          ...post({ program: STUB_FLOW, filename: "StubFlow.omar", present }),
+        })
+      ).json();
+
+    // Nothing set: the program does not move, and says so rather than
+    // pretending it would.
+    const idle = await project([]);
+    assert.equal(idle.ok, true, JSON.stringify(idle));
+    assert.deepEqual(idle.open_inputs, ["flow.topic"]);
+    assert.deepEqual(idle.steps, []);
+
+    const projected = await project(["flow.topic"]);
+    assert.equal(projected.truncated, false);
+    assert.ok(projected.steps.length >= 2, JSON.stringify(projected.steps));
+    assert.deepEqual(projected.steps[0].events, ["flow.topic"]);
+
+    // A program that does not compile is reported, not projected.
+    const broken = await (
+      await fetch(`${real.url}/v1/programs/project`, {
+        ...post({ program: "team Broken {", filename: "Broken.omar", present: [] }),
+      })
+    ).json();
+    assert.equal(broken.ok, false);
+    assert.match(broken.errors[0], /Broken\.omar/);
+    // The scratch path it was compiled at is not the operator's business.
+    assert.doesNotMatch(broken.errors[0], /omar-check-/);
+  });
+
   test("a real proposal compiles and carries a snapshot the client accepts", async () => {
     // `--no-ea` still writes the context, so the harness can stand in for the
     // assistant without an agent process existing.

--- a/web/tests/conformance.test.mjs
+++ b/web/tests/conformance.test.mjs
@@ -307,32 +307,38 @@ describe("wire conformance between the fake and the real daemon", { skip: WIRE_S
     }
   });
 
-  test("a projection is what the run then does", async () => {
-    // The timeline's whole claim. If the projection and the run disagree, the
-    // operator is being shown a prediction of a different program.
-    const project = async (present) =>
+  test("a timeline is what the run then does, and is asked for", async () => {
+    // The timeline's whole claim. If it and the run disagree, the operator is
+    // being shown a prediction of a different program.
+    const check = async (body) =>
       (
-        await fetch(`${real.url}/v1/programs/project`, {
-          ...post({ program: STUB_FLOW, filename: "StubFlow.omar", present }),
+        await fetch(`${real.url}/v1/programs/check`, {
+          ...post({ program: STUB_FLOW, filename: "StubFlow.omar", ...body }),
         })
       ).json();
 
+    // Validity alone. A caller that did not ask for a timeline is not handed
+    // one to ignore.
+    const plain = await check({});
+    assert.equal(plain.ok, true, JSON.stringify(plain));
+    assert.deepEqual(plain.open_inputs, ["flow.topic"]);
+    assert.equal(plain.steps, undefined);
+    assert.equal(plain.truncated, undefined);
+
     // Nothing set: the program does not move, and says so rather than
     // pretending it would.
-    const idle = await project([]);
-    assert.equal(idle.ok, true, JSON.stringify(idle));
-    assert.deepEqual(idle.open_inputs, ["flow.topic"]);
+    const idle = await check({ timeline: true, present: [] });
     assert.deepEqual(idle.steps, []);
 
-    const projected = await project(["flow.topic"]);
-    assert.equal(projected.truncated, false);
-    assert.ok(projected.steps.length >= 2, JSON.stringify(projected.steps));
-    assert.deepEqual(projected.steps[0].events, ["flow.topic"]);
+    const drawn = await check({ timeline: true, present: ["flow.topic"] });
+    assert.equal(drawn.truncated, false);
+    assert.ok(drawn.steps.length >= 2, JSON.stringify(drawn.steps));
+    assert.deepEqual(drawn.steps[0].events, ["flow.topic"]);
 
-    // A program that does not compile is reported, not projected.
+    // A program that does not compile is reported, not drawn.
     const broken = await (
-      await fetch(`${real.url}/v1/programs/project`, {
-        ...post({ program: "team Broken {", filename: "Broken.omar", present: [] }),
+      await fetch(`${real.url}/v1/programs/check`, {
+        ...post({ program: "team Broken {", filename: "Broken.omar", timeline: true }),
       })
     ).json();
     assert.equal(broken.ok, false);

--- a/web/tests/e2e/flow.spec.ts
+++ b/web/tests/e2e/flow.spec.ts
@@ -237,6 +237,42 @@ test("a web component's panel opens from the diagram, and answers it", async ({
   await expect(panel).toBeHidden();
 });
 
+test("a delayed connection is solid, with its delay in a break in the line", async ({
+  page,
+}) => {
+  // Captured from a real compile of tests/topology/src/PortManager.omar, whose
+  // feedback carries a period so the loop closes over a tick.
+  await fake.close();
+  fake = (await startFakeServe({
+    stepMs: 30,
+    port: FAKE_SERVE_PORT,
+    snapshot: "diagram-delay.v1.json",
+  })) as FakeServe;
+  await useFakeServe(page);
+  await draftUntilProposed(page);
+
+  // Both connections cost something, and each says what. `after 30s` is a
+  // duration; `after 0` costs a microstep, which is a step in order rather
+  // than in time and so is named instead of measured.
+  const label = page.locator(".omar-edge-delay");
+  await expect(label).toHaveCount(2);
+  await expect(label).toHaveText(["\u03bcstep", "30s"]);
+
+  // Solid, like any other connection: a stroke that could only say "some
+  // delay" and never which is not worth spending the stroke on.
+  const dashes = await page
+    .locator(".omar-edge.connection")
+    .first()
+    .evaluate((node) => getComputedStyle(node).strokeDasharray);
+  expect(["none", ""]).toContain(dashes);
+
+  // The line breaks around the number rather than running through it, so a
+  // connection carrying one is drawn as two paths where a plain one is drawn
+  // as a single path. Both of these carry one.
+  const connections = await page.locator(".omar-edge.connection").count();
+  expect(connections).toBe(4);
+});
+
 test("Enter sends, modified Enter writes a new line", async ({ page }) => {
   await useFakeServe(page);
   const composer = page.getByLabel("Describe a workflow");

--- a/web/tests/e2e/flow.spec.ts
+++ b/web/tests/e2e/flow.spec.ts
@@ -1190,6 +1190,37 @@ test("an edge into a reaction actually reaches it", async ({ page }) => {
   }
 });
 
+test("the timeline projects a program before anything is deployed", async ({
+  page,
+}) => {
+  // The determinism claim, made checkable: what a program will do is decided
+  // by the program, so it can be shown before it has done it.
+  await useFakeServe(page);
+  await draftUntilProposed(page);
+
+  await page.getByRole("button", { name: "▲ Timeline" }).click();
+  const timeline = page.getByLabel("Logical timeline");
+  await expect(timeline).toBeVisible();
+
+  // Nothing has run, and the tags are there anyway.
+  await expect(timeline).toContainText("projected");
+  await expect(timeline.locator(".timeline-tag")).toHaveText(/^\d+:\d+$/);
+
+  // Stepping moves through tags, and the diagram marks what each one touches.
+  const scrubber = timeline.getByLabel("Logical tag");
+  await expect(scrubber).toHaveValue("0");
+  await expect(page.locator(".omar-reaction.at-tag").first()).toBeVisible();
+  await expect(page.locator(".off-tag").first()).toBeVisible();
+
+  await timeline.getByRole("button", { name: "Next tag" }).click();
+  await expect(scrubber).toHaveValue("1");
+  await timeline.getByRole("button", { name: "Previous tag" }).click();
+  await expect(scrubber).toHaveValue("0");
+
+  await timeline.getByRole("button", { name: "Hide" }).click();
+  await expect(timeline).toBeHidden();
+});
+
 test("the assistant's terminal opens from the wait, not from a menu", async ({
   page,
 }) => {

--- a/web/tests/fake-serve.mjs
+++ b/web/tests/fake-serve.mjs
@@ -393,6 +393,31 @@ export async function startFakeServe({
       reactions: [reaction.name],
     }));
     const present = request.present ?? [];
+    // A topology shaped by what was typed: one container per `x = Team()` in
+    // the source. Not a compiler — enough that a diagram which follows the
+    // text is told apart from one that does not.
+    const preview = structuredClone(golden);
+    const declared = [...request.program.matchAll(/(\w+)\s*=\s*\w+\s*\(/g)].map((m) => m[1]);
+    if (declared.length > 0) {
+      preview.instances = declared.map((name) => ({
+        id: `instance::${name}`,
+        name,
+        team: "Team",
+        parent: "",
+      }));
+      // A container with nothing in it is not drawn, and rightly so: give each
+      // one a member so the drawing has something to put in the box.
+      preview.agents = declared.map((name) => ({
+        id: `agent::${name}.worker`,
+        name: `${name}.worker`,
+        backend: "Codex",
+        instance: name,
+      }));
+      preview.ports = [];
+      preview.timers = [];
+      preview.reactions = [];
+      preview.edges = [];
+    }
     return json(response, 200, {
       ok: true,
       team: golden.team,
@@ -401,6 +426,7 @@ export async function startFakeServe({
       // to be able to show.
       steps: present.length > 0 ? steps : [],
       truncated: false,
+      preview,
     });
   }
 

--- a/web/tests/fake-serve.mjs
+++ b/web/tests/fake-serve.mjs
@@ -393,31 +393,6 @@ export async function startFakeServe({
       reactions: [reaction.name],
     }));
     const present = request.present ?? [];
-    // A topology shaped by what was typed: one container per `x = Team()` in
-    // the source. Not a compiler — enough that a diagram which follows the
-    // text is told apart from one that does not.
-    const preview = structuredClone(golden);
-    const declared = [...request.program.matchAll(/(\w+)\s*=\s*\w+\s*\(/g)].map((m) => m[1]);
-    if (declared.length > 0) {
-      preview.instances = declared.map((name) => ({
-        id: `instance::${name}`,
-        name,
-        team: "Team",
-        parent: "",
-      }));
-      // A container with nothing in it is not drawn, and rightly so: give each
-      // one a member so the drawing has something to put in the box.
-      preview.agents = declared.map((name) => ({
-        id: `agent::${name}.worker`,
-        name: `${name}.worker`,
-        backend: "Codex",
-        instance: name,
-      }));
-      preview.ports = [];
-      preview.timers = [];
-      preview.reactions = [];
-      preview.edges = [];
-    }
     return json(response, 200, {
       ok: true,
       team: golden.team,
@@ -426,7 +401,6 @@ export async function startFakeServe({
       // to be able to show.
       steps: present.length > 0 ? steps : [],
       truncated: false,
-      preview,
     });
   }
 

--- a/web/tests/fake-serve.mjs
+++ b/web/tests/fake-serve.mjs
@@ -404,6 +404,14 @@ export async function startFakeServe({
     });
   }
 
+  /** Inputs nothing in the topology writes to: a diagnostic, as on the daemon. */
+  function openInputsOf(snapshot) {
+    const fed = new Set(
+      snapshot.edges.filter((edge) => edge.kind === "connection").map((edge) => edge.target),
+    );
+    return snapshot.ports.filter((port) => port.kind === "input" && !fed.has(port.id));
+  }
+
   /** One pending invocation per reaction whose agent is on the `web` backend. */
   function webPending(snapshot) {
     const web = new Set(

--- a/web/tests/fake-serve.mjs
+++ b/web/tests/fake-serve.mjs
@@ -59,8 +59,8 @@ export async function startFakeServe({
     if (request.method === "GET" && url.pathname === "/health") {
       return json(response, 200, { status: "ok", protocol_version: 1 });
     }
-    if (request.method === "POST" && url.pathname === "/v1/programs/check") {
-      return readBody(request).then((body) => checkProgram(body, response));
+    if (request.method === "POST" && url.pathname === "/v1/programs/project") {
+      return readBody(request).then((body) => projectProgram(body, response));
     }
     if (request.method === "POST" && url.pathname === "/v1/runs") {
       return readBody(request).then((body) => admit(body, response));
@@ -345,13 +345,13 @@ export async function startFakeServe({
   }
 
   /**
-   * What the real daemon does with `POST /v1/programs/check`.
+   * What the real daemon does with `POST /v1/programs/project`.
    *
    * The real one runs omarc; this recognises the same shapes the browser tests
    * need — a name that is not a program file, and the marker the suite already
    * uses to mean "omarc rejects this".
    */
-  function checkProgram(body, response) {
+  function projectProgram(body, response) {
     let request;
     try {
       request = JSON.parse(body);
@@ -383,7 +383,25 @@ export async function startFakeServe({
         ],
       });
     }
-    return json(response, 200, { ok: true, team: "ReviewFlow", open_inputs: [] });
+    // A projection the shape of the real one: one tag per reaction, in the
+    // order the captured topology has them. The real scheduling is the
+    // runtime's, and the conformance suite is what checks it.
+    const steps = golden.reactions.map((reaction, index) => ({
+      timestamp: 0,
+      microstep: index,
+      events: reaction.triggers.map((id) => id.replace(/^(port|timer)::/, "")),
+      reactions: [reaction.name],
+    }));
+    const present = request.present ?? [];
+    return json(response, 200, {
+      ok: true,
+      team: golden.team,
+      open_inputs: openInputsOf(golden).map((port) => port.name),
+      // Nothing set means nothing moves, which is the state the timeline has
+      // to be able to show.
+      steps: present.length > 0 ? steps : [],
+      truncated: false,
+    });
   }
 
   /** One pending invocation per reaction whose agent is on the `web` backend. */

--- a/web/tests/fake-serve.mjs
+++ b/web/tests/fake-serve.mjs
@@ -59,8 +59,8 @@ export async function startFakeServe({
     if (request.method === "GET" && url.pathname === "/health") {
       return json(response, 200, { status: "ok", protocol_version: 1 });
     }
-    if (request.method === "POST" && url.pathname === "/v1/programs/project") {
-      return readBody(request).then((body) => projectProgram(body, response));
+    if (request.method === "POST" && url.pathname === "/v1/programs/check") {
+      return readBody(request).then((body) => checkProgram(body, response));
     }
     if (request.method === "POST" && url.pathname === "/v1/runs") {
       return readBody(request).then((body) => admit(body, response));
@@ -345,13 +345,13 @@ export async function startFakeServe({
   }
 
   /**
-   * What the real daemon does with `POST /v1/programs/project`.
+   * What the real daemon does with `POST /v1/programs/check`.
    *
    * The real one runs omarc; this recognises the same shapes the browser tests
    * need — a name that is not a program file, and the marker the suite already
    * uses to mean "omarc rejects this".
    */
-  function projectProgram(body, response) {
+  function checkProgram(body, response) {
     let request;
     try {
       request = JSON.parse(body);
@@ -383,25 +383,31 @@ export async function startFakeServe({
         ],
       });
     }
-    // A projection the shape of the real one: one tag per reaction, in the
-    // order the captured topology has them. The real scheduling is the
-    // runtime's, and the conformance suite is what checks it.
-    const steps = golden.reactions.map((reaction, index) => ({
-      timestamp: 0,
-      microstep: index,
-      events: reaction.triggers.map((id) => id.replace(/^(port|timer)::/, "")),
-      reactions: [reaction.name],
-    }));
-    const present = request.present ?? [];
-    return json(response, 200, {
+    const answer = {
       ok: true,
       team: golden.team,
       open_inputs: openInputsOf(golden).map((port) => port.name),
+      preview: structuredClone(golden),
+    };
+    // Only when asked, as the daemon does: a caller that wants validity alone
+    // gets no timeline, and a client that reads one it did not ask for would
+    // pass here and fail against the real thing.
+    if (request.timeline) {
+      // A timeline the shape of the real one: one tag per reaction, in the
+      // order the captured topology has them. The real scheduling is the
+      // runtime's, and the conformance suite is what checks it.
+      const steps = golden.reactions.map((reaction, index) => ({
+        timestamp: 0,
+        microstep: index,
+        events: reaction.triggers.map((id) => id.replace(/^(port|timer)::/, "")),
+        reactions: [reaction.name],
+      }));
       // Nothing set means nothing moves, which is the state the timeline has
       // to be able to show.
-      steps: present.length > 0 ? steps : [],
-      truncated: false,
-    });
+      answer.steps = (request.present ?? []).length > 0 ? steps : [];
+      answer.truncated = false;
+    }
+    return json(response, 200, answer);
   }
 
   /** Inputs nothing in the topology writes to: a diagnostic, as on the daemon. */

--- a/web/tests/fixtures/diagram-delay.v1.json
+++ b/web/tests/fixtures/diagram-delay.v1.json
@@ -1,0 +1,176 @@
+{
+  "agents": [
+    {
+      "backend": "ClaudeCode",
+      "id": "agent::gauge.sensor",
+      "instance": "gauge",
+      "name": "gauge.sensor"
+    },
+    {
+      "backend": "Web",
+      "id": "agent::pm.panel",
+      "instance": "pm",
+      "name": "pm.panel"
+    }
+  ],
+  "current_tag": null,
+  "edges": [
+    {
+      "delay": 0,
+      "id": "connection::gauge.reading::pm.reading",
+      "kind": "connection",
+      "source": "port::gauge.reading",
+      "target": "port::pm.reading"
+    },
+    {
+      "delay": 30000000000,
+      "id": "connection::pm.setpoint::gauge.setpoint",
+      "kind": "connection",
+      "source": "port::pm.setpoint",
+      "target": "port::gauge.setpoint"
+    },
+    {
+      "delay": null,
+      "id": "trigger::gauge.beat::gauge.reaction.0",
+      "kind": "trigger",
+      "source": "timer::gauge.beat",
+      "target": "reaction::gauge.reaction.0"
+    },
+    {
+      "delay": null,
+      "id": "trigger::gauge.setpoint::gauge.reaction.0",
+      "kind": "trigger",
+      "source": "port::gauge.setpoint",
+      "target": "reaction::gauge.reaction.0"
+    },
+    {
+      "delay": null,
+      "id": "effect::gauge.reaction.0::gauge.reading",
+      "kind": "effect",
+      "source": "reaction::gauge.reaction.0",
+      "target": "port::gauge.reading"
+    },
+    {
+      "delay": null,
+      "id": "trigger::pm.reading::pm.reaction.0",
+      "kind": "trigger",
+      "source": "port::pm.reading",
+      "target": "reaction::pm.reaction.0"
+    },
+    {
+      "delay": null,
+      "id": "effect::pm.reaction.0::pm.setpoint",
+      "kind": "effect",
+      "source": "reaction::pm.reaction.0",
+      "target": "port::pm.setpoint"
+    }
+  ],
+  "instances": [
+    {
+      "id": "instance::gauge",
+      "name": "gauge",
+      "parent": "",
+      "team": "Gauge"
+    },
+    {
+      "id": "instance::pm",
+      "name": "pm",
+      "parent": "",
+      "team": "PortManager"
+    }
+  ],
+  "lag": null,
+  "ports": [
+    {
+      "delay": null,
+      "id": "port::gauge.reading",
+      "instance": "gauge",
+      "kind": "output",
+      "last_tag": null,
+      "name": "gauge.reading",
+      "type": "string",
+      "value": null
+    },
+    {
+      "delay": null,
+      "id": "port::gauge.setpoint",
+      "instance": "gauge",
+      "kind": "input",
+      "last_tag": null,
+      "name": "gauge.setpoint",
+      "type": "int",
+      "value": null
+    },
+    {
+      "delay": null,
+      "id": "port::pm.reading",
+      "instance": "pm",
+      "kind": "input",
+      "last_tag": null,
+      "name": "pm.reading",
+      "type": "string",
+      "value": null
+    },
+    {
+      "delay": null,
+      "id": "port::pm.setpoint",
+      "instance": "pm",
+      "kind": "output",
+      "last_tag": null,
+      "name": "pm.setpoint",
+      "type": "int",
+      "value": null
+    }
+  ],
+  "protocol_version": 1,
+  "reactions": [
+    {
+      "agent": "agent::gauge.sensor",
+      "contract": "gauge.reading",
+      "effects": [
+        "port::gauge.reading"
+      ],
+      "id": "reaction::gauge.reaction.0",
+      "instance": "gauge",
+      "invocation_id": null,
+      "name": "gauge.reaction.0",
+      "order": 0,
+      "status": "idle",
+      "triggers": [
+        "timer::gauge.beat",
+        "port::gauge.setpoint"
+      ],
+      "within": null
+    },
+    {
+      "agent": "agent::pm.panel",
+      "contract": "pm.setpoint",
+      "effects": [
+        "port::pm.setpoint"
+      ],
+      "id": "reaction::pm.reaction.0",
+      "instance": "pm",
+      "invocation_id": null,
+      "name": "pm.reaction.0",
+      "order": 1,
+      "status": "idle",
+      "triggers": [
+        "port::pm.reading"
+      ],
+      "within": 600000000000
+    }
+  ],
+  "sequence": 0,
+  "status": "ready",
+  "team": "WebPanel",
+  "timers": [
+    {
+      "id": "timer::gauge.beat",
+      "instance": "gauge",
+      "last_tag": null,
+      "name": "gauge.beat",
+      "offset": 0,
+      "period": 30000000000
+    }
+  ]
+}


### PR DESCRIPTION
Based on #205, which this is rebased onto — retarget to `main` once that lands.

A logical timeline under the diagram: every tag the program passes through, and what fires at each. A handle opens it; a slider and arrows step through it.

## Projected, not guessed

Before anything is deployed the tags are **computed from the program**. That is possible because of what OMAR decides and what it leaves to the agents: an agent decides *values*, never *schedule*.

Values are not projected, only presence. So a reaction whose contract offers alternatives (`-> (x|y)`) is projected as writing **both** — an over-approximation, never a missed step.

## It is the runtime's projection, not a second one

`topology::timeline` walks the same machinery the event loop does — `settle_connections`, `deliver` and `precedence_layers` — so what settles at a tag, and which tag it settles at, cannot drift between what is shown and what runs. Tests hold a timeline against the tags a **real run** hits, including the delay case where a re-implementation would drift first:

```rust
assert_eq!(timeline_tags(&state, &["start"]), real);
```

## Live

Once a run exists the same strip follows it, matched **on the tag** rather than counted — a run reaching a tag the timeline did not expect leaves the strip where it was rather than lying about where the run is. Scrubbing takes the strip off the run.

## Asynchronous input

What counts as *present* changes when a run exists:

- **before one** — every open input. The question is what this program does when fed, and no values are needed to answer it.
- **after one** — only what has been sent. An unfed run projects nothing, which is the truth about it, and an input arriving mid-run **recomputes** the tail.

## Also here

- **Tab indents** in the editor instead of moving focus out of it.
- **Triggers and effects are dashed.** They are a reaction's own wiring, not a path a value travels between ports; solid is reserved for connections.
- **A connection's delay is written on the line**, in a real break in it, rather than said with a dashed stroke. A stroke can only say "some delay" and never which one.
- `/v1/programs/check` takes `{ program, filename, timeline }`, so a caller that only wants to know whether a program compiles does not pay for a timeline it will not read.

## What the rebase onto #205 changed

#205 gave ports Lingua Franca's semantics: a plain connection costs nothing, `after 0` costs a microstep, and a tag runs to a fixpoint. Three consequences here:

- **`timeline` was rewritten** against the new loop. It settles connections, walks the static precedence order, and merges instantaneous effects into the tag in progress — the same sequence `run_event_loop_observed` follows.
- **A reaction's effect now lands at the tag it fired at**, so a program that used to project two tags projects one. `a_program_nobody_has_fed_projects_nothing` was updated to match, and the drift test passes unmodified — which is the point of sharing the machinery.
- **`after 0` is now meaningful on the diagram** and gets a `μstep` label, where a plain connection gets none. The delay e2e test asserts both labels.

One commit was **dropped**: `Add the program the once-per-tag question turns on` added a `Depths.omar` demonstrating the watcher firing twice at different microsteps, and posed the question #196 asked. #205 answers it and ships a `Depths.omar` of its own where the watcher fires once holding both children.

## Two bugs found while building it

- **Highlighting by building ids from names lights nothing.** A reaction's id carries the instance its name may not. Entities are looked up by name and their own id used.
- **A reply was being dropped when its request was aborted after the reply had arrived.** Aborting tells the network to stop; it does not decide whether a reply in hand is still wanted. That question is which request is newest — the timeline showed no tags because the reply carrying them had been thrown away.

## Not in this branch, on purpose

Making the diagram follow the edited text is out. The mechanism works — the check response carries the compiled topology — but replacing the snapshot on every check re-ran the ELK layout for a drawing that had not changed, and **the browser suite went from 50 seconds to 25 minutes**. That comes back on its own branch, with the layout cost dealt with rather than discovered.

## Verification

Locally, on the rebased branch: **345 Rust tests**, clippy and `cargo fmt` clean; **45 browser tests in 44s**; 12 web unit; TypeScript and lint clean; Lean compiler tests pass.

## Still open

- The strip does not re-attach to follow mode once scrubbed away.
- A truncated timeline cannot be paged past.
- A timeline/run mismatch is *visible* but not called out. Naming it is the obvious next thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
