### PR TITLE
Bound every CI job, and stop waiting forever for the dpkg lock

### DIFF
--- a/.github/scripts/install-packages.sh
+++ b/.github/scripts/install-packages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Install packages the runner does not already have.
+#
+# `apt-get` competes with the unattended-upgrades already running on a fresh
+# GitHub runner for the dpkg lock, and by default it waits for that lock with no
+# bound. That is how installing tmux came to hold a job for six hours until the
+# 6h ceiling killed it, twice in one day, on a package the job needs for about a
+# minute of work.
+#
+# Three guards, in the order they help:
+#   - skip entirely when the tool is already on the image, which is the common
+#     case and costs nothing;
+#   - bound the wait for the lock, so a contended runner fails in two minutes
+#     rather than occupying one for six hours;
+#   - say up front that nothing may prompt, since a prompt behind `-y` waits
+#     for input that is never coming.
+#
+# Takes command names, not package names. Every package we install is named
+# after the binary it provides; one that is not would need looking up here.
+set -euo pipefail
+
+missing=()
+for command in "$@"; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    missing+=("$command")
+  fi
+done
+
+if [ ${#missing[@]} -eq 0 ]; then
+  echo "already present: $*"
+  exit 0
+fi
+
+echo "installing: ${missing[*]}"
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get -o DPkg::Lock::Timeout=120 update
+sudo apt-get -o DPkg::Lock::Timeout=120 install -y "${missing[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -37,6 +38,7 @@ jobs:
   fmt:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -51,6 +53,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -76,6 +79,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -83,7 +87,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        run: .github/scripts/install-packages.sh tmux
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -102,6 +106,7 @@ jobs:
   omar-language:
     name: OMAR Language
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -220,6 +225,7 @@ jobs:
   popup-quote-integration:
     name: Popup Quote Integration
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -227,7 +233,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install tmux and zsh
-        run: sudo apt-get update && sudo apt-get install -y tmux zsh
+        run: .github/scripts/install-packages.sh tmux zsh
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -249,6 +255,7 @@ jobs:
   unresolved-session-integration:
     name: Unresolved Session Integration
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -256,7 +263,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        run: .github/scripts/install-packages.sh tmux
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -278,6 +285,7 @@ jobs:
   codex-yolo-integration:
     name: Codex YOLO Integration
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -285,7 +293,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        run: .github/scripts/install-packages.sh tmux
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -307,6 +315,7 @@ jobs:
   ea-zero-selector-integration:
     name: EA Zero Selector Integration
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -314,7 +323,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        run: .github/scripts/install-packages.sh tmux
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -336,6 +345,7 @@ jobs:
   dashboard-relaunch-handoff-integration:
     name: Dashboard Relaunch Handoff Integration
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -343,7 +353,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        run: .github/scripts/install-packages.sh tmux
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -365,6 +375,7 @@ jobs:
   opencode-compat:
     name: Opencode Compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -372,7 +383,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        run: .github/scripts/install-packages.sh tmux
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -406,6 +417,7 @@ jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -443,6 +455,7 @@ jobs:
     name: CI Success
     needs: [check, fmt, clippy, test, omar-language, popup-quote-integration, unresolved-session-integration, codex-yolo-integration, ea-zero-selector-integration, dashboard-relaunch-handoff-integration, opencode-compat, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: always()
     steps:
       - name: Check all jobs passed

--- a/.github/workflows/opencode-nightly.yml
+++ b/.github/workflows/opencode-nightly.yml
@@ -30,7 +30,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux curl
+        run: .github/scripts/install-packages.sh tmux curl
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
             target: x86_64-apple-darwin
             suffix: darwin-amd64
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -50,7 +51,7 @@ jobs:
 
       - name: Install tmux (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        run: .github/scripts/install-packages.sh tmux
 
       # Mission Control is embedded in the binary, so it is built before the
       # runtime that carries it. Without this the release ships an `omar` whose
@@ -99,6 +100,7 @@ jobs:
     name: Publish Release
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/download-artifact@v4
 
@@ -121,6 +123,7 @@ jobs:
     name: Update Homebrew Formula
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/download-artifact@v4
 

--- a/.github/workflows/topology-ci-test.yml
+++ b/.github/workflows/topology-ci-test.yml
@@ -48,7 +48,7 @@ jobs:
           test: false
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        run: .github/scripts/install-packages.sh tmux
 
       - name: Cache Cargo dependencies
         uses: actions/cache@v4

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -59,7 +59,7 @@ jobs:
         run: cargo build --bin omar
         working-directory: .
       # Topology agents run in tmux panes, so a real run needs one.
-      - run: sudo apt-get update && sudo apt-get install -y tmux
+      - run: .github/scripts/install-packages.sh tmux
         working-directory: .
       - run: npm ci
       # Probes the runtime for the features it needs and skips what is missing,
@@ -83,7 +83,7 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - uses: dtolnay/rust-toolchain@stable
       # `omar serve` launches the assistant in a tmux pane.
-      - run: sudo apt-get update && sudo apt-get install -y tmux
+      - run: .github/scripts/install-packages.sh tmux
         working-directory: .
       - run: npm ci
       - name: Start both, check both, stop both


### PR DESCRIPTION
## What broke

`Install tmux` held a job on `main` for **six hours** before the 6h ceiling killed it:

```
X Unresolved Session Integration in 6h0m14s
  ✓ Install Rust toolchain
  X Install tmux              ← six hours here
  - Build omar                ← never ran
  - Run unresolved session integration
```

Every other job on that commit passed. `CI Success` then failed because one job had not, so `main` is red on a step that installs a package it needs for about a minute of work.

The same step did it again the same day on #206's Web Conformance, taking that job's whole 45 minutes. Third time this session counting the Playwright browser download.

## Why it waits rather than fails

A fresh GitHub runner is already running `unattended-upgrades`. `apt-get` competes with it for the dpkg lock and, by default, **waits for that lock with no bound**. Losing the race is not an error, so nothing fails — the job's ceiling is the only thing that ends it.

`ci.yml` had no ceiling on any of its thirteen jobs, and `release.yml` none on its three. That is the difference between a six-hour job and a twenty-minute one.

## The fix

Twelve copies of `sudo apt-get update && sudo apt-get install -y tmux` across six workflows, so one script instead — `.github/scripts/install-packages.sh`:

- **Skip when the tool is already on the image.** The common case, and it costs nothing. Verified locally: `already present: tmux`.
- **Bound the lock wait** with `-o DPkg::Lock::Timeout=120`, so a contended runner fails in two minutes rather than occupying one for six hours.
- **`DEBIAN_FRONTEND=noninteractive`**, since a prompt behind `-y` is waiting for input that is never coming.

And a ceiling on every job in the repo. `web.yml`, `opencode-nightly.yml` and `topology-ci-test.yml` already had one; `ci.yml` and `release.yml` now do too:

| workflow | `runs-on` | `timeout-minutes` |
|---|---|---|
| ci.yml | 13 | 13 |
| release.yml | 3 | 3 |
| web.yml | 5 | 5 |
| opencode-nightly.yml | 1 | 1 |
| topology-ci-test.yml | 1 | 1 |

Ceilings are generous against observed durations — everything in `ci.yml` runs in one to two minutes and is bounded at 20 — so a slow runner is not failed, but a hang is noticed the same hour it happens.

## Verification

This PR's own CI is the test: every job here installs tmux through the new script. Beyond that the change is workflow configuration, which nothing but a real run exercises.