### PR TITLE
Bound the apt that Playwright runs, and stop refetching the browser

### DIFF
--- a/.github/scripts/bound-apt.sh
+++ b/.github/scripts/bound-apt.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Stop apt waiting forever for the dpkg lock, whoever runs it.
+#
+# A fresh GitHub runner is already running unattended-upgrades, and apt waits
+# for the lock unbounded by default -- so losing that race is not an error, it
+# is a hang, and the job's ceiling is the only thing that ends it.
+#
+# Configured on the runner rather than passed at the call site, because the apt
+# that hangs most is not ours: `playwright install --with-deps` shells out to
+# apt several layers down and takes no flags from us. A file here reaches that
+# one too.
+set -euo pipefail
+
+sudo tee /etc/apt/apt.conf.d/99-omar-ci >/dev/null <<'CONF'
+DPkg::Lock::Timeout "120";
+Acquire::Retries "3";
+CONF
+
+echo "apt: lock wait bounded at 120s, 3 retries on fetch"

--- a/.github/scripts/install-packages.sh
+++ b/.github/scripts/install-packages.sh
@@ -32,6 +32,9 @@ if [ ${#missing[@]} -eq 0 ]; then
 fi
 
 echo "installing: ${missing[*]}"
+# One definition of the bound, applied to every apt on this runner rather than
+# only the two below.
+"$(dirname "$0")/bound-apt.sh"
 export DEBIAN_FRONTEND=noninteractive
-sudo apt-get -o DPkg::Lock::Timeout=120 update
-sudo apt-get -o DPkg::Lock::Timeout=120 install -y "${missing[@]}"
+sudo apt-get update
+sudo apt-get install -y "${missing[@]}"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -110,6 +110,18 @@ jobs:
       - name: Build the runtime with the UI in it
         run: cargo build --bin omar --features ui
         working-directory: .
+      # `--with-deps` shells out to apt for the browser's shared libraries, and
+      # that apt is the one that has hung this job to its ceiling twice. It
+      # takes no flags from us, so the bound goes on the runner.
+      - name: Bound apt's wait for the dpkg lock
+        run: .github/scripts/bound-apt.sh
+        working-directory: .
+      # The browser is ~150MB from a CDN and changes only when Playwright does.
+      - name: Cache the browser
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
       - run: npx playwright install --with-deps chromium
       - run: npm run test:serve-ui
 
@@ -125,6 +137,18 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: npm ci
+      # `--with-deps` shells out to apt for the browser's shared libraries, and
+      # that apt is the one that has hung this job to its ceiling twice. It
+      # takes no flags from us, so the bound goes on the runner.
+      - name: Bound apt's wait for the dpkg lock
+        run: .github/scripts/bound-apt.sh
+        working-directory: .
+      # The browser is ~150MB from a CDN and changes only when Playwright does.
+      - name: Cache the browser
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
       - run: npx playwright install --with-deps chromium
       # Drives prompt -> design -> confirm -> spawn -> finished against a fake
       # `omar serve`. No model, no Lean toolchain, no tmux.


### PR DESCRIPTION
`npx playwright install --with-deps chromium` has now hung a job to its ceiling twice — Web E2E at 20 minutes, Web Serve UI at 30. Neither ran a test. The most recent is on #220, which is otherwise 18/19 green.

```
X Web Serve UI in 30m20s
  ✓ Build the runtime with the UI in it
  X Run npx playwright install --with-deps chromium     ← thirty minutes here
  - Run npm run test:serve-ui                            ← never ran
```

## Why #218 did not already fix this

#218 bounded the apt calls *written in the workflows*. This is not one of them.

`--with-deps` shells out to apt from inside Playwright, several layers down, and takes no flags from us. So the bound cannot go at the call site — it goes on the runner:

```bash
sudo tee /etc/apt/apt.conf.d/99-omar-ci <<'CONF'
DPkg::Lock::Timeout "120";
Acquire::Retries "3";
CONF
```

That file governs every apt on the box, ours and Playwright's alike. `install-packages.sh` now applies it rather than passing `-o DPkg::Lock::Timeout` itself, so there is one definition of what the bound is instead of two that can drift.

## The other half

The browser is ~150MB from a CDN, it changes only when Playwright does, and both jobs were refetching it every run. Now cached, keyed on `web/package-lock.json` so a Playwright upgrade fetches a fresh one.

Between them: a contended dpkg lock fails in two minutes instead of hanging, and most runs skip the download entirely.

## Scope

This is the third distinct hang from the same root cause — unattended-upgrades holding the dpkg lock on a fresh runner while apt waits for it unbounded. #218 fixed the direct calls and added the ceilings that turn these into 20-minute failures rather than 6-hour ones. This closes the indirect one.

Verified locally that `install-packages.sh tmux` still short-circuits on an already-present package without reaching sudo.