### PR TITLE
Fix: enable tungstenite's handshake feature explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tracing = "0.1.44"
 # Terminal attach. `tungstenite` is the sync API, which matches the blocking
 # thread-per-connection model `omar serve` already uses; TLS is off because the
 # server binds loopback only.
-tungstenite = { version = "0.24", default-features = false }
+tungstenite = { version = "0.24", default-features = false, features = ["handshake"] }
 portable-pty = "0.8"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- `Cargo.toml` disables tungstenite's default features, but `src/serve.rs` uses `tungstenite::handshake::derive_accept_key`, which lives behind the `handshake` feature
- It only compiled because `bridges/slack`'s `tokio-tungstenite` dependency happens to unify the `handshake` feature across the workspace when building via `cargo build --bin omar` (what CI does) — but `cargo build -p omar` and `cargo install --path .` build the package in isolation and fail with `cannot find handshake in tungstenite`
- Fix: request `features = ["handshake"]` explicitly so the root crate doesn't rely on an unrelated crate's transitive feature unification

## Test plan
- [x] `cargo build -p omar --bin omar` succeeds (previously failed with `E0433`)
- [x] `cargo fmt --check` passes
- [ ] CI (`cargo build --bin omar`, `cargo test`) — was already passing before this change and should remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)