### PR TITLE
Let the tap update run twice, and check the token when it has nothing to push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,5 +182,22 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/omar.rb
+
+          TAP="https://x-access-token:${GH_TOKEN}@github.com/omar-os/homebrew-omar.git"
+          if git diff --cached --quiet; then
+            # The formula already says this. A re-run of the job, or a release
+            # whose tap someone updated by hand. `git commit` fails on an empty
+            # commit, which reads as a broken release rather than as nothing to
+            # do -- and under `set -e` takes the job with it.
+            #
+            # Still reach the remote, because "nothing to push" must not become
+            # the one case that never checks the credential. Ref discovery
+            # authenticates, so a dead token fails here rather than silently
+            # holding the tap a version back until someone runs `brew`.
+            echo "formula already at ${VERSION}"
+            git push --dry-run "$TAP" HEAD:main
+            exit 0
+          fi
+
           git commit -m "update omar to ${VERSION}"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/omar-os/homebrew-omar.git" HEAD:main
+          git push "$TAP" HEAD:main


### PR DESCRIPTION
Two releases in a row published their artifacts and left Homebrew a version behind. The token was the first cause, and it has been replaced. This is the second.

## The bug

```bash
git add Formula/omar.rb
git commit -m "update omar to ${VERSION}"    # fails when nothing changed
git push ...
```

`git commit` exits non-zero on an empty commit, and the step runs under `set -e`. So a tap that already carries the version being released fails the job — a re-run, or a release whose formula someone updated by hand, reported as a broken release rather than as nothing to do.

**That is live right now.** I pushed 0.4.1 to the tap by hand after the token failed, so the very next run of this job would have failed on the empty commit and looked exactly like another token problem.

## The fix

Nothing to commit is now nothing to commit — but it still reaches the remote:

```bash
if git diff --cached --quiet; then
  echo "formula already at ${VERSION}"
  git push --dry-run "$TAP" HEAD:main
  exit 0
fi
```

The dry run is the point. "The formula is already right" must not become the one path that never exercises the credential: ref discovery authenticates, so a dead token fails *here*, at release time, rather than holding the tap a version back until someone runs `brew` and wonders why they got the old one. That is precisely how the last two releases went quiet.

## Verified

Against the real tap, which is currently at 0.4.1 — the case that used to fail:

```
TAKES the already-current branch (correct)
Everything up-to-date
dry-run push reached the remote and exited 0
```

and with the formula edited, so the normal path is intact:

```
TAKES the commit path (correct)
```

## Still worth doing separately

A PAT expires; this one lasted five months. A deploy key on `omar-os/homebrew-omar` with write access does not, and scopes to that one repo. It needs a key created and a secret set, which is not something a PR can do — happy to make the `release.yml` half whenever you want it.