### PR TITLE
Follow the text with the drawing, and lay it out only when it changes

### DIFF
--- a/web/app/diagram/diagram-canvas.tsx
+++ b/web/app/diagram/diagram-canvas.tsx
@@ -1027,44 +1027,80 @@ function fitScale(layout: Layout, size: Size): number {
 const WRAP_CANDIDATES = [3.0, 2.2, 1.6];
 const WRAP_GAIN = 1.08;
 
-async function computeLayout(
+/**
+ * Where everything sits, which is the expensive half of drawing.
+ *
+ * Kept apart from the drawing itself so it can be reused: ELK runs up to four
+ * times to pick a wrapping, and a snapshot whose shape has not changed deserves
+ * none of them.
+ */
+type Geometry = {
+  declared: ContainerView[];
+  elk: ElkNode;
+};
+
+async function computeGeometry(
   snapshot: DiagramSnapshot,
   size: Size,
-): Promise<Layout> {
+): Promise<Geometry> {
   const { default: ELK } = await import("elkjs/lib/elk.bundled.js");
   const factory = ELK as unknown as ElkFactory;
 
   const declared = containersOf(snapshot);
-  const single = buildLayout(
-    snapshot,
-    declared,
-    await runElk(factory, snapshot, declared, null),
-  );
+  const plain = await runElk(factory, snapshot, declared, null);
   const nodeCount = snapshot.reactions.length + snapshot.ports.length;
-  if (size.width === 0 || size.height === 0 || nodeCount < 4) return single;
+  if (size.width === 0 || size.height === 0 || nodeCount < 4) {
+    return { declared, elk: plain };
+  }
 
-  let best = single;
-  let bestScale = fitScale(single, size) * WRAP_GAIN;
+  let best = plain;
+  let bestScale = fitScale(buildLayout(snapshot, declared, plain), size) * WRAP_GAIN;
   for (const aspectRatio of WRAP_CANDIDATES) {
-    let candidate: Layout;
+    let candidate: ElkNode;
+    let scale: number;
     try {
-      candidate = buildLayout(
-        snapshot,
-        declared,
-        await runElk(factory, snapshot, declared, aspectRatio),
-      );
+      candidate = await runElk(factory, snapshot, declared, aspectRatio);
+      scale = fitScale(buildLayout(snapshot, declared, candidate), size);
     } catch {
       // Wrapping is an optimisation, and ELK throws on some graphs — cyclic
       // ones especially. Losing a candidate is fine; losing the diagram is not.
       continue;
     }
-    const scale = fitScale(candidate, size);
     if (scale > bestScale) {
       best = candidate;
       bestScale = scale;
     }
   }
-  return best;
+  return { declared, elk: best };
+}
+
+/**
+ * Everything the geometry depends on, and nothing that moves while a run does.
+ *
+ * A snapshot arrives on every event of a live run and on every keystroke once
+ * the editor feeds the diagram, but almost all of those carry the same drawing
+ * with different numbers in it. Laying that out again is pure waste, and enough
+ * of it to matter: this is what tells the two cases apart.
+ *
+ * Built by removing what is live rather than by listing what is structural, so
+ * a field added to the protocol counts until someone says otherwise.
+ */
+function layoutKey(snapshot: DiagramSnapshot): string {
+  return JSON.stringify({
+    team: snapshot.team,
+    instances: snapshot.instances ?? [],
+    agents: snapshot.agents,
+    timers: snapshot.timers ?? [],
+    edges: snapshot.edges,
+    // Blanked rather than dropped, so a field added to either later counts
+    // towards the shape until someone decides it is live too.
+    ports: snapshot.ports.map((port) => ({ ...port, value: null, last_tag: null })),
+    reactions: snapshot.reactions.map((reaction) => ({
+      ...reaction,
+      status: "",
+      invocation_id: null,
+    })),
+  });
 }
 
 /**
@@ -1141,17 +1177,38 @@ export function DiagramCanvas({
   // would yank the view out from under anyone who has zoomed in, so the fit is
   // only reclaimed when the topology itself changes.
   const structureRef = useRef<string | null>(null);
+  // ELK's answer for the shape currently drawn, and the shape it answers for.
+  // Distinct from `structureRef`, which is coarser on purpose: it asks whether
+  // the view should be refitted, and a rename is not worth yanking the view for
+  // even though it does move the boxes.
+  const geometryRef = useRef<{ key: string; geometry: Geometry } | null>(null);
   const sizeBucket =
     size.width && size.height
       ? `${Math.round(size.width / 80)}x${Math.round(size.height / 80)}`
       : "";
+  const shape = `${layoutKey(snapshot)}|${sizeBucket}`;
 
   useEffect(() => {
     let cancelled = false;
-    computeLayout(snapshot, sizeRef.current)
-      .then((next) => {
+
+    // Same shape as what is already drawn: the values moved and nothing else,
+    // so redraw from the geometry in hand rather than asking ELK for it again.
+    const drawn = geometryRef.current;
+    if (drawn?.key === shape) {
+      try {
+        setLayout(buildLayout(snapshot, drawn.geometry.declared, drawn.geometry.elk));
+        setError(null);
+      } catch (cause: unknown) {
+        setError(cause instanceof Error ? cause.message : String(cause));
+      }
+      return;
+    }
+
+    computeGeometry(snapshot, sizeRef.current)
+      .then((geometry) => {
         if (cancelled) return;
-        setLayout(next);
+        geometryRef.current = { key: shape, geometry };
+        setLayout(buildLayout(snapshot, geometry.declared, geometry.elk));
         const structure = structureKey(snapshot);
         if (structureRef.current !== structure) {
           structureRef.current = structure;
@@ -1166,7 +1223,7 @@ export function DiagramCanvas({
     return () => {
       cancelled = true;
     };
-  }, [snapshot, sizeBucket]);
+  }, [snapshot, shape]);
 
   useEffect(() => {
     const host = hostRef.current;

--- a/web/app/lib/runtime-client.ts
+++ b/web/app/lib/runtime-client.ts
@@ -214,7 +214,13 @@ export async function checkProgram(
   if (!response.ok) {
     throw new Error(await readError(response));
   }
-  return (await response.json()) as ProgramCheck;
+  const check = (await response.json()) as ProgramCheck;
+  // Normalised like any other snapshot. It arrives straight off the compiler
+  // rather than through the diagram endpoint, and a drawing that skipped the
+  // defaults would differ from the same program once it is deployed.
+  return check.preview
+    ? { ...check, preview: assertDiagramSnapshot(check.preview) }
+    : check;
 }
 
 export async function startRun(

--- a/web/app/studio.tsx
+++ b/web/app/studio.tsx
@@ -171,6 +171,11 @@ export function Studio({
    * the newest one asked for, which is the actual question.
    */
   const checkTokenRef = useRef(0);
+  // Read by the check, which must not re-run every time a run advances.
+  const runRef = useRef<RunRecord | null>(null);
+  useEffect(() => {
+    runRef.current = run;
+  }, [run]);
 
   /**
    * What the tag being shown touches: the ports carrying a value and the
@@ -517,6 +522,14 @@ export function Studio({
         .then((result) => {
           if (!current()) return;
           setSourceErrors(result.ok ? [] : (result.errors ?? []));
+          // The drawing follows the text. Only while the program compiles: a
+          // half-typed one has no topology to draw, and blanking the diagram on
+          // every transient error would make it flicker for the whole of an
+          // edit. And only until a run exists, after which the diagram belongs
+          // to what is running rather than to what has since been typed.
+          if (result.ok && result.preview && runRef.current === null) {
+            setSnapshot(result.preview);
+          }
           setSteps(result.steps ?? []);
           setTruncated(result.truncated ?? false);
           // A recomputed projection replaces the tail, so a hand-held position

--- a/web/tests/e2e/flow.spec.ts
+++ b/web/tests/e2e/flow.spec.ts
@@ -1257,6 +1257,51 @@ test("the timeline projects a program before anything is deployed", async ({
   await expect(timeline).toBeHidden();
 });
 
+test("the diagram follows the text", async ({ page }) => {
+  // An editor whose drawing lags the text is showing a program that no longer
+  // exists. The client has no compiler, so the drawing is the one the daemon
+  // compiles from what has been typed.
+  await useFakeServe(page);
+  await draftUntilProposed(page);
+
+  const title = page.locator(".diagram-heading h2");
+  await expect(title).toHaveText("ReviewFlow");
+
+  await page.getByRole("button", { name: "Show the source pane" }).click();
+  const editor = page.getByLabel("OMAR program");
+  await expect(editor).toBeVisible();
+  const source = await editor.inputValue();
+  await editor.fill(source.replace(/\bmain\b/, "main Renamed"));
+
+  // No deploy, no reload: the drawing is recompiled from the text on the pause
+  // in typing, and says so.
+  await expect(title).toHaveText("Renamed");
+
+  // A half-typed program has no topology to draw. The last good drawing stays
+  // rather than the diagram blanking for the whole of an edit.
+  await editor.fill("team Broken {");
+  await expect(page.locator(".source-errors")).toBeVisible();
+  await expect(title).toHaveText("Renamed");
+
+  // Once a run exists the drawing belongs to it. Deploying happens moments
+  // after the last edit, so a check can still be in flight when it does -- and
+  // an answer that lands afterwards describes text, not the run. Held open here
+  // to make that ordering certain rather than lucky.
+  await page.route("**/v1/programs/check", async (route) => {
+    await new Promise((resume) => setTimeout(resume, 2000));
+    await route.continue();
+  });
+  await editor.fill(source.replace(/\bmain\b/, "main Stale"));
+  await deploy(page);
+
+  const stats = page.locator(".run-stats");
+  await expect(stats).toContainText(/running|completed/);
+  // Past when the held-open check resolves. The run is what is drawn.
+  await page.waitForTimeout(3000);
+  await expect(title).not.toHaveText("Stale");
+  await expect(stats).not.toContainText("ready");
+});
+
 test("the assistant's terminal opens from the wait, not from a menu", async ({
   page,
 }) => {

--- a/web/tests/fake-serve.mjs
+++ b/web/tests/fake-serve.mjs
@@ -383,11 +383,18 @@ export async function startFakeServe({
         ],
       });
     }
+    // The daemon reports the team the program declares: the name on `main` when
+    // it carries one, and the file's own stem otherwise. Not a compiler, but
+    // enough of one that the answer depends on the text -- which is the whole
+    // of what a drawing following the editor relies on.
+    const declared =
+      request.program.match(/\bmain\s+([A-Za-z_]\w*)/)?.[1] ??
+      filename.replace(/\.omar$/, "");
     const answer = {
       ok: true,
-      team: golden.team,
+      team: declared,
       open_inputs: openInputsOf(golden).map((port) => port.name),
-      preview: structuredClone(golden),
+      preview: { ...structuredClone(golden), team: declared },
     };
     // Only when asked, as the daemon does: a caller that wants validity alone
     // gets no timeline, and a client that reads one it did not ask for would


### PR DESCRIPTION
Rebased onto `main` at `fa87dcc`, now that #205 and #195 have both landed. Targets `main` directly.

An editor whose diagram lags the text is showing a program that no longer exists. This makes the drawing follow the editor — and fixes the reason it couldn't.

## The layout was the cost, not the drawing

`ec72de0` took this feature out of #195 with a measurement: *"Replacing the snapshot on every check re-ran the layout for a drawing that had not changed. The browser suite went from 50 seconds to 25 minutes."*

That was ELK, not rendering. `computeLayout` runs ELK up to **four times** — once plain, then once per wrapping candidate — and the layout effect depended on the snapshot *object*, so every new snapshot paid all four. On every keystroke once the editor fed it.

It was already being paid on **every event of a live run**, where a port value had moved and not one box had. That cost has been there the whole time; the editor only made it obvious.

So geometry is now computed against a key built from what the shape actually depends on, with the live fields blanked:

```ts
ports: snapshot.ports.map((port) => ({ ...port, value: null, last_tag: null })),
reactions: snapshot.reactions.map((r) => ({ ...r, status: "", invocation_id: null })),
```

Blanked rather than dropped, so a field added to the protocol later counts towards the shape until someone decides it is live. When the key matches, the cached ELK result is reused and only `buildLayout` re-runs — a pass over the nodes.

**Full suite: 46 tests in 49s.** One more test than before, and no slower.

## Two rules the drawing follows

**While it compiles.** A half-typed program has no topology, and blanking the diagram on every transient error would leave it flickering for the whole of an edit. The last good drawing stays.

**Until a run exists.** Deploying happens moments after the last edit, so a check can still be in flight when it does — and that answer describes the text, not the run. The test forces that ordering by holding the check open across a deploy; without the guard the live drawing is replaced by a preview that has never run.

I checked whether the guard was reachable before keeping it. It is not reachable by editing — the editor unmounts on deploy — and `presentKey` is built from *dangling inputs*, which are structural and cannot move during a run. The race is the one path that reaches it, which is why the test is written as a race.

## Server side

None needed. `check_program` has been returning `"preview": DiagramSnapshot::from_vm_state(&state)` since #195; only the client half was missing. `checkProgram` now runs it through `assertDiagramSnapshot`, as every other snapshot is — it arrives straight off the compiler rather than through the diagram endpoint, and one that skipped the defaults would differ from the same program once deployed.

## Test

`the diagram follows the text` — rename the program in the editor and the heading follows without a deploy; break it and the last good drawing stays; hold a check open across a deploy and the run keeps its diagram.

The fake daemon now derives the team from the program the way the daemon does (`main X`, else the file stem), so its answer depends on the text — which is the whole of what this relies on.

## Verification

46 browser tests in 49s; 12 web unit; 345 Rust; TypeScript, ESLint and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

