### PR TITLE
Give every delay a unit, and let a reaction bound how long it may take

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,11 @@ jobs:
                   if instruction["op"] == "connect_ports":
                       assert keys == connection_order, (path, keys)
                   if instruction["op"] == "install_reaction":
-                      assert keys == reaction_order, (path, keys)
+                      # `within` is a deadline the reaction set for itself, and
+                      # is absent when it set none.
+                      assert keys in (
+                          reaction_order, reaction_order + ["within"]
+                      ), (path, keys)
                   # A program picks its own backends; what CI pins is that the
                   # bytecode spawns the one its source asked for. Instantiating
                   # qualifies an agent by its instance path, so the declaration

--- a/lang/Omar/Compiler.lean
+++ b/lang/Omar/Compiler.lean
@@ -114,6 +114,9 @@ structure Reaction where
   effects : Array String
   contract : String
   prompt : String
+  /-- How long one invocation may take, in nanoseconds. `none` leaves it to the
+      run-wide timeout. -/
+  within : Option Nat := none
   instance_ : String := ""
   deriving Repr
 
@@ -287,9 +290,33 @@ private def productionTargets (tokens : List Token) : Array String :=
     | _ :: rest => collect expectAtom acc rest
   collect true #[] tokens
 
-private partial def takeContract (acc : List Token) : List Token -> Except String (List Token × String × List Token)
+/-- Nanoseconds. A duration is wall-clock; `after 3` is logical delay measured
+    in tags. Written as bare numbers the two would read identically, so a
+    duration must carry its unit. -/
+private def durationScale (unit : String) : Except String Nat :=
+  match unit with
+  | "ns" => pure 1
+  | "us" => pure 1000
+  | "ms" => pure 1000000
+  | "s" | "sec" => pure 1000000000
+  | "min" => pure 60000000000
+  | "h" | "hr" => pure 3600000000000
+  -- 'm' and 'ms' differ by one character and five orders of magnitude, and a
+  -- deadline that is 60000x wrong fails silently.
+  | "m" => throw "'m' is ambiguous: write 'min' for minutes or 'ms' for milliseconds"
+  | other => throw s!"unknown duration unit '{other}'; use ns, us, ms, s, min, or h"
+
+private def duration : Parser Nat
+  | Token.nat value :: Token.word unit :: rest => do
+      pure (value * (← durationScale unit), rest)
+  | Token.nat value :: _ => throw s!"duration '{value}' needs a unit, e.g. '{value}s'"
+  | tokens => throw s!"expected a duration, found {reprStr tokens.head?}"
+
+/-- Everything between `->` and either `within` or the prompt string. -/
+private partial def takeContract (acc : List Token) : List Token -> Except String (List Token × List Token)
   | [] => throw "expected prompt string after production contract"
-  | Token.text prompt :: rest => pure (acc.reverse, prompt, rest)
+  | tokens@(Token.text _ :: _) => pure (acc.reverse, tokens)
+  | tokens@(Token.word "within" :: _) => pure (acc.reverse, tokens)
   | token :: rest => takeContract (token :: acc) rest
 
 /-- `port`, or `instance.port` written as one dotted name. -/
@@ -386,12 +413,25 @@ private partial def parseDeclarations
       let (_, rest) ← expectSym "(" rest
       let (triggers, rest) ← parseDependencies #[] rest
       let (_, rest) ← expectSym "->" rest
-      let (contractTokens, prompt, rest) ← takeContract [] rest
+      let (contractTokens, rest) ← takeContract [] rest
+      -- `within(30s)` sits between the contract and the prompt because what
+      -- expiry does is read off the contract: silence completes the tag when
+      -- the contract permits no writes, and raises when it requires one.
+      let (within, rest) ← match rest with
+        | Token.word "within" :: tail => do
+            let (_, tail) ← expectSym "(" tail
+            let (value, tail) ← duration tail
+            let (_, tail) ← expectSym ")" tail
+            pure (some value, tail)
+        | _ => pure (none, rest)
+      let (prompt, rest) ← match rest with
+        | Token.text prompt :: tail => pure (prompt, tail)
+        | _ => throw "expected prompt string after production contract"
       let effects := productionTargets contractTokens
       let contract := String.intercalate " " (contractTokens.map tokenSource)
       let reaction := {
         id := s!"reaction.{reactionIndex}"
-        agent, triggers, effects, contract, prompt
+        agent, triggers, effects, contract, prompt, within
       }
       parseDeclarations (reactionIndex + 1) ports timers connections (reactions.push reaction) instances rest
   | Token.word first :: rest => do
@@ -745,7 +785,7 @@ def compile (program : Program) : String :=
       ("delay", toJson connection.delay)
     ]
   let reactions := program.reactions.map fun reaction =>
-    instruction "install_reaction" [
+    let fields := [
       ("instance", toJson reaction.instance_),
       ("id", toJson reaction.id),
       ("agent", toJson reaction.agent),
@@ -753,7 +793,10 @@ def compile (program : Program) : String :=
       ("effects", jsonStringArray reaction.effects),
       ("contract", toJson reaction.contract),
       ("prompt", toJson reaction.prompt)
-    ]
+    ] ++ match reaction.within with
+      | some within => [("within", toJson within)]
+      | none => []
+    instruction "install_reaction" fields
   let commit := instruction "commit_plan"
   let instructions :=
     #[begin] ++ instances ++ agents ++ ports ++ timers ++ connections ++ reactions ++ #[commit]

--- a/lang/Omar/Compiler.lean
+++ b/lang/Omar/Compiler.lean
@@ -29,7 +29,7 @@ def durationScale (unit : String) : Except String Nat :=
   -- 'm' and 'ms' differ by one character and five orders of magnitude, and a
   -- delay that is 60000x wrong fails silently.
   | "m" => throw "'m' is ambiguous: write 'min' for minutes or 'ms' for milliseconds"
-  | other => throw s!"unknown duration unit '{other}'; use ns, us, ms, s, min, or h"
+  | other => throw s!"unknown duration unit '{other}'; use ns, us, ms, s, sec, min, h, or hr"
 
 private def isWordStart (c : Char) : Bool := c.isAlpha || c == '_'
 private def isWordRest (c : Char) : Bool := c.isAlphanum || c == '_'

--- a/lang/Omar/Compiler.lean
+++ b/lang/Omar/Compiler.lean
@@ -7,9 +7,29 @@ namespace Omar
 inductive Token where
   | word : String -> Token
   | nat : Nat -> Token
+  /-- A number with a unit attached, already reduced to nanoseconds. Lexed as
+      one token so `after 3ns` cannot be confused with `after 3` followed by a
+      declaration that happens to start with a word. -/
+  | duration : Nat -> Token
   | text : String -> Token
   | sym : String -> Token
   deriving Repr, BEq
+
+/-- Nanoseconds per unit. All time in the language is physical, so a bare
+    number says nothing about its magnitude: `3` could be three nanoseconds or
+    three hours, and only the unit tells them apart. -/
+def durationScale (unit : String) : Except String Nat :=
+  match unit with
+  | "ns" => pure 1
+  | "us" => pure 1000
+  | "ms" => pure 1000000
+  | "s" | "sec" => pure 1000000000
+  | "min" => pure 60000000000
+  | "h" | "hr" => pure 3600000000000
+  -- 'm' and 'ms' differ by one character and five orders of magnitude, and a
+  -- delay that is 60000x wrong fails silently.
+  | "m" => throw "'m' is ambiguous: write 'min' for minutes or 'ms' for milliseconds"
+  | other => throw s!"unknown duration unit '{other}'; use ns, us, ms, s, min, or h"
 
 private def isWordStart (c : Char) : Bool := c.isAlpha || c == '_'
 private def isWordRest (c : Char) : Bool := c.isAlphanum || c == '_'
@@ -59,7 +79,20 @@ private partial def lexChars : List Char -> Except String (List Token)
         let (suffix, tail) := takeWhile (·.isDigit) rest
         let value := String.ofList (c :: suffix)
         match value.toNat? with
-        | some value => do pure (Token.nat value :: (← lexChars tail))
+        | some value => do
+            -- A unit binds to the number it touches. Taken here rather than in
+            -- the parser because `3ns` and `3` followed by `ns` are the same
+            -- two tokens otherwise, and so are `3` and the `input` after it.
+            match tail with
+            | unitStart :: unitRest =>
+                if isWordStart unitStart then
+                  let (unitSuffix, tail) := takeWhile isWordRest unitRest
+                  let unit := String.ofList (unitStart :: unitSuffix)
+                  let scale ← durationScale unit
+                  pure (Token.duration (value * scale) :: (← lexChars tail))
+                else
+                  pure (Token.nat value :: (← lexChars tail))
+            | [] => pure (Token.nat value :: (← lexChars tail))
         | none => throw s!"invalid natural number '{value}'"
       else if "(),;:{}?|=<>[].".contains c then
         do pure (Token.sym c.toString :: (← lexChars rest))
@@ -270,6 +303,7 @@ private def kindName : PortKind -> String
 private def tokenSource : Token -> String
   | .word value => value
   | .nat value => toString value
+  | .duration value => s!"{value}ns"
   | .sym value => value
   | .text _ => "<prompt>"
 
@@ -290,27 +324,17 @@ private def productionTargets (tokens : List Token) : Array String :=
     | _ :: rest => collect expectAtom acc rest
   collect true #[] tokens
 
-/-- Nanoseconds. A duration is wall-clock; `after 3` is logical delay measured
-    in tags. Written as bare numbers the two would read identically, so a
-    duration must carry its unit. -/
-private def durationScale (unit : String) : Except String Nat :=
-  match unit with
-  | "ns" => pure 1
-  | "us" => pure 1000
-  | "ms" => pure 1000000
-  | "s" | "sec" => pure 1000000000
-  | "min" => pure 60000000000
-  | "h" | "hr" => pure 3600000000000
-  -- 'm' and 'ms' differ by one character and five orders of magnitude, and a
-  -- deadline that is 60000x wrong fails silently.
-  | "m" => throw "'m' is ambiguous: write 'min' for minutes or 'ms' for milliseconds"
-  | other => throw s!"unknown duration unit '{other}'; use ns, us, ms, s, min, or h"
-
 private def duration : Parser Nat
-  | Token.nat value :: Token.word unit :: rest => do
-      pure (value * (← durationScale unit), rest)
+  | Token.duration value :: rest => pure (value, rest)
   | Token.nat value :: _ => throw s!"duration '{value}' needs a unit, e.g. '{value}s'"
   | tokens => throw s!"expected a duration, found {reprStr tokens.head?}"
+
+/-- A logical delay: a duration, or a bare zero.
+    Zero is the same instant whatever unit it is written in, so it alone may go
+    without one. Every other delay must say what it means. -/
+private def delayValue : Parser Nat
+  | Token.nat 0 :: rest => pure (0, rest)
+  | tokens => duration tokens
 
 /-- Everything between `->` and either `within` or the prompt string. -/
 private partial def takeContract (acc : List Token) : List Token -> Except String (List Token × List Token)
@@ -354,7 +378,7 @@ private partial def parseArgs (acc : Array Literal) : Parser (Array Literal)
 
 private def parseActionDelay : Parser (Option Nat)
   | Token.sym "(" :: Token.word "delay" :: Token.sym "=" :: rest => do
-      let (delay, rest) ← natural rest
+      let (delay, rest) ← delayValue rest
       let (_, rest) ← expectSym ")" rest
       pure (some delay, rest)
   | tokens => pure (none, tokens)
@@ -397,9 +421,9 @@ private partial def parseDeclarations
   | Token.word "timer" :: rest => do
       let (name, rest) ← word rest
       let (_, rest) ← expectSym "(" rest
-      let (offset, rest) ← natural rest
+      let (offset, rest) ← delayValue rest
       let (_, rest) ← expectSym "," rest
-      let (period, rest) ← natural rest
+      let (period, rest) ← delayValue rest
       let (_, rest) ← expectSym ")" rest
       parseDeclarations reactionIndex ports (timers.push { name, offset, period }) connections reactions instances rest
   | Token.word name :: Token.sym "=" :: rest => do
@@ -445,7 +469,7 @@ private partial def parseDeclarations
       -- `after` is optional, matching main: a connection with no delay still
       -- lands on the next microstep.
       let (delay, rest) ← match rest with
-        | Token.word "after" :: tail => natural tail
+        | Token.word "after" :: tail => delayValue tail
         | _ => pure (0, rest)
       parseDeclarations reactionIndex ports timers (connections.push { source, target, delay }) reactions instances rest
   | token :: _ => throw s!"unexpected token in team body: {reprStr token}"
@@ -492,7 +516,7 @@ private partial def parseMainBody
       -- `after` is optional here. A connection with no delay still lands on
       -- the next microstep, so a feedback loop through instances progresses.
       let (delay, rest) ← match rest with
-        | Token.word "after" :: tail => natural tail
+        | Token.word "after" :: tail => delayValue tail
         | _ => pure (0, rest)
       let connection :=
         { sourceInstance, sourcePort, targetInstance, targetPort, delay : InstanceConnection }

--- a/lang/Tests.lean
+++ b/lang/Tests.lean
@@ -133,7 +133,43 @@ def nodeTeam : String :=
      prompt agent(token) -> out \"node $(idx) got $(token)\"
    }"
 
+/-- One reaction carrying whatever deadline the caller writes. -/
+def deadlineTeam (deadline : String) : String :=
+  "team Desk[a : Codex] {
+     input req : string
+     output res : string
+     prompt a(req) -> res? within(" ++ deadline ++ ") \"do it\"
+   }
+   main { d = Desk() }"
+
+/-- A deadline is nanoseconds, and it is not part of the contract the runtime
+    checks writes against — `within` sits between the two on the page. -/
+def testWithin : IO Unit := do
+  for (written, nanos) in [("30s", 30000000000), ("100ms", 100000000),
+                           ("2min", 120000000000), ("1hr", 3600000000000)] do
+    match lex (deadlineTeam written) >>= parse "Desk" with
+    | .ok program => do
+        assertEqual s!"within {written}"
+          (program.reactions.any (·.within == some nanos)) true
+        assertEqual s!"contract unpolluted by {written}"
+          (program.reactions.any (·.contract == "d.res ?")) true
+    | .error message => throw (IO.userError s!"within {written}: {message}")
+  -- No deadline is not a zero deadline: the run-wide timeout still applies.
+  let plain := "team Desk[a : Codex] { input req : string output res : string
+                prompt a(req) -> res \"go\" } main { d = Desk() }"
+  match lex plain >>= parse "Desk" with
+  | .ok program =>
+      assertEqual "no deadline" (program.reactions.all (·.within == none)) true
+  | .error message => throw (IO.userError s!"no deadline: {message}")
+  IO.println "within tests passed"
+
 def rejectionCases : Array (String × String × String) := #[
+  -- 'm' and 'ms' differ by one character and five orders of magnitude.
+  ("ambiguous duration unit", deadlineTeam "5m", "ambiguous"),
+  -- A bare number is logical delay elsewhere in the language; a duration is
+  -- wall-clock, and the two must not read alike.
+  ("duration without a unit", deadlineTeam "30", "needs a unit"),
+  ("unknown duration unit", deadlineTeam "5weeks", "unknown duration unit"),
   ("unknown team",
     nodeTeam ++ " main { a = Missing(1) }", "unknown team 'Missing'"),
   ("argument count",
@@ -185,6 +221,7 @@ def main : IO UInt32 := do
       testRejection label source expected
     testBareTeamHeader
     testNamedMain
+    testWithin
     IO.println "compiler rejection tests passed"
     pure 0
   catch error =>

--- a/lang/Tests.lean
+++ b/lang/Tests.lean
@@ -25,6 +25,9 @@ def topologyCases : Array TopologyCase := #[
     reactions := 1, instructions := 23 },
   { file := "BusinessLoop.omar", team := "BusinessLoop", agents := 8,
     ports := 20, reactions := 11, instructions := 42 },
+  -- `main WithinTest` names the program, so the team is not the file stem.
+  { file := "DeadlineProbe.omar", team := "WithinTest", agents := 3, ports := 3,
+    reactions := 3, instructions := 13 },
   { file := "EffectContracts.omar", team := "EffectContracts", agents := 1, ports := 6,
     reactions := 3, instructions := 13 },
   { file := "FanOutFanIn.omar", team := "FanOutFanIn", agents := 4, ports := 5,
@@ -112,6 +115,18 @@ def testTopology (test : TopologyCase) : IO Unit := do
     assertEqual "ring is wired head to tail"
       (program.connections.map fun connection => s!"{connection.source}->{connection.target}")
       #["n1.out->n2.token", "n2.out->n3.token", "n3.out->n1.token"]
+  if test.file == "DeadlineProbe.omar" then
+    -- Nanoseconds, and only on the reactions that asked for one.
+    assertEqual "generous deadline"
+      (program.reactions.any (·.within == some 600000000000)) true
+    assertEqual "1ms deadline"
+      (program.reactions.any (·.within == some 1000000)) true
+    assertEqual "no deadline on the reporter"
+      (program.reactions.any (·.within == none)) true
+    -- The optional contract is what turns expiry into a completed tag rather
+    -- than a failed run, so it has to survive instantiation.
+    assertEqual "expiry-absorbing contract"
+      (program.reactions.any (·.contract == "probe.missed ?")) true
   if test.file == "SuperdenseTime.omar" then
     -- Names are instance-qualified now that every program instantiates.
     assertEqual "fixed action delay"

--- a/lang/Tests.lean
+++ b/lang/Tests.lean
@@ -163,7 +163,50 @@ def testWithin : IO Unit := do
   | .error message => throw (IO.userError s!"no deadline: {message}")
   IO.println "within tests passed"
 
+/-- A team with two ports and whatever declarations the caller writes between
+    them, for exercising delays without an agent or a reaction. -/
+def wireTeam (body : String) : String :=
+  "team Wire { input src : int output dst : int " ++ body ++ " }
+   main { w = Wire() }"
+
+/-- Every delay in the language is a duration, and only zero may go without a
+    unit. A bare number would say nothing about its magnitude. -/
+def testDelayUnits : IO Unit := do
+  for (body, nanos) in [("src -> dst after 0", 0), ("src -> dst after 3ns", 3),
+                        ("src -> dst after 2ms", 2000000),
+                        -- Zero with a unit is still zero, and still allowed.
+                        ("src -> dst after 0ms", 0)] do
+    match lex (wireTeam body) >>= parse "Wire" with
+    | .ok program =>
+        assertEqual s!"connection delay for '{body}'"
+          (program.connections.any (·.delay == nanos)) true
+    | .error message => throw (IO.userError s!"{body}: {message}")
+
+  match lex (wireTeam "src -> dst after 0 timer t(0, 10ns)") >>= parse "Wire" with
+  | .ok program => do
+      assertEqual "timer offset" (program.timers.any (·.offset == 0)) true
+      assertEqual "timer period" (program.timers.any (·.period == 10)) true
+  | .error message => throw (IO.userError s!"timer units: {message}")
+
+  -- A unit binds only to a number it touches. `0` here is followed by the word
+  -- `action`, which must stay a declaration rather than becoming a unit.
+  match lex (wireTeam "src -> dst after 0 action mid : int") >>= parse "Wire" with
+  | .ok program =>
+      assertEqual "a following declaration is not a unit"
+        (program.ports.any (·.name == "w.mid")) true
+  | .error message => throw (IO.userError s!"delay then declaration: {message}")
+  IO.println "delay unit tests passed"
+
 def rejectionCases : Array (String × String × String) := #[
+  -- Only zero may be unitless; every other delay says what it means.
+  ("connection delay without a unit",
+    wireTeam "src -> dst after 3", "needs a unit"),
+  ("timer offset without a unit",
+    wireTeam "src -> dst after 0 timer t(5, 0)", "needs a unit"),
+  ("timer period without a unit",
+    wireTeam "src -> dst after 0 timer t(0, 10)", "needs a unit"),
+  ("action delay without a unit",
+    wireTeam "action mid(delay=2) : int src -> dst after 0", "needs a unit"),
   -- 'm' and 'ms' differ by one character and five orders of magnitude.
   ("ambiguous duration unit", deadlineTeam "5m", "ambiguous"),
   -- A bare number is logical delay elsewhere in the language; a duration is
@@ -222,6 +265,7 @@ def main : IO UInt32 := do
     testBareTeamHeader
     testNamedMain
     testWithin
+    testDelayUnits
     IO.println "compiler rejection tests passed"
     pure 0
   catch error =>

--- a/lang/Tests.lean
+++ b/lang/Tests.lean
@@ -27,7 +27,7 @@ def topologyCases : Array TopologyCase := #[
     ports := 20, reactions := 11, instructions := 42 },
   -- `main WithinTest` names the program, so the team is not the file stem.
   { file := "DeadlineProbe.omar", team := "WithinTest", agents := 3, ports := 3,
-    reactions := 3, instructions := 13 },
+    reactions := 3, instructions := 13, codexOnly := false },
   { file := "EffectContracts.omar", team := "EffectContracts", agents := 1, ports := 6,
     reactions := 3, instructions := 13 },
   { file := "FanOutFanIn.omar", team := "FanOutFanIn", agents := 4, ports := 5,
@@ -116,6 +116,9 @@ def testTopology (test : TopologyCase) : IO Unit := do
       (program.connections.map fun connection => s!"{connection.source}->{connection.target}")
       #["n1.out->n2.token", "n2.out->n3.token", "n3.out->n1.token"]
   if test.file == "DeadlineProbe.omar" then
+    -- `codexOnly` is off, so the backend is pinned here instead of skipped.
+    assertEqual "every agent runs on Claude Code"
+      (program.agents.all (·.backend == "ClaudeCode")) true
     -- Nanoseconds, and only on the reactions that asked for one.
     assertEqual "generous deadline"
       (program.reactions.any (·.within == some 600000000000)) true

--- a/lang/spec.md
+++ b/lang/spec.md
@@ -28,7 +28,10 @@ action      = "action", identifier, [ "(", "delay", "=", natural, ")" ],
 connection  = identifier, "->", identifier, "after", natural ;
 
 prompt      = "prompt", identifier, "(", triggers, ")",
-              "->", effects, prompt-string ;
+              "->", effects, [ deadline ], prompt-string ;
+deadline    = "within", "(", duration, ")" ;
+duration    = natural, unit ;
+unit        = "ns" | "us" | "ms" | "s" | "sec" | "min" | "h" | "hr" ;
 triggers    = [ identifier, { ",", identifier } ] ;
 
 effects     = effect, { ",", effect } ;
@@ -83,6 +86,25 @@ The expression after `->` declares the ports a reaction may set:
 Every trigger must be an input or action. Every effect must be an output or
 action. A connection target must be an output or action, and its source and
 target types must match. Values must match their port types.
+
+### 2.3 Deadlines
+
+`within(30s)` bounds how long one invocation may take, measured from when that
+invocation starts. Without it the run-wide timeout applies.
+
+A duration is wall-clock and must carry a unit. `after 3` is a logical delay
+measured in tags; written as bare numbers the two would read alike and mean
+nothing alike. `m` is rejected as ambiguous: `min` is minutes, `ms` is
+milliseconds.
+
+What expiry does is read off the effect contract, so a deadline needs no
+second clause saying what to fall back to:
+
+- a contract that writing nothing already satisfies — `a?`, or no effects at
+  all — completes the tag with no writes. The ports it would have written are
+  absent, so whatever they feed does not fire.
+- a contract requiring an effect — `a`, `(a | b)` — has not been honoured.
+  There is no value to invent, so the run fails.
 
 ## 3. Compiled topology
 
@@ -242,8 +264,8 @@ REMOVE_PORT name
 
 CONNECT_PORTS source target delay
 
-INSTALL_REACTION id agent triggers effects contract prompt
-UPDATE_REACTION id triggers effects contract prompt
+INSTALL_REACTION id agent triggers effects contract prompt within
+UPDATE_REACTION id triggers effects contract prompt within
 REMOVE_REACTION id
 
 ACTIVATE_TOPOLOGY revision
@@ -267,8 +289,10 @@ The port `delay` field is omitted when no fixed delay is declared.
 Reaction fields are ordered:
 
 ```text
-op, id, agent, triggers, effects, contract, prompt
+op, id, agent, triggers, effects, contract, prompt, within
 ```
+
+`within` is nanoseconds, and is omitted when the reaction declares no deadline.
 
 The VM verifies the complete plan before performing effects. Unknown
 instructions, invalid references, invalid types, or inconsistent contracts are

--- a/lang/spec.md
+++ b/lang/spec.md
@@ -20,16 +20,18 @@ program     = "team", identifier, "(", agents, ")",
 agents      = [ agent, { ",", agent } ] ;
 agent       = identifier, ":", identifier ;
 
-declaration = input | output | action | connection | prompt ;
+declaration = input | output | action | timer | connection | prompt ;
 input       = "input", identifier, ":", type ;
 output      = "output", identifier, ":", type ;
-action      = "action", identifier, [ "(", "delay", "=", natural, ")" ],
+action      = "action", identifier, [ "(", "delay", "=", delay, ")" ],
               [ ":", type ] ;
-connection  = identifier, "->", identifier, "after", natural ;
+timer       = "timer", identifier, "(", delay, ",", delay, ")" ;
+connection  = identifier, "->", identifier, "after", delay ;
 
 prompt      = "prompt", identifier, "(", triggers, ")",
               "->", effects, [ deadline ], prompt-string ;
 deadline    = "within", "(", duration, ")" ;
+delay       = duration | "0" ;
 duration    = natural, unit ;
 unit        = "ns" | "us" | "ms" | "s" | "sec" | "min" | "h" | "hr" ;
 triggers    = [ identifier, { ",", identifier } ] ;
@@ -54,10 +56,12 @@ delimits a block comment.
 - `output` is a typed externally observable result.
 - `action` is a typed internal port.
 - An action without a type is a signal carrying no value.
-- `action a(delay=2) : int` gives `a` a fixed logical delay of two timestamp
-  units.
-- `a -> b after 3` copies each value present on `a` to `b` with an additional
-  logical delay of three timestamp units.
+- `action a(delay=2ms) : int` gives `a` a fixed logical delay of two
+  milliseconds.
+- `a -> b after 3s` copies each value present on `a` to `b` with an additional
+  logical delay of three seconds.
+- `timer t(1s, 500ms)` fires at one second and every five hundred milliseconds
+  after that. A period of `0` fires once, at the offset.
 - `prompt agent(a, b)` declares a reaction on `agent` triggered when port `a`
   or port `b` is present. If both are present at the same tag, the reaction is
   invoked once with both values.
@@ -92,10 +96,7 @@ target types must match. Values must match their port types.
 `within(30s)` bounds how long one invocation may take, measured from when that
 invocation starts. Without it the run-wide timeout applies.
 
-A duration is wall-clock and must carry a unit. `after 3` is a logical delay
-measured in tags; written as bare numbers the two would read alike and mean
-nothing alike. `m` is rejected as ambiguous: `min` is minutes, `ms` is
-milliseconds.
+See §2.4: a deadline is a duration like any other, and carries a unit.
 
 What expiry does is read off the effect contract, so a deadline needs no
 second clause saying what to fall back to:
@@ -105,6 +106,27 @@ second clause saying what to fall back to:
   absent, so whatever they feed does not fire.
 - a contract requiring an effect — `a`, `(a | b)` — has not been honoured.
   There is no value to invent, so the run fails.
+
+### 2.4 Durations
+
+Every span of time in the language is a duration: `after`, a timer's offset and
+period, an action's `delay`, and `within`. All are stored as nanoseconds.
+
+A duration must carry a unit — `ns`, `us`, `ms`, `s` (or `sec`), `min`, `h` (or
+`hr`). A bare number says nothing about its magnitude, and `3` meaning three
+nanoseconds rather than three hours is not something a reader should have to
+know from elsewhere.
+
+`m` is rejected as ambiguous: `min` is minutes, `ms` is milliseconds, and the
+two differ by one character and five orders of magnitude.
+
+Zero is the one exception. `after 0` is the same instant in every unit, so it
+needs none — though `0ms` is also accepted and means the same thing.
+
+A unit binds to the number it touches. `after 3ns` is one duration; `after 3`
+followed by a declaration beginning with a word is a delay and then that
+declaration, and `3 ns` with a space between is an error rather than a
+duration.
 
 ## 3. Compiled topology
 

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -88,6 +88,11 @@ pub struct DiagramReaction {
     pub status: String,
     pub invocation_id: Option<String>,
     pub instance: String,
+    /// Nanoseconds this reaction gave itself, or `None` for one bounded only by
+    /// the run. Carried so a client can draw the bound rather than leaving the
+    /// operator to read it out of the source.
+    #[serde(default)]
+    pub within: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -205,6 +210,7 @@ impl DiagramSnapshot {
                 status: "idle".to_string(),
                 invocation_id: None,
                 instance: reaction.instance.clone(),
+                within: reaction.within,
             })
             .collect();
         let mut edges = Vec::new();

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -744,6 +744,7 @@ mod tests {
                     effects: vec!["answer".to_string()],
                     contract: "answer".to_string(),
                     prompt: "Respond".to_string(),
+                    within: None,
                 },
             )]),
         }
@@ -809,6 +810,7 @@ mod tests {
                     effects: vec!["writer.draft".to_string()],
                     contract: "writer.draft".to_string(),
                     prompt: "Draft".to_string(),
+                    within: None,
                 },
             )]),
         }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -1001,7 +1001,9 @@ fn expired(invocation: &InvocationSpec, deadline: Duration) -> Result<BTreeMap<S
     match validate_contract(&invocation.contract, &BTreeMap::new()) {
         Ok(()) => Ok(BTreeMap::new()),
         Err(_) => bail!(
-            "'{}' did not answer within {:?}, and contract '{}' requires an effect",
+            "reaction '{}' invocation '{}': '{}' did not answer within {:?}, and contract '{}' requires an effect",
+            invocation.reaction_id,
+            invocation.id,
             invocation.agent,
             deadline,
             invocation.contract
@@ -2207,9 +2209,12 @@ mod tests {
             .unwrap_err()
             .to_string();
         // Names the contract, so an operator reads which promise went unkept
-        // rather than only that something timed out.
+        // rather than only that something timed out, and names the invocation
+        // so the line can be found in a log next to the rest of its run.
         assert!(error.contains("requires an effect"), "{error}");
         assert!(error.contains("memo"), "{error}");
+        assert!(error.contains("reaction.0"), "{error}");
+        assert!(error.contains(&spec.id), "{error}");
     }
 
     /// Answers nothing, which is what an expired deadline does to a contract

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -80,6 +80,10 @@ pub enum Instruction {
         prompt: String,
         #[serde(default)]
         instance: String,
+        /// Nanoseconds one invocation may take before it is given up on.
+        /// Absent leaves it to the run-wide timeout.
+        #[serde(default)]
+        within: Option<u64>,
     },
     CommitPlan,
 }
@@ -152,6 +156,9 @@ pub struct ReactionState {
     pub effects: Vec<String>,
     pub contract: String,
     pub prompt: String,
+    /// Nanoseconds one invocation may take. `None` uses the run-wide timeout.
+    #[serde(default)]
+    pub within: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -451,6 +458,7 @@ pub fn verify(bytecode: &Bytecode) -> Result<VmState> {
                 contract,
                 prompt,
                 instance,
+                within,
             } => {
                 let order = state.reactions.len();
                 check_instance(&state, "reaction", id, instance)?;
@@ -494,6 +502,7 @@ pub fn verify(bytecode: &Bytecode) -> Result<VmState> {
                             effects: effects.clone(),
                             contract: contract.clone(),
                             prompt: prompt.clone(),
+                            within: *within,
                         },
                     )
                     .is_some()
@@ -972,10 +981,32 @@ struct InvocationSpec {
     allowed_effects: BTreeMap<String, String>,
     contract: String,
     prompt: String,
+    /// What the program allows this invocation, overriding the run-wide
+    /// timeout. `None` means the program said nothing and the run's applies.
+    within: Option<Duration>,
 }
 
 trait ReactionExecutor: Sync {
     fn invoke(&self, invocation: InvocationSpec) -> Result<BTreeMap<String, Value>>;
+}
+
+/// What an expired deadline means, which the effect contract decides.
+///
+/// A contract that writing nothing already satisfies is one the program said
+/// may stay silent, so the tag completes with no writes and whatever those
+/// ports feed simply does not fire. A contract that requires an effect has not
+/// been honoured and there is no value to invent, so the run stops rather than
+/// carrying on from a decision nobody made.
+fn expired(invocation: &InvocationSpec, deadline: Duration) -> Result<BTreeMap<String, Value>> {
+    match validate_contract(&invocation.contract, &BTreeMap::new()) {
+        Ok(()) => Ok(BTreeMap::new()),
+        Err(_) => bail!(
+            "'{}' did not answer within {:?}, and contract '{}' requires an effect",
+            invocation.agent,
+            deadline,
+            invocation.contract
+        ),
+    }
 }
 
 struct TmuxReactionExecutor {
@@ -1021,13 +1052,10 @@ impl ReactionExecutor for TmuxReactionExecutor {
             return Err(error);
         }
 
-        let result = match completion.recv_timeout(self.timeout) {
+        let deadline = invocation.within.unwrap_or(self.timeout);
+        let result = match completion.recv_timeout(deadline) {
             Ok(writes) => Ok(writes),
-            Err(mpsc::RecvTimeoutError::Timeout) => Err(anyhow::anyhow!(
-                "invocation '{}' on agent '{}' timed out",
-                invocation_id,
-                invocation.agent
-            )),
+            Err(mpsc::RecvTimeoutError::Timeout) => expired(&invocation, deadline),
             Err(mpsc::RecvTimeoutError::Disconnected) => Err(anyhow::anyhow!(
                 "topology invocation service stopped unexpectedly"
             )),
@@ -1473,6 +1501,7 @@ fn invocation_spec(
         allowed_effects,
         contract: reaction.contract.clone(),
         prompt: reaction.prompt.clone(),
+        within: reaction.within.map(Duration::from_nanos),
     })
 }
 
@@ -1890,6 +1919,7 @@ mod tests {
                     effects: effects.into_iter().map(str::to_string).collect(),
                     contract: contract.into(),
                     prompt: "prompt".into(),
+                    within: None,
                 },
             );
         }
@@ -2114,6 +2144,119 @@ mod tests {
         .unwrap();
         let error = verify(&orphan).unwrap_err().to_string();
         assert!(error.contains("undeclared parent 'b'"), "{error}");
+    }
+
+    /// One reaction under a contract of the caller's choosing, with or without
+    /// a deadline the program set for itself.
+    fn deadline_spec(contract: &str, within: Option<u64>) -> InvocationSpec {
+        let within = match within {
+            Some(nanos) => format!(r#","within":{nanos}"#),
+            None => String::new(),
+        };
+        let bytecode: Bytecode = serde_json::from_str(&format!(
+            r#"{{
+              "version": 1,
+              "team": "Desk",
+              "instructions": [
+                {{"op":"begin_plan","team":"Desk"}},
+                {{"op":"spawn_agent","name":"clerk","backend":"Codex"}},
+                {{"op":"define_port","kind":"input","name":"topic","type":"string"}},
+                {{"op":"define_port","kind":"output","name":"memo","type":"string"}},
+                {{"op":"install_reaction","id":"reaction.0","agent":"clerk",
+                 "triggers":["topic"],"effects":["memo"],
+                 "contract":"{contract}","prompt":"p"{within}}},
+                {{"op":"commit_plan"}}
+              ]
+            }}"#
+        ))
+        .unwrap();
+        let state = verify(&bytecode).unwrap();
+        let (id, reaction) = state.reactions.get_key_value("reaction.0").unwrap();
+        invocation_spec(
+            &state,
+            (id, reaction),
+            &BTreeMap::from([("topic".to_string(), json!("x"))]),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn a_program_sets_its_own_deadline() {
+        assert_eq!(
+            deadline_spec("memo", Some(30_000_000_000)).within,
+            Some(Duration::from_secs(30))
+        );
+        // Saying nothing leaves the run-wide timeout in charge rather than
+        // inventing a deadline the program never asked for.
+        assert_eq!(deadline_spec("memo", None).within, None);
+    }
+
+    #[test]
+    fn silence_completes_the_tag_when_the_contract_permits_it() {
+        let spec = deadline_spec("memo ?", Some(1));
+        assert_eq!(
+            expired(&spec, Duration::from_secs(30)).unwrap(),
+            BTreeMap::new()
+        );
+    }
+
+    #[test]
+    fn silence_stops_the_run_when_the_contract_requires_an_effect() {
+        let spec = deadline_spec("memo", Some(1));
+        let error = expired(&spec, Duration::from_secs(30))
+            .unwrap_err()
+            .to_string();
+        // Names the contract, so an operator reads which promise went unkept
+        // rather than only that something timed out.
+        assert!(error.contains("requires an effect"), "{error}");
+        assert!(error.contains("memo"), "{error}");
+    }
+
+    /// Answers nothing, which is what an expired deadline does to a contract
+    /// that permits silence.
+    struct SilentExecutor;
+
+    impl ReactionExecutor for SilentExecutor {
+        fn invoke(&self, _invocation: InvocationSpec) -> Result<BTreeMap<String, Value>> {
+            Ok(BTreeMap::new())
+        }
+    }
+
+    #[test]
+    fn a_silent_reaction_leaves_what_it_feeds_unfired() {
+        // Silence is absence, not a value: the port it would have written is
+        // not present, so the reaction reading it never runs and the run ends
+        // rather than stalling on a value that is never coming.
+        let bytecode: Bytecode = serde_json::from_str(
+            r#"{
+              "version": 1,
+              "team": "Desk",
+              "instructions": [
+                {"op":"begin_plan","team":"Desk"},
+                {"op":"spawn_agent","name":"clerk","backend":"Codex"},
+                {"op":"spawn_agent","name":"editor","backend":"Codex"},
+                {"op":"define_port","kind":"input","name":"topic","type":"string"},
+                {"op":"define_port","kind":"action","name":"memo","type":"string"},
+                {"op":"define_port","kind":"output","name":"report","type":"string"},
+                {"op":"install_reaction","id":"reaction.0","agent":"clerk",
+                 "triggers":["topic"],"effects":["memo"],
+                 "contract":"memo ?","prompt":"p","within":1},
+                {"op":"install_reaction","id":"reaction.1","agent":"editor",
+                 "triggers":["memo"],"effects":["report"],
+                 "contract":"report","prompt":"p"},
+                {"op":"commit_plan"}
+              ]
+            }"#,
+        )
+        .unwrap();
+        let state = verify(&bytecode).unwrap();
+        let outputs = run_event_loop(
+            &state,
+            BTreeMap::from([("topic".to_string(), json!("x"))]),
+            &SilentExecutor,
+        )
+        .unwrap();
+        assert!(outputs.is_empty(), "nothing downstream ran: {outputs:?}");
     }
 
     /// Records the tag every invocation arrived at, so a timer's schedule can

--- a/tests/topology/run_local.sh
+++ b/tests/topology/run_local.sh
@@ -300,7 +300,8 @@ run_case Nested Nested run.summary --input run.brief='hierarchy'
 run_case Timer Timer beacon.note
 # Four one-shot timers opening three rounds and a deadline, on Claude Code.
 run_case Cadence Cadence chair.report
-# Two deadlines at one tag: one generous and met, one of 1ms that cannot be.
+# Two deadlines at one tag on Claude Code: one generous and met, one of 1ms
+# that cannot be.
 # The 1ms contract is optional, so its expiry completes the tag rather than
 # failing the run, and `report` shows <absent> where that write would have been.
 # `main` names the program, so the completion marker is WithinTest.

--- a/tests/topology/run_local.sh
+++ b/tests/topology/run_local.sh
@@ -300,6 +300,11 @@ run_case Nested Nested run.summary --input run.brief='hierarchy'
 run_case Timer Timer beacon.note
 # Four one-shot timers opening three rounds and a deadline, on Claude Code.
 run_case Cadence Cadence chair.report
+# Two deadlines at one tag: one generous and met, one of 1ms that cannot be.
+# The 1ms contract is optional, so its expiry completes the tag rather than
+# failing the run, and `report` shows <absent> where that write would have been.
+# `main` names the program, so the completion marker is WithinTest.
+run_case DeadlineProbe WithinTest probe.report
 run_case SameAgentSerial SameAgentSerial serial.result \
   --input serial.request='serialize these reactions'
 run_case SuperdenseTime SuperdenseTime time.fixed_result,time.connected_result \

--- a/tests/topology/src/Cadence.omar
+++ b/tests/topology/src/Cadence.omar
@@ -68,10 +68,10 @@ team Desk[editor : ClaudeCode]
 
 team Chair(topic : string)[chair : ClaudeCode]
 {
-    timer open1(1, 0)
-    timer open2(10, 0)
-    timer open3(20, 0)
-    timer close(30, 0)
+    timer open1(1ns, 0)
+    timer open2(10ns, 0)
+    timer open3(20ns, 0)
+    timer close(30ns, 0)
 
     input digest : string
     output brief : string

--- a/tests/topology/src/DeadlineProbe.omar
+++ b/tests/topology/src/DeadlineProbe.omar
@@ -9,7 +9,7 @@
 // `reporter` triggers on both, so it fires at that tag with the met value
 // present and the missed one expanding to <absent>. That difference is the
 // observable result of the test.
-team DeadlineProbe[punctual : Codex, tardy : Codex, reporter : Codex]
+team DeadlineProbe[punctual : ClaudeCode, tardy : ClaudeCode, reporter : ClaudeCode]
 {
     // Period 0: fires once, at logical time 1ns, then the program finishes.
     timer start(1ns, 0)

--- a/tests/topology/src/DeadlineProbe.omar
+++ b/tests/topology/src/DeadlineProbe.omar
@@ -1,0 +1,54 @@
+// Exercises the `within` deadline keyword.
+//
+// Two reactions fire from the same timer tag:
+//   - `punctual` has a generous deadline it will meet, and a mandatory effect.
+//   - `tardy` has a deadline of 1ms that no agent can meet. Its contract is
+//     optional (missed?), so expiry completes the tag with no write rather
+//     than failing the run.
+//
+// `reporter` triggers on both, so it fires at that tag with the met value
+// present and the missed one expanding to <absent>. That difference is the
+// observable result of the test.
+team DeadlineProbe[punctual : Codex, tardy : Codex, reporter : Codex]
+{
+    // Period 0: fires once, at logical time 1ns, then the program finishes.
+    timer start(1ns, 0)
+
+    action met : string
+    action missed : string
+    output report : string
+
+    prompt punctual(start) -> met within(10min)
+    "
+        The timer fired at logical time $(start).
+        Your deadline is 10 minutes, far more than you need.
+        Set `met` to exactly: punctual
+    "
+
+    prompt tardy(start) -> missed? within(1ms)
+    "
+        The timer fired at logical time $(start).
+        This invocation has a deadline of 1ms, which has almost certainly
+        expired before you read this. If you somehow answer in time, set
+        `missed` to exactly: tardy. Otherwise the deadline passes and nothing
+        is written, which is the expected outcome.
+    "
+
+    prompt reporter(met, missed) -> report
+    "
+        Two reactions ran under `within` deadlines at the same tag.
+        The generous one reported: $(met)
+        The 1ms one reported: $(missed)
+
+        Set `report` to exactly one line of this form:
+        met=$(met) missed=$(missed)
+
+        A value of <absent> for the second one means its deadline expired and
+        its optional contract absorbed the expiry. That is a pass, not an
+        error.
+    "
+}
+
+main WithinTest {
+    probe = DeadlineProbe()
+}

--- a/tests/topology/src/Heartbeat.omar
+++ b/tests/topology/src/Heartbeat.omar
@@ -14,7 +14,7 @@
 
 team Pulse[monitor : ClaudeCode]
 {
-    timer tick(0, 10)
+    timer tick(0, 10ns)
     output reading : string
 
     prompt monitor(tick) -> reading

--- a/tests/topology/src/OrderedWrites.omar
+++ b/tests/topology/src/OrderedWrites.omar
@@ -15,7 +15,10 @@ team OrderedWrites[first : Codex,
         Set `shared` to `first: $(request)`.
     "
 
-    prompt optional(request) -> shared?
+    // Its contract permits silence, so an expired deadline completes the tag
+    // with no write rather than failing the run. Bounded well above what an
+    // agent takes, so the run exercises the field without racing it.
+    prompt optional(request) -> shared? within(10min)
     "
         Exercise an optional effect: do not set `shared`; just complete this
         invocation. The earlier value must remain buffered for this tag.

--- a/tests/topology/src/SuperdenseTime.omar
+++ b/tests/topology/src/SuperdenseTime.omar
@@ -8,12 +8,12 @@ team SuperdenseTime[producer : Codex,
     output connected_result : int
 
     action immediate : int
-    action fixed(delay=2) : int
-    action connected(delay=1) : int
+    action fixed(delay=2ns) : int
+    action connected(delay=1ns) : int
 
     // `immediate` arrives at (0, 1). The connection delay of 3 and connected's
     // fixed delay of 1 are additive, so `connected` arrives at (4, 0).
-    immediate -> connected after 3
+    immediate -> connected after 3ns
 
     prompt producer(start) -> immediate, fixed
     "

--- a/tests/topology/src/Timer.omar
+++ b/tests/topology/src/Timer.omar
@@ -7,7 +7,7 @@
 // re-arms forever and has no place in a test that must finish.
 team Beacon(label : string)[agent : Codex]
 {
-    timer t(5, 0)
+    timer t(5ns, 0)
     output note : string
 
     prompt agent(t) -> note

--- a/web/app/diagram/diagram-canvas.tsx
+++ b/web/app/diagram/diagram-canvas.tsx
@@ -57,6 +57,16 @@ type Box = { x: number; y: number; width: number; height: number };
 const REACTION_SIZE = { width: 154, height: 50 };
 /** Chevron text starts after the order badge and must clear the right notch. */
 const REACTION_TEXT_X = 46;
+/**
+ * The stopwatch a `within` deadline is drawn as, and the room it needs.
+ *
+ * A face plus a crown, so it reads as a stopwatch rather than the clock a timer
+ * already uses — one counts down against a reaction, the other fires on its
+ * own. It sits before the chevron's point with its interval beneath, and the
+ * node widens to hold both rather than crowding the name.
+ */
+const WITHIN_RADIUS = 7;
+const WITHIN_ROOM = 40;
 const REACTION_MAX_WIDTH = 340;
 const ACTION_SIZE = { width: 26, height: 26 };
 /** A timer's clock face. Larger than an action: it carries two hands. */
@@ -127,6 +137,8 @@ type ReactionView = {
   box: Box;
   /** The agent that runs it, which is whose terminal opens on double click. */
   agent: string;
+  /** Nanoseconds from `within`, drawn as a stopwatch. Null when unbounded. */
+  within: number | null;
 };
 
 type EdgeView = {
@@ -383,13 +395,16 @@ function textWidth(text: string, perChar: number): number {
   return text.length * perChar;
 }
 
-function reactionWidth(labels: ReactionLabels): number {
+function reactionWidth(labels: ReactionLabels, within: number | null): number {
   const widest = Math.max(
     textWidth(labels.name, 6.9),
     textWidth(labels.meta, 5.2),
   );
+  // A deadline is drawn between the text and the point, so the node has to be
+  // wider for it rather than the stopwatch sitting on top of the name.
+  const deadline = within === null ? 0 : WITHIN_ROOM;
   return clamp(
-    Math.ceil(REACTION_TEXT_X + widest + CHEVRON_NOTCH + 10),
+    Math.ceil(REACTION_TEXT_X + widest + deadline + CHEVRON_NOTCH + 10),
     REACTION_SIZE.width,
     REACTION_MAX_WIDTH,
   );
@@ -622,6 +637,7 @@ async function runElk(
             id: reaction.id,
             width: reactionWidth(
               labels.get(reaction.id) ?? { name: reaction.name, meta: "" },
+              reaction.within,
             ),
             height: REACTION_SIZE.height,
           })),
@@ -727,6 +743,7 @@ function buildLayout(
       status: reaction.status,
       box: nodeBoxes.get(reaction.id) ?? { x: 0, y: 0, ...REACTION_SIZE },
       agent: componentName(reaction.agent),
+      within: reaction.within,
     };
   });
 
@@ -1400,6 +1417,38 @@ export function DiagramCanvas({
                   >
                     {reaction.meta}
                   </text>
+                  {/* A deadline the program set for itself. A stopwatch rather
+                      than a clock: a timer fires on its own, this counts down
+                      against work already running. */}
+                  {reaction.within === null ? null : (
+                    <g
+                      className="omar-within"
+                      transform={`translate(${
+                        reaction.box.width - CHEVRON_NOTCH - WITHIN_ROOM / 2
+                      },${reaction.box.height / 2})`}
+                    >
+                      <title>{`must answer within ${formatDuration(reaction.within)}`}</title>
+                      {/* The crown, which is what tells it from a clock face. */}
+                      <line
+                        className="omar-within-crown"
+                        x1={0}
+                        y1={-WITHIN_RADIUS - 5}
+                        x2={0}
+                        y2={-WITHIN_RADIUS - 2}
+                      />
+                      <circle className="omar-within-face" cy={-4} r={WITHIN_RADIUS} />
+                      <line
+                        className="omar-within-hand"
+                        x1={0}
+                        y1={-4}
+                        x2={3.6}
+                        y2={-7.6}
+                      />
+                      <text className="omar-within-meta" y={14} textAnchor="middle">
+                        {formatDuration(reaction.within)}
+                      </text>
+                    </g>
+                  )}
                 </g>
               ))}
             </g>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -801,6 +801,29 @@ h2 {
   font-weight: 600;
 }
 
+/* A `within` deadline: a stopwatch, not a clock. A timer fires on its own; this
+   counts down against work already running, and red because reaching zero is a
+   thing the operator wants to notice. */
+.omar-within-face {
+  fill: #fff5f5;
+  stroke: #c0392b;
+  stroke-width: 1.4;
+}
+
+.omar-within-crown,
+.omar-within-hand {
+  stroke: #c0392b;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+}
+
+.omar-within-meta {
+  fill: #c0392b;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
 /* Timers: a clock face, because nothing feeds one — it fires on its own. */
 .omar-timer-face {
   fill: #ffffff;

--- a/web/app/lib/fixtures.ts
+++ b/web/app/lib/fixtures.ts
@@ -85,6 +85,7 @@ export const reviewWorkflow: DiagramSnapshot = {
       status: "completed",
       invocation_id: "inv-001",
       instance: "flow",
+      within: null,
     },
     {
       id: "reaction::flow.reaction.1",
@@ -97,6 +98,8 @@ export const reviewWorkflow: DiagramSnapshot = {
       status: "running",
       invocation_id: "inv-002",
       instance: "flow",
+      // A deadline the program set for itself, drawn as a stopwatch.
+      within: 300_000_000_000,
     },
     {
       id: "reaction::flow.reaction.2",
@@ -109,6 +112,7 @@ export const reviewWorkflow: DiagramSnapshot = {
       status: "idle",
       invocation_id: null,
       instance: "flow",
+      within: null,
     },
   ],
   edges: [

--- a/web/app/lib/protocol.ts
+++ b/web/app/lib/protocol.ts
@@ -69,6 +69,11 @@ export type DiagramReaction = {
   status: "idle" | "running" | "completed";
   invocation_id: string | null;
   instance: string;
+  /**
+   * Nanoseconds this reaction gave itself with `within`, or null for one
+   * bounded only by the run. Null also for a runtime that predates the field.
+   */
+  within: number | null;
 };
 
 /**
@@ -266,6 +271,14 @@ export function assertDiagramSnapshot(value: unknown): DiagramSnapshot {
     // A runtime that does not measure lag is not a runtime with no lag, so
     // this stays null and the readout says so rather than claiming zero.
     lag: typeof snapshot.lag === "number" ? snapshot.lag : null,
+    // Likewise `within`: a reaction that declares no deadline, and one from a
+    // runtime that predates them, both arrive without the field. The type says
+    // `number | null`, so make that true rather than leaving `undefined` for
+    // every reader to guard against.
+    reactions: (snapshot.reactions ?? []).map((reaction) => ({
+      ...reaction,
+      within: typeof reaction.within === "number" ? reaction.within : null,
+    })),
   } as DiagramSnapshot;
 }
 

--- a/web/tests/e2e/flow.spec.ts
+++ b/web/tests/e2e/flow.spec.ts
@@ -151,6 +151,37 @@ test("the run header reports how far behind it is, in readable units", async ({
   await expect(stats).toContainText("LAG");
 });
 
+test("a reaction's deadline is drawn as a stopwatch on its chevron", async ({
+  page,
+}) => {
+  await useFakeServe(page);
+  await draftUntilProposed(page);
+  await expect(page.locator(".omar-reaction")).toHaveCount(3);
+
+  // One reaction in the captured topology declares `within(5min)`; the other
+  // two are bounded only by the run and carry nothing.
+  const deadlines = page.locator(".omar-within");
+  await expect(deadlines).toHaveCount(1);
+  await expect(deadlines.locator(".omar-within-face")).toBeVisible();
+  // The crown is what tells a stopwatch from the clock a timer already uses.
+  // Attached rather than visible: it is a vertical line, so its bounding box
+  // has no width and Playwright counts that as hidden.
+  await expect(deadlines.locator(".omar-within-crown")).toBeAttached();
+  // 300000000000ns divides exactly into five minutes, so that is the unit it
+  // reads in — not 300s, and not the digits.
+  await expect(deadlines.locator(".omar-within-meta")).toHaveText("5min");
+  await expect(deadlines.locator("title")).toHaveText(
+    "must answer within 5min",
+  );
+
+  // The chevron widens for it rather than the stopwatch landing on the name.
+  const marked = page.locator(".omar-reaction", { has: deadlines });
+  const plain = page.locator(".omar-reaction").first();
+  const markedBox = (await marked.locator("polygon").boundingBox())!;
+  const plainBox = (await plain.locator("polygon").boundingBox())!;
+  expect(markedBox.width).toBeGreaterThan(plainBox.width);
+});
+
 test("Enter sends, modified Enter writes a new line", async ({ page }) => {
   await useFakeServe(page);
   const composer = page.getByLabel("Describe a workflow");

--- a/web/tests/fixtures/diagram-snapshot.v1.json
+++ b/web/tests/fixtures/diagram-snapshot.v1.json
@@ -98,7 +98,8 @@
       "contract": "critique",
       "status": "idle",
       "invocation_id": null,
-      "instance": "flow"
+      "instance": "flow",
+      "within": 300000000000
     },
     {
       "id": "reaction::flow.reaction.2",


### PR DESCRIPTION
Every span of time in the language is now a duration that carries its unit, and a reaction can bound how long it may take.

## `within(30s)`

A run had one timeout for every reaction in it, set outside the program with `--timeout-seconds`, and expiring it failed the run. A reviewer and a human panel could not be given different patience, and silence was always fatal.

```omar
prompt panel(verdict, rounds) -> depth?, topic? within(5min)
"Round $(rounds) came back $(verdict). Set depth and topic to continue."
```

Bounds one invocation, measured from when it starts. Without it the run-wide timeout still applies — saying nothing is not a zero deadline.

### No `else` clause

The effect contract already says what silence means. A fallback clause would say it a second time and let the two disagree:

| contract | on expiry |
|---|---|
| `a?`, or no effects at all | completes the tag with no writes |
| `a`, `(a \| b)` | run fails, naming the contract |

That table is `validate_contract(contract, {})` — the function that already decides whether writes honour a contract, asked about the empty set. Silence is absence, not a value: the ports that went unwritten are not present, so what they feed does not fire.

A required effect stays legal to pair with a deadline. `-> (approve | reject) within(1h)` is a real program — decide within an hour or the deal is off — so this is a runtime failure rather than a compile-time rejection.

The deadline reaches every backend, so it closes the same liveness hole for LLM agents, where one slow reaction has always been able to fail a run.

## Units, everywhere a delay appears

`within(30s)` needing a unit while `after 3` did not would have left the language saying some spans of time are worth being clear about and others are not. They are the same kind of thing.

`after`, a timer's offset and period, and an action's `delay` are durations too — `ns`, `us`, `ms`, `s`/`sec`, `min`, `h`/`hr`, all stored as nanoseconds. Zero is the one exception: the same instant in every unit, so it needs none (`0ms` is also accepted).

```
duration '30' needs a unit, e.g. '30s'
'm' is ambiguous: write 'min' for minutes or 'ms' for milliseconds
unknown duration unit 'weeks'; use ns, us, ms, s, min, or h
```

`m` is refused deliberately — one character and five orders of magnitude from `ms`, and the failure is silent.

**A unit is taken by the lexer, not the parser.** `3ns` and `3` followed by `ns` are otherwise the same two tokens — and so are `after 3` and the `input` declaration on the next line. Binding the unit to the number it touches removes the ambiguity rather than guessing at it. As a consequence `3 ns` with a space is an error, not a duration.

### Corpus migration

Four programs said things they no longer say. Each is rewritten in nanoseconds, which is what those numbers already meant, so **nothing changes speed**:

```
timer tick(0, 10)               ->  timer tick(0, 10ns)      Heartbeat.omar
timer close(30, 0)              ->  timer close(30ns, 0)     Cadence.omar  (and open1/2/3)
timer t(5, 0)                   ->  timer t(5ns, 0)          Timer.omar
action fixed(delay=2) : int     ->  action fixed(delay=2ns)  SuperdenseTime.omar
immediate -> connected after 3  ->  after 3ns                SuperdenseTime.omar
```

Whether any of those wanted seconds is a question their authors can now answer in the source instead of in a comment. That is the point of the change: the old spellings kept compiling while meaning something nobody had stated.

## Verification

- 325 Rust tests, clippy and `cargo fmt` clean. Four are new: the deadline reaching the invocation from the program, silence under each kind of contract, and a silent reaction leaving what it feeds unfired rather than stalling.
- Lean suite passes. Seven new rejections (`5m`, bare `30`, `5weeks`, and a unitless `after` / timer offset / timer period / action delay), plus unit conversion, zero-without-a-unit, and that a declaration following a bare `0` is not eaten as a unit.
- All 19 `.omar` files in the repo compile. The CI bytecode key-order assertion passes on the migrated corpus and accepts `install_reaction` with or without `within`.
- `OrderedWrites.omar` carries a `within(10min)` on the reaction whose contract already permitted silence, so the release gate exercises the field — bounded well above what an agent takes, so it does not race it.

## Follow-ups

- [#198](https://github.com/omar-os/omar/issues/198) records `lag(interval)` — Lingua Franca's deadline, on how late a tag *starts* rather than how long it takes.
- [#201](https://github.com/omar-os/omar/pull/201) holds the logical clock against the wall clock, which is what makes these units mean anything at runtime. Independent of this PR and mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FGAWP6ouCgTu87mH5RhuK
