### PR TITLE
Release 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "bridges/slack", "bridges/computer"]
 
 [package]
 name = "omar"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Agent dashboard for tmux"
 license = "MIT"


### PR DESCRIPTION
Version bump for 0.4.1. One line: `Cargo.toml`. `Cargo.lock` is gitignored, so it does not appear.

Tagging `v0.4.1` after this lands is what builds and publishes the artifacts — `release.yml` triggers on `v*`.

## Since 0.4.0

- **#205** — ports carry Lingua Franca's semantics: a plain connection costs nothing, `after 0` costs a microstep, and a tag runs to a fixpoint with a causality-loop check.
- **#195** — the editor shows the tags a program will pass through before anything is deployed.
- **#206** — the diagram follows the text as it is edited, and the layout runs only when the shape changes.
- **#218** — CI stopped waiting six hours for a package install, and every job now has a ceiling.

## Note on the README

The Quick Start's `omar serve --ui` is left as it is. The flag exists, is documented in `omar serve --help`, and works on both paths the README describes: `make install` runs `cargo build --release --features ui`, and `release.yml` builds published binaries the same way. It hard-errors only on a plain `cargo build`, which does not embed the Mission Control bundle:

```
Error: This build has no UI in it. Build one with:
  (cd web && npm install && npm run build:spa)
  cargo build --release --features ui
```

So anyone installing 0.4.1 from a release or from `make install` gets a working `--ui`.