### PR TITLE
Give codex a side channel, and a home of its own

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -43,6 +43,11 @@ pub enum Channel {
     /// model but not rendered in the transcript, and `noReply` seats it
     /// without starting a turn.
     OpencodeHttp { port: u16, session: String },
+    /// codex's app-server. `thread/inject_items` appends to the thread the
+    /// pane's TUI is showing without starting a turn and without drawing
+    /// anything, so the agent reads the event on its next turn and the
+    /// composer never moves.
+    CodexAppServer { socket: PathBuf },
     /// A file the backend's own hook drains into model context.
     ///
     /// cursor-agent and antigravity take no message from outside, but both run
@@ -148,6 +153,14 @@ impl Channel {
                     return None;
                 }
             }
+            // A pane that has exited takes its app-server with it. Answering
+            // with a channel whose socket is gone only costs the caller a
+            // round trip before it falls back.
+            if let Channel::CodexAppServer { socket } = &channel {
+                if !socket.exists() {
+                    return None;
+                }
+            }
             return Some(channel);
         }
         match backend {
@@ -174,6 +187,9 @@ impl Channel {
             }
             "spool" => (!rest.is_empty()).then(|| Channel::Spool {
                 path: PathBuf::from(rest),
+            }),
+            "codex" => (!rest.is_empty()).then(|| Channel::CodexAppServer {
+                socket: PathBuf::from(rest),
             }),
             _ => None,
         }
@@ -210,6 +226,11 @@ impl Channel {
                 }
                 Ok(())
             }
+            Channel::CodexAppServer { socket } => {
+                let mut session = CodexSession::open(socket)?;
+                let thread = session.newest_thread()?;
+                session.inject(&thread, text)
+            }
             Channel::Spool { path } => {
                 if let Some(parent) = path.parent() {
                     std::fs::create_dir_all(parent).context("create spool directory")?;
@@ -230,6 +251,7 @@ impl Channel {
         match self {
             Channel::ClaudePeer { .. } => "claude peer socket",
             Channel::OpencodeHttp { .. } => "opencode http api",
+            Channel::CodexAppServer { .. } => "codex app-server",
             Channel::Spool { .. } => "hook spool",
         }
     }
@@ -409,17 +431,236 @@ pub fn provision_in_background(backend: Option<&str>, session: String, command: 
     // launched with a `--port`, and polling one of those for 90 seconds — then
     // stamping whatever answered as a delivery channel — would be worse than
     // having no channel at all.
-    if backend != Some("opencode") {
-        return;
-    }
-    let Some(port) = opencode_port(&command) else {
-        return;
+    let stamped: Box<dyn FnOnce() -> Option<String> + Send> = match backend {
+        Some("opencode") => match opencode_port(&command) {
+            Some(port) => Box::new(move || provision_opencode(port)),
+            None => return,
+        },
+        Some("codex") => match codex_home(&command) {
+            Some(home) => {
+                // Which pane this home belongs to, so a later launch can tell
+                // that the pane is gone and take the app-server with it.
+                let _ =
+                    std::fs::write(home.join(crate::manager::CODEX_HOME_SESSION_FILE), &session);
+                Box::new(move || provision_codex(&home))
+            }
+            None => return,
+        },
+        _ => return,
     };
     std::thread::spawn(move || {
-        if let Some(stamp) = provision_opencode(port) {
+        if let Some(stamp) = stamped() {
             let _ = crate::tmux::TmuxClient::new("").set_session_delivery(&session, &stamp);
         }
     });
+}
+
+/// `CODEX_HOME=<dir>` as it appears in a launch command.
+///
+/// The launch command is where OMAR records which per-pane codex home this
+/// pane was given, the same way `--port` records opencode's port.
+pub(crate) fn codex_home(command: &str) -> Option<PathBuf> {
+    command
+        .split_whitespace()
+        .find_map(|token| token.strip_prefix("CODEX_HOME="))
+        // The assignment is one statement of several, single-quoted against
+        // spaces in the operator's home directory.
+        .map(|dir| PathBuf::from(dir.trim_end_matches(';').trim_matches('\'')))
+        .filter(|dir| !dir.as_os_str().is_empty())
+}
+
+/// Where a codex home's app-server listens.
+pub fn codex_socket_path(home: &Path) -> PathBuf {
+    home.join("app-server-control")
+        .join("app-server-control.sock")
+}
+
+/// Wait for a pane's app-server to come up with the TUI attached to it.
+///
+/// The socket file appears before the server is answering, and the server
+/// answers before the TUI has opened its thread — an empty thread list is the
+/// signal that the pane is not attached yet, so both are waited out here.
+fn provision_codex(home: &Path) -> Option<String> {
+    let socket = codex_socket_path(home);
+    let deadline = std::time::Instant::now() + PROVISION_TIMEOUT;
+    while std::time::Instant::now() < deadline {
+        if socket.exists()
+            && CodexSession::open(&socket)
+                .and_then(|mut session| session.newest_thread())
+                .is_ok()
+        {
+            return Some(format!("codex:{}", socket.display()));
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    None
+}
+
+/// The RFC 6455 example nonce.
+///
+/// The server's `Sec-WebSocket-Accept` is derived from this and we do not
+/// check it — there is no proxy or cache between two ends of a Unix socket to
+/// confuse — so a constant keeps the request a fixed string.
+const WS_NONCE: &str = "dGhlIHNhbXBsZSBub25jZQ==";
+
+/// A JSON-RPC conversation with a codex app-server.
+///
+/// The transport is a WebSocket over a Unix socket. The upgrade request is
+/// written by hand rather than through `tungstenite`'s client handshake, which
+/// is behind a feature this crate does not enable and which only speaks in
+/// terms of URLs — `src/serve.rs` answers the server half the same way.
+struct CodexSession {
+    socket: tungstenite::WebSocket<UnixStream>,
+    next_id: u64,
+}
+
+impl CodexSession {
+    /// Connect, upgrade, and complete the app-server's opening handshake.
+    fn open(path: &Path) -> Result<CodexSession> {
+        let mut stream =
+            UnixStream::connect(path).with_context(|| format!("connect to {}", path.display()))?;
+        stream.set_read_timeout(Some(WRITE_TIMEOUT))?;
+        stream.set_write_timeout(Some(WRITE_TIMEOUT))?;
+        stream
+            .write_all(
+                format!(
+                    "GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\n\
+                     Connection: Upgrade\r\nSec-WebSocket-Key: {}\r\n\
+                     Sec-WebSocket-Version: 13\r\n\r\n",
+                    WS_NONCE
+                )
+                .as_bytes(),
+            )
+            .context("send websocket upgrade")?;
+        stream.flush()?;
+
+        // One byte at a time so nothing past the header is swallowed — the
+        // first data frame may already be in the same read.
+        let mut header = Vec::new();
+        let mut byte = [0u8; 1];
+        while !header.ends_with(b"\r\n\r\n") {
+            if std::io::Read::read(&mut stream, &mut byte).context("read upgrade response")? == 0 {
+                anyhow::bail!("app-server closed during the upgrade");
+            }
+            header.push(byte[0]);
+            if header.len() > 4096 {
+                anyhow::bail!("app-server sent no upgrade response");
+            }
+        }
+        let header = String::from_utf8_lossy(&header);
+        if !header.starts_with("HTTP/1.1 101") {
+            anyhow::bail!(
+                "app-server refused the upgrade: {}",
+                header.lines().next().unwrap_or_default()
+            );
+        }
+
+        let mut session = CodexSession {
+            socket: tungstenite::WebSocket::from_raw_socket(
+                stream,
+                tungstenite::protocol::Role::Client,
+                None,
+            ),
+            next_id: 1,
+        };
+        session
+            .call(
+                "initialize",
+                serde_json::json!({
+                    "clientInfo": {
+                        "name": "omar",
+                        "title": "omar",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    }
+                }),
+            )
+            .context("initialize the app-server session")?;
+        session.notify("initialized")?;
+        Ok(session)
+    }
+
+    fn send(&mut self, message: serde_json::Value) -> Result<()> {
+        self.socket
+            .send(tungstenite::Message::Text(message.to_string()))
+            .context("write to the app-server")
+    }
+
+    fn notify(&mut self, method: &str) -> Result<()> {
+        self.send(serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": {},
+        }))
+    }
+
+    /// Send a request and read until its answer arrives.
+    ///
+    /// The server pushes notifications of its own down the same socket, so a
+    /// reply is found by id rather than by being the next message.
+    fn call(&mut self, method: &str, params: serde_json::Value) -> Result<serde_json::Value> {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.send(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }))?;
+
+        loop {
+            let message = self.socket.read().context("read from the app-server")?;
+            let tungstenite::Message::Text(body) = message else {
+                continue;
+            };
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(&body) else {
+                continue;
+            };
+            if value.get("id").and_then(serde_json::Value::as_u64) != Some(id) {
+                continue;
+            }
+            if let Some(error) = value.get("error") {
+                anyhow::bail!("{} failed: {}", method, error);
+            }
+            return Ok(value.get("result").cloned().unwrap_or_default());
+        }
+    }
+
+    /// The thread the pane is showing.
+    fn newest_thread(&mut self) -> Result<String> {
+        let listed = self.call("thread/loaded/list", serde_json::json!({}))?;
+        newest_thread(&listed).context("the pane's app-server has no loaded thread")
+    }
+
+    /// Append the event to a thread without starting a turn.
+    fn inject(&mut self, thread: &str, text: &str) -> Result<()> {
+        self.call(
+            "thread/inject_items",
+            serde_json::json!({
+                "threadId": thread,
+                "items": [{
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": text }],
+                }],
+            }),
+        )?;
+        Ok(())
+    }
+}
+
+/// Pick the thread an event belongs in out of a `thread/loaded/list` reply.
+///
+/// `/new` leaves the old thread loaded alongside the new one, and an event
+/// appended to the thread the user has moved on from is never read. Thread ids
+/// are UUIDv7, whose text order is creation order, so the largest is current.
+fn newest_thread(listed: &serde_json::Value) -> Option<String> {
+    listed
+        .get("data")?
+        .as_array()?
+        .iter()
+        .filter_map(|thread| thread.as_str())
+        .max()
+        .map(str::to_string)
 }
 
 /// `--port N` as it appears in a launch command.
@@ -936,6 +1177,199 @@ mod tests {
         }
     }
 
+    /// Play the app-server's half of one delivery and report what it was
+    /// asked, so the framing is checked against a real socket rather than a
+    /// string.
+    fn fake_app_server(listener: UnixListener, threads: Vec<&'static str>) -> Vec<String> {
+        let (mut stream, _) = listener.accept().unwrap();
+
+        let mut header = Vec::new();
+        let mut byte = [0u8; 1];
+        while !header.ends_with(b"\r\n\r\n") {
+            stream.read_exact(&mut byte).unwrap();
+            header.push(byte[0]);
+        }
+        let request = String::from_utf8_lossy(&header).into_owned();
+        let key = request
+            .lines()
+            .find_map(|line| line.strip_prefix("Sec-WebSocket-Key: "))
+            .expect("a websocket upgrade");
+        stream
+            .write_all(
+                format!(
+                    "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\
+                     Connection: Upgrade\r\nSec-WebSocket-Accept: {}\r\n\r\n",
+                    tungstenite::handshake::derive_accept_key(key.trim().as_bytes())
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+
+        let mut socket = tungstenite::WebSocket::from_raw_socket(
+            stream,
+            tungstenite::protocol::Role::Server,
+            None,
+        );
+        let answer = |socket: &mut tungstenite::WebSocket<UnixStream>,
+                      request: &serde_json::Value,
+                      result: serde_json::Value| {
+            let reply = serde_json::json!({ "id": request["id"], "result": result });
+            socket
+                .send(tungstenite::Message::Text(reply.to_string()))
+                .unwrap();
+        };
+
+        let mut asked = Vec::new();
+        loop {
+            let tungstenite::Message::Text(body) = socket.read().unwrap() else {
+                continue;
+            };
+            asked.push(body.clone());
+            let request: serde_json::Value = serde_json::from_str(&body).unwrap();
+            match request["method"].as_str().unwrap_or_default() {
+                "initialize" => {
+                    // The server talks unprompted; a reply is found by id, not
+                    // by being the next thing to arrive.
+                    socket
+                        .send(tungstenite::Message::Text(
+                            serde_json::json!({
+                                "method": "remoteControl/status/changed",
+                                "params": { "status": "disabled" },
+                            })
+                            .to_string(),
+                        ))
+                        .unwrap();
+                    answer(
+                        &mut socket,
+                        &request,
+                        serde_json::json!({ "userAgent": "codex-tui/0.147.0" }),
+                    );
+                }
+                "thread/loaded/list" => answer(
+                    &mut socket,
+                    &request,
+                    serde_json::json!({ "data": threads, "nextCursor": null }),
+                ),
+                "thread/inject_items" => {
+                    answer(&mut socket, &request, serde_json::json!({}));
+                    return asked;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn an_event_reaches_codex_as_an_injected_item_over_the_app_server_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("app-server-control.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            fake_app_server(
+                listener,
+                // `/new` leaves the old thread loaded next to the new one.
+                vec![
+                    "01a0204b-f2e8-73e3-b95a-09abf7616b22",
+                    "01a02051-f65b-7260-9afe-13ffe5229bf6",
+                ],
+            )
+        });
+
+        Channel::CodexAppServer {
+            socket: socket.clone(),
+        }
+        .deliver("CI went red on main")
+        .expect("deliver over the app-server");
+
+        let asked: Vec<serde_json::Value> = server
+            .join()
+            .unwrap()
+            .iter()
+            .map(|body| serde_json::from_str(body).unwrap())
+            .collect();
+        let methods: Vec<&str> = asked
+            .iter()
+            .map(|request| request["method"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            methods,
+            vec![
+                "initialize",
+                "initialized",
+                "thread/loaded/list",
+                "thread/inject_items"
+            ]
+        );
+
+        let inject = asked.last().unwrap();
+        assert_eq!(
+            inject["params"]["threadId"], "01a02051-f65b-7260-9afe-13ffe5229bf6",
+            "the event belongs in the thread the pane is showing"
+        );
+        let item = &inject["params"]["items"][0];
+        assert_eq!(item["role"], "user");
+        assert_eq!(item["content"][0]["text"], "CI went red on main");
+        // Every request is JSON-RPC; a notification carries no id.
+        assert_eq!(asked[1].get("id"), None);
+    }
+
+    #[test]
+    fn a_dead_app_server_is_a_failed_delivery_rather_than_a_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(Channel::CodexAppServer {
+            socket: dir.path().join("gone.sock"),
+        }
+        .deliver("standup in 5")
+        .is_err());
+    }
+
+    #[test]
+    fn a_codex_stamp_names_the_socket_to_inject_through() {
+        assert_eq!(
+            Channel::from_stamp("codex:/Users/ke/.omar/codex/ab12/app.sock"),
+            Some(Channel::CodexAppServer {
+                socket: PathBuf::from("/Users/ke/.omar/codex/ab12/app.sock")
+            })
+        );
+        assert_eq!(Channel::from_stamp("codex:"), None);
+    }
+
+    #[test]
+    fn a_codex_home_is_read_back_out_of_a_launch_command() {
+        assert_eq!(
+            codex_home("export CODEX_HOME='/Users/ke/.omar/codex/ab12'; codex --no-alt-screen"),
+            Some(PathBuf::from("/Users/ke/.omar/codex/ab12"))
+        );
+        assert_eq!(codex_home("codex --no-alt-screen"), None);
+        assert_eq!(codex_home("export CODEX_HOME=''; codex"), None);
+    }
+
+    #[test]
+    fn the_newest_thread_is_the_one_the_pane_is_showing() {
+        // Ids are UUIDv7, so their text order is creation order.
+        let listed = serde_json::json!({
+            "data": ["01a0204b-f2e8-73e3-b95a-09abf7616b22", "01a02051-f65b-7260-9afe-13ffe5229bf6"],
+        });
+        assert_eq!(
+            newest_thread(&listed).as_deref(),
+            Some("01a02051-f65b-7260-9afe-13ffe5229bf6")
+        );
+        // A pane whose TUI has not opened a thread yet is not a channel.
+        assert_eq!(newest_thread(&serde_json::json!({ "data": [] })), None);
+        assert_eq!(newest_thread(&serde_json::json!({})), None);
+    }
+
+    #[test]
+    fn a_pane_that_is_gone_takes_its_app_server_with_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("app.sock");
+        let stamp = format!("codex:{}", socket.display());
+        assert_eq!(Channel::resolve("codex", 0, Some(&stamp)), None);
+
+        let _listener = UnixListener::bind(&socket).unwrap();
+        assert!(Channel::resolve("codex", 0, Some(&stamp)).is_some());
+    }
+
     #[test]
     fn a_spool_stamp_round_trips() {
         assert_eq!(
@@ -948,19 +1382,25 @@ mod tests {
     }
 
     #[test]
-    fn only_opencode_is_provisioned_however_the_command_is_written() {
+    fn provisioning_is_gated_on_the_backend_not_on_the_command() {
         // Plenty of things are launched with a `--port` — tunnels, notebook
         // servers, tensorboard. Polling one of those and then stamping
         // whatever answered as a delivery channel would send events into it.
+        // The same goes for an inherited `CODEX_HOME`.
         assert_eq!(opencode_port("tensorboard --port 6006"), Some(6006));
-        for backend in [None, Some("claude"), Some("codex"), Some("cursor")] {
+        assert!(codex_home("export CODEX_HOME=/somewhere; jupyter lab").is_some());
+        for backend in [None, Some("claude"), Some("cursor"), Some("agy")] {
             // Nothing is spawned and nothing is stamped: the guard is on the
             // backend, and the flag alone must never be enough.
             provision_in_background(
                 backend,
                 "unused-session".to_string(),
-                "tensorboard --port 6006".to_string(),
+                "export CODEX_HOME=/somewhere; tensorboard --port 6006".to_string(),
             );
+        }
+        // And a backend that is provisioned still needs its command to say so.
+        for backend in [Some("opencode"), Some("codex")] {
+            provision_in_background(backend, "unused-session".to_string(), "bare".to_string());
         }
     }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -506,8 +506,8 @@ const WS_NONCE: &str = "dGhlIHNhbXBsZSBub25jZQ==";
 /// A JSON-RPC conversation with a codex app-server.
 ///
 /// The transport is a WebSocket over a Unix socket. The upgrade request is
-/// written by hand rather than through `tungstenite`'s client handshake, which
-/// is behind a feature this crate does not enable and which only speaks in
+/// written by hand rather than through `tungstenite::connect`, which is behind
+/// a feature this crate's own manifest turns off and which only speaks in
 /// terms of URLs — `src/serve.rs` answers the server half the same way.
 struct CodexSession {
     socket: tungstenite::WebSocket<UnixStream>,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -228,7 +228,7 @@ impl Channel {
             }
             Channel::CodexAppServer { socket } => {
                 let mut session = CodexSession::open(socket)?;
-                let thread = session.newest_thread()?;
+                let thread = session.only_thread()?;
                 session.inject(&thread, text)
             }
             Channel::Spool { path } => {
@@ -439,9 +439,8 @@ pub fn provision_in_background(backend: Option<&str>, session: String, command: 
         Some("codex") => match codex_home(&command) {
             Some(home) => {
                 // Which pane this home belongs to, so a later launch can tell
-                // that the pane is gone and take the app-server with it.
-                let _ =
-                    std::fs::write(home.join(crate::manager::CODEX_HOME_SESSION_FILE), &session);
+                // that it is finished and reclaim the disk.
+                crate::manager::claim_codex_home(&home, &session);
                 Box::new(move || provision_codex(&home))
             }
             None => return,
@@ -455,18 +454,40 @@ pub fn provision_in_background(backend: Option<&str>, session: String, command: 
     });
 }
 
-/// `CODEX_HOME=<dir>` as it appears in a launch command.
+/// `export CODEX_HOME='<dir>'` as it appears in a launch command.
 ///
 /// The launch command is where OMAR records which per-pane codex home this
 /// pane was given, the same way `--port` records opencode's port.
+///
+/// The value is read back through the quoting `shell_single_quote` put on it,
+/// rather than split on whitespace: an operator whose home directory has a
+/// space in it is ordinary, and half a path here is worse than none. A path
+/// that does not come back whole yields `None`, so provisioning is skipped and
+/// the pane falls back to the input box.
 pub(crate) fn codex_home(command: &str) -> Option<PathBuf> {
-    command
-        .split_whitespace()
-        .find_map(|token| token.strip_prefix("CODEX_HOME="))
-        // The assignment is one statement of several, single-quoted against
-        // spaces in the operator's home directory.
-        .map(|dir| PathBuf::from(dir.trim_end_matches(';').trim_matches('\'')))
-        .filter(|dir| !dir.as_os_str().is_empty())
+    let assignment = command.split_once("export CODEX_HOME=")?.1;
+    let dir = unquote_single(assignment)?;
+    (!dir.is_empty()).then(|| PathBuf::from(dir))
+}
+
+/// Undo `shell_single_quote`: read one `'...'` word, in which a literal quote
+/// appears as `'\''`.
+fn unquote_single(text: &str) -> Option<String> {
+    let mut rest = text.strip_prefix('\'')?;
+    let mut out = String::new();
+    loop {
+        let (chunk, tail) = rest.split_once('\'')?;
+        out.push_str(chunk);
+        match tail.strip_prefix("\\''") {
+            // An escaped quote: the word continues.
+            Some(tail) => {
+                out.push('\'');
+                rest = tail;
+            }
+            // Anything else closes the word.
+            None => return Some(out),
+        }
+    }
 }
 
 /// Where a codex home's app-server listens.
@@ -486,7 +507,7 @@ fn provision_codex(home: &Path) -> Option<String> {
     while std::time::Instant::now() < deadline {
         if socket.exists()
             && CodexSession::open(&socket)
-                .and_then(|mut session| session.newest_thread())
+                .and_then(|mut session| session.only_thread())
                 .is_ok()
         {
             return Some(format!("codex:{}", socket.display()));
@@ -625,10 +646,10 @@ impl CodexSession {
         }
     }
 
-    /// The thread the pane is showing.
-    fn newest_thread(&mut self) -> Result<String> {
+    /// The thread the pane is showing, when that is unambiguous.
+    fn only_thread(&mut self) -> Result<String> {
         let listed = self.call("thread/loaded/list", serde_json::json!({}))?;
-        newest_thread(&listed).context("the pane's app-server has no loaded thread")
+        only_thread(&listed).context("the pane has no single loaded thread to inject into")
     }
 
     /// Append the event to a thread without starting a turn.
@@ -648,19 +669,25 @@ impl CodexSession {
     }
 }
 
-/// Pick the thread an event belongs in out of a `thread/loaded/list` reply.
+/// The thread an event belongs in, out of a `thread/loaded/list` reply — and
+/// only when there is no doubt which that is.
 ///
-/// `/new` leaves the old thread loaded alongside the new one, and an event
-/// appended to the thread the user has moved on from is never read. Thread ids
-/// are UUIDv7, whose text order is creation order, so the largest is current.
-fn newest_thread(listed: &serde_json::Value) -> Option<String> {
-    listed
-        .get("data")?
-        .as_array()?
-        .iter()
-        .filter_map(|thread| thread.as_str())
-        .max()
-        .map(str::to_string)
+/// The app-server will say which threads a pane has loaded but not which one
+/// it is showing, and neither creation order nor activity separates them:
+/// `/new` leaves the old thread loaded under a newer id, and `/resume` puts
+/// the pane back on an *older* id while the abandoned new one stays loaded. A
+/// guess that lands on the thread the user has moved on from is delivered,
+/// acknowledged, and never read.
+///
+/// So OMAR only claims a channel it is sure of. More than one loaded thread
+/// means no channel, and delivery goes back through the input box — which
+/// since the draft is protected is a working path, not a failure.
+fn only_thread(listed: &serde_json::Value) -> Option<String> {
+    let threads = listed.get("data")?.as_array()?;
+    match threads.as_slice() {
+        [only] => only.as_str().map(str::to_string),
+        _ => None,
+    }
 }
 
 /// `--port N` as it appears in a launch command.
@@ -1265,14 +1292,7 @@ mod tests {
         let socket = dir.path().join("app-server-control.sock");
         let listener = UnixListener::bind(&socket).unwrap();
         let server = std::thread::spawn(move || {
-            fake_app_server(
-                listener,
-                // `/new` leaves the old thread loaded next to the new one.
-                vec![
-                    "01a0204b-f2e8-73e3-b95a-09abf7616b22",
-                    "01a02051-f65b-7260-9afe-13ffe5229bf6",
-                ],
-            )
+            fake_app_server(listener, vec!["01a02051-f65b-7260-9afe-13ffe5229bf6"])
         });
 
         Channel::CodexAppServer {
@@ -1345,18 +1365,85 @@ mod tests {
     }
 
     #[test]
-    fn the_newest_thread_is_the_one_the_pane_is_showing() {
-        // Ids are UUIDv7, so their text order is creation order.
-        let listed = serde_json::json!({
+    fn a_home_under_a_directory_with_a_space_comes_back_whole() {
+        // Read back through the quoting rather than split on whitespace. Half
+        // a path parses as a plausible home, and provisioning would then claim
+        // and poll somewhere the pane never was — while the pane's real home,
+        // never claimed, ages into the prune.
+        for home in [
+            "/Users/ke/My Home/.omar/codex/ab12",
+            "/Users/ke/it's mine/.omar/codex/ab12",
+            "/Users/ke/two  spaces/ab12",
+        ] {
+            let command = format!(
+                "export CODEX_HOME={}; codex app-server --listen unix://",
+                crate::manager::shell_single_quote(home)
+            );
+            assert_eq!(
+                codex_home(&command),
+                Some(PathBuf::from(home)),
+                "in {command}"
+            );
+        }
+        // A word that never closes is not a path worth guessing at.
+        assert_eq!(
+            codex_home("export CODEX_HOME='/Users/ke/unterminated"),
+            None
+        );
+    }
+
+    #[test]
+    fn an_event_goes_only_to_a_thread_there_is_no_doubt_about() {
+        let listed = serde_json::json!({ "data": ["01a0204b-f2e8-73e3-b95a-09abf7616b22"], "nextCursor": null });
+        assert_eq!(
+            only_thread(&listed).as_deref(),
+            Some("01a0204b-f2e8-73e3-b95a-09abf7616b22")
+        );
+
+        // Two loaded threads and the app-server will not say which the pane is
+        // showing. Creation order does not settle it: `/new` moves the pane to
+        // the newer id, `/resume` moves it back to the older one while the
+        // abandoned new thread stays loaded. Guessing wrong is delivered,
+        // acknowledged, and never read — so OMAR declines and the event goes
+        // through the input box instead.
+        let ambiguous = serde_json::json!({
             "data": ["01a0204b-f2e8-73e3-b95a-09abf7616b22", "01a02051-f65b-7260-9afe-13ffe5229bf6"],
         });
-        assert_eq!(
-            newest_thread(&listed).as_deref(),
-            Some("01a02051-f65b-7260-9afe-13ffe5229bf6")
-        );
+        assert_eq!(only_thread(&ambiguous), None);
+
         // A pane whose TUI has not opened a thread yet is not a channel.
-        assert_eq!(newest_thread(&serde_json::json!({ "data": [] })), None);
-        assert_eq!(newest_thread(&serde_json::json!({})), None);
+        assert_eq!(only_thread(&serde_json::json!({ "data": [] })), None);
+        assert_eq!(only_thread(&serde_json::json!({})), None);
+    }
+
+    #[test]
+    fn an_ambiguous_pane_reports_a_failure_rather_than_injecting_somewhere() {
+        // The caller's cue to fall back is an error. Returning `Ok` after
+        // injecting into a thread nobody is reading would lose the event with
+        // no sign that anything went wrong.
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("app-server-control.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            fake_app_server(
+                listener,
+                vec![
+                    "01a0204b-f2e8-73e3-b95a-09abf7616b22",
+                    "01a02051-f65b-7260-9afe-13ffe5229bf6",
+                ],
+            )
+        });
+
+        let failure = Channel::CodexAppServer {
+            socket: socket.clone(),
+        }
+        .deliver("CI went red")
+        .expect_err("two loaded threads must not be guessed between");
+        assert!(
+            failure.to_string().contains("no single loaded thread"),
+            "unexpected error: {failure}"
+        );
+        drop(server);
     }
 
     #[test]
@@ -1388,14 +1475,14 @@ mod tests {
         // whatever answered as a delivery channel would send events into it.
         // The same goes for an inherited `CODEX_HOME`.
         assert_eq!(opencode_port("tensorboard --port 6006"), Some(6006));
-        assert!(codex_home("export CODEX_HOME=/somewhere; jupyter lab").is_some());
+        assert!(codex_home("export CODEX_HOME='/somewhere'; jupyter lab").is_some());
         for backend in [None, Some("claude"), Some("cursor"), Some("agy")] {
             // Nothing is spawned and nothing is stamped: the guard is on the
             // backend, and the flag alone must never be enough.
             provision_in_background(
                 backend,
                 "unused-session".to_string(),
-                "export CODEX_HOME=/somewhere; tensorboard --port 6006".to_string(),
+                "export CODEX_HOME='/somewhere'; tensorboard --port 6006".to_string(),
             );
         }
         // And a backend that is provisioned still needs its command to say so.

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -474,6 +474,223 @@ fn codex_mcp_overrides(context: &McpLaunchContext) -> Option<String> {
     ))
 }
 
+/// The longest `sun_path` a Unix socket may have. macOS allows 104 bytes
+/// including the terminator; a per-pane codex home longer than that leaves the
+/// app-server unable to bind, so OMAR declines the side channel instead.
+const SUN_PATH_MAX: usize = 104;
+
+/// A codex home of OMAR's own, one per launched pane.
+///
+/// codex's TUI only attaches to an app-server when it is started with no
+/// config overrides at all, so everything OMAR needs to configure — the
+/// developer instructions, the OMAR MCP server, the directory trust record —
+/// has to be a `config.toml` rather than the `-c` flags it used to be. That
+/// file is per-pane because the MCP context file it names is per-agent, so the
+/// home holding it is per-pane too.
+///
+/// The name is a fresh id rather than anything derived from the pane: sibling
+/// workers under one EA share an MCP context, and two panes sharing one home
+/// would share one app-server and one ambiguous thread list.
+fn codex_home_dir(context: &McpLaunchContext) -> Option<PathBuf> {
+    // Short by design: `<home>/app-server-control/app-server-control.sock` has
+    // to fit in `sun_path`, and a session-shaped name would not.
+    let id = Uuid::new_v4().simple().to_string();
+    let dir = context.omar_dir.join("codex").join(&id[..12]);
+    let socket = crate::channel::codex_socket_path(&dir);
+    if socket.as_os_str().len() >= SUN_PATH_MAX {
+        return None;
+    }
+    prune_stale_codex_homes(&context.omar_dir.join("codex"));
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir)
+}
+
+/// Drop the codex homes — and the app-servers — of panes that are gone.
+///
+/// Each launch makes a new home, and codex fills it with several megabytes of
+/// state, so without this they accumulate for the life of the machine. The
+/// server matters more than the disk: `tmux kill-session` closes the pane's
+/// terminal without signalling anything in it, so the shell's own trap only
+/// fires when the TUI notices and exits, and an app-server can outlive its
+/// pane indefinitely.
+///
+/// A home is finished when the pane named in it is no longer a tmux session.
+/// One that names no pane yet is mid-launch, and is left alone until it is old
+/// enough that it plainly never got one.
+fn prune_stale_codex_homes(root: &Path) {
+    const GRACE: Duration = Duration::from_secs(3600);
+    let client = TmuxClient::new("");
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let pane = std::fs::read_to_string(path.join(CODEX_HOME_SESSION_FILE));
+        let finished = match &pane {
+            Ok(session) => !client.has_session(session.trim()).unwrap_or(true),
+            Err(_) => entry
+                .metadata()
+                .and_then(|meta| meta.modified())
+                .map(|modified| modified.elapsed().unwrap_or_default() >= GRACE)
+                .unwrap_or(false),
+        };
+        if !finished {
+            continue;
+        }
+        kill_codex_app_server(&path);
+        let _ = std::fs::remove_dir_all(&path);
+    }
+}
+
+/// Where the pane's shell records its app-server, and where provisioning
+/// records which tmux session the home belongs to.
+const CODEX_HOME_PID_FILE: &str = "app-server.pid";
+pub(crate) const CODEX_HOME_SESSION_FILE: &str = "omar-session";
+
+/// Stop the app-server a finished home left running.
+///
+/// The recorded pid is checked against what is actually running first: pids
+/// are reused, and killing whatever inherited this one would be far worse than
+/// leaving a server up.
+fn kill_codex_app_server(home: &Path) {
+    let Ok(pid) = std::fs::read_to_string(home.join(CODEX_HOME_PID_FILE)) else {
+        return;
+    };
+    let pid = pid.trim();
+    if pid.is_empty() || pid.parse::<u32>().is_err() {
+        return;
+    }
+    let running = std::process::Command::new("ps")
+        .args(["-p", pid, "-o", "command="])
+        .output()
+        .map(|out| String::from_utf8_lossy(&out.stdout).contains("app-server"))
+        .unwrap_or(false);
+    if running {
+        let _ = std::process::Command::new("kill").arg(pid).status();
+    }
+}
+
+/// The `config.toml` for a per-pane codex home.
+///
+/// The operator's own `~/.codex/config.toml` is the base, so their model,
+/// plugins and the rest still apply — minus `projects`, whose trust records
+/// the pane appends for its own working directory and which must not appear
+/// twice in one file.
+fn codex_config_toml(
+    user_config: &str,
+    developer_instructions: &str,
+    server_exe: &Path,
+    context_file: &Path,
+) -> String {
+    let mut config: toml::Table = toml::from_str(user_config).unwrap_or_default();
+    config.remove("projects");
+    config.insert(
+        "developer_instructions".to_string(),
+        developer_instructions.into(),
+    );
+    if let Some(features) = config
+        .entry("features")
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+    {
+        features.insert("scheduled_tasks".to_string(), false.into());
+    }
+    let mut omar = toml::Table::new();
+    omar.insert(
+        "command".to_string(),
+        server_exe.display().to_string().into(),
+    );
+    omar.insert(
+        "args".to_string(),
+        toml::Value::Array(vec![
+            "mcp-server".into(),
+            "--context-file".into(),
+            context_file.display().to_string().into(),
+        ]),
+    );
+    if let Some(servers) = config
+        .entry("mcp_servers")
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()))
+        .as_table_mut()
+    {
+        servers.insert("omar".to_string(), toml::Value::Table(omar));
+    }
+    config.to_string()
+}
+
+/// Fill a per-pane codex home and return where it is.
+///
+/// Returns `None` on any IO failure, and the caller then launches codex the
+/// old way — with `-c` overrides and no side channel. A pane that comes up
+/// without a channel still works; one that does not come up at all does not.
+fn codex_home_launch(context: &McpLaunchContext, developer_instructions: &str) -> Option<PathBuf> {
+    let server_exe = omar_server_exe()?;
+    let context_file = materialize_mcp_context_file(context)?;
+    let home = codex_home_dir(context)?;
+    let user_codex = dirs::home_dir()?.join(".codex");
+
+    let config = codex_config_toml(
+        &std::fs::read_to_string(user_codex.join("config.toml")).unwrap_or_default(),
+        developer_instructions,
+        &server_exe,
+        &context_file,
+    );
+    write_private_file(&home.join("config.toml"), config.as_bytes()).ok()?;
+
+    // Symlinked, not copied: the token is refreshed in place, and a pane
+    // holding a stale copy would be logged out mid-run.
+    let _ = std::os::unix::fs::symlink(user_codex.join("auth.json"), home.join("auth.json"));
+    // A home that has never seen an update check opens the release prompt over
+    // the TUI and waits for a keypress that never comes. Carrying the
+    // operator's own answer across means the pane starts where they left off.
+    let _ = std::fs::copy(user_codex.join("version.json"), home.join("version.json"));
+
+    Some(home)
+}
+
+/// Launch codex in a per-pane home, with an app-server the pane owns.
+///
+/// Three things happen before the TUI starts, all in the pane's own shell:
+///
+/// 1. The pane's working directory is recorded as trusted. Only the shell
+///    knows it — `pwd -P` resolves it the same way codex does — and without
+///    the record a fresh home opens a "do you trust this directory?" prompt
+///    the agent never answers. Appended only if it is not already there: the
+///    same table twice is a parse error, and codex refuses to start on one.
+/// 2. An app-server is started on the home's socket. The TUI attaches to it on
+///    its way up, which is what gives OMAR somewhere to inject events. A trap
+///    kills it when the shell exits, and its pid is written down so that
+///    `prune_stale_codex_homes` can finish the job when the shell does not —
+///    `tmux kill-session` signals nothing inside the pane.
+/// 3. The TUI waits for the socket. A brand-new home has no state database
+///    yet, and a server and a TUI creating it at the same moment collide on
+///    the migration — codex then refuses to start with a "local database
+///    appears to be damaged". Waiting for the socket means the server has
+///    finished. The wait is bounded: past it the TUI starts anyway, with no
+///    channel, which is the ordinary fallback.
+///
+/// The TUI itself is launched with no `-c` and no `--profile`: any of those
+/// makes codex refuse to attach, which is the whole reason the configuration
+/// moved into the home's `config.toml`.
+fn codex_home_command(home: &Path, tui_command: &str) -> String {
+    let home = shell_single_quote(&home.display().to_string());
+    let socket = "\"$CODEX_HOME/app-server-control/app-server-control.sock\"";
+    format!(
+        "export CODEX_HOME={home}; \
+         omar_cwd=\"$(pwd -P)\"; \
+         grep -qF \"[projects.\\\"$omar_cwd\\\"]\" \"$CODEX_HOME/config.toml\" || \
+         printf '\\n[projects.\"%s\"]\\ntrust_level = \"trusted\"\\n' \"$omar_cwd\" \
+         >> \"$CODEX_HOME/config.toml\"; \
+         codex app-server --listen unix:// >/dev/null 2>&1 & \
+         echo $! > \"$CODEX_HOME/{CODEX_HOME_PID_FILE}\"; \
+         trap \"kill $! 2>/dev/null\" EXIT HUP TERM; \
+         omar_waited=0; \
+         while [ ! -S {socket} ] && [ \"$omar_waited\" -lt 100 ]; \
+         do sleep 0.2; omar_waited=$((omar_waited+1)); done; \
+         {tui_command}"
+    )
+}
+
 fn opencode_config_env(context: &McpLaunchContext) -> Option<String> {
     let server_exe = omar_server_exe()?;
     let context_file = materialize_mcp_context_file(context)?;
@@ -838,6 +1055,22 @@ pub fn build_agent_command(
             ),
         },
         Some(BackendKind::Codex) => {
+            // Preferred: everything in a per-pane home's `config.toml`, so the
+            // TUI carries no `-c` and will attach to an app-server OMAR can
+            // reach. Falls back to the flags if the home cannot be written.
+            let instructions = std::fs::read_to_string(prompt_file).map(|body| {
+                substitutions
+                    .iter()
+                    .fold(body, |body, (pattern, replacement)| {
+                        body.replace(pattern, replacement)
+                    })
+            });
+            if let Some(home) = instructions
+                .ok()
+                .and_then(|instructions| codex_home_launch(mcp_context, &instructions))
+            {
+                return codex_home_command(&home, &base_command);
+            }
             let mut cmd = format!(
                 "{} -c \"developer_instructions='''{}'''\"",
                 base_command, shell_expr
@@ -1683,26 +1916,179 @@ mod tests {
         }
     }
 
+    /// A tempdir short enough that a codex home under it can still bind a
+    /// Unix socket. The default one lives under a long `/var/folders/...`
+    /// path on macOS, which is over the `sun_path` limit before codex has
+    /// added a single character of its own.
+    fn short_tempdir() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("omar-test-")
+            .tempdir_in("/tmp")
+            .unwrap()
+    }
+
     #[test]
     fn test_build_agent_command_codex() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = short_tempdir();
+        let prompt = dir.path().join("ea.md");
+        std::fs::write(&prompt, "be helpful, {{EA_NAME}}").unwrap();
         let cmd = build_agent_command(
             "codex --no-alt-screen",
-            Path::new("/tmp/prompts/ea.md"),
-            &[],
+            &prompt,
+            &[("{{EA_NAME}}", "CapX")],
             &test_mcp_context(dir.path()),
         );
-        assert!(cmd.starts_with(
-            "codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox -c \"developer_instructions='''$(cat '/tmp/prompts/ea.md')'''\""
-        ));
+
+        // Nothing on codex's disqualifier list may reach the TUI, or it
+        // refuses to attach to the app-server and there is no side channel.
+        assert!(
+            cmd.ends_with("codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox"),
+            "the TUI must be launched bare: {cmd}"
+        );
+        assert!(
+            !cmd.contains(" -c "),
+            "no config override may survive: {cmd}"
+        );
+        assert!(cmd.contains("export CODEX_HOME="), "{cmd}");
+        assert!(
+            cmd.contains("codex app-server --listen unix://"),
+            "the pane must own an app-server: {cmd}"
+        );
+        assert!(cmd.contains("trap \"kill $!"), "and must kill it: {cmd}");
+        assert!(
+            cmd.contains(
+                "while [ ! -S \"$CODEX_HOME/app-server-control/app-server-control.sock\" ]"
+            ),
+            "the TUI must wait for the server, or they race on a fresh home's \
+             state database and codex refuses to start: {cmd}"
+        );
+        assert!(
+            cmd.contains("trust_level = \"trusted\"") && cmd.contains("$(pwd -P)"),
+            "the launch cwd must be trusted or codex blocks on a prompt: {cmd}"
+        );
+
+        // The configuration the flags used to carry now lives in the home.
+        let home = crate::channel::codex_home(&cmd).expect("command names a codex home");
+        let config = std::fs::read_to_string(home.join("config.toml")).unwrap();
+        assert!(config.contains("be helpful, CapX"), "{config}");
+        assert!(config.contains("scheduled_tasks = false"), "{config}");
+        assert!(config.contains("[mcp_servers.omar]"), "{config}");
+        assert!(config.contains("mcp-server"), "{config}");
+    }
+
+    #[test]
+    fn a_codex_home_too_deep_for_a_socket_falls_back_to_the_flags() {
+        // `sun_path` is 104 bytes. A pane whose home cannot hold a socket gets
+        // no side channel — but it must still launch, with the configuration
+        // it always had.
+        let dir = short_tempdir();
+        let deep = dir.path().join("d".repeat(90));
+        std::fs::create_dir_all(&deep).unwrap();
+        let prompt = deep.join("ea.md");
+        std::fs::write(&prompt, "be helpful").unwrap();
+        let cmd = build_agent_command(
+            "codex --no-alt-screen",
+            &prompt,
+            &[],
+            &test_mcp_context(&deep),
+        );
+        assert!(
+            cmd.starts_with(
+                "codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox \
+                 -c \"developer_instructions='''$(cat '"
+            ),
+            "unexpected fallback command: {cmd}"
+        );
         assert!(cmd.contains("mcp_servers.omar.command"));
         assert!(cmd.contains("mcp_servers.omar.args"));
         assert!(cmd.contains("-c features.scheduled_tasks=false"));
     }
 
     #[test]
+    fn a_codex_home_outlives_its_pane_only_until_the_next_launch() {
+        // `tmux kill-session` signals nothing inside the pane, so the shell's
+        // own trap cannot be relied on to take the app-server down with it.
+        let dir = short_tempdir();
+        let root = dir.path();
+
+        let finished = root.join("finished");
+        std::fs::create_dir_all(&finished).unwrap();
+        std::fs::write(
+            finished.join(CODEX_HOME_SESSION_FILE),
+            "omar-agent-no-such-session-1a2b3c",
+        )
+        .unwrap();
+
+        // Written by the pane's shell before OMAR knows the session name.
+        let launching = root.join("launching");
+        std::fs::create_dir_all(&launching).unwrap();
+
+        prune_stale_codex_homes(root);
+
+        assert!(!finished.exists(), "a home whose pane is gone must go");
+        assert!(
+            launching.exists(),
+            "a home that has not been claimed yet is mid-launch"
+        );
+    }
+
+    #[test]
+    fn a_codex_config_keeps_the_operators_own_settings_but_not_their_trust_records() {
+        let config = codex_config_toml(
+            "model = \"gpt-5.6-terra\"\n\
+             [features]\n\
+             web_search = true\n\
+             [projects.\"/somewhere/else\"]\n\
+             trust_level = \"trusted\"\n",
+            "be helpful",
+            Path::new("/usr/local/bin/omar"),
+            Path::new("/home/ea/context.json"),
+        );
+        let parsed: toml::Table = toml::from_str(&config).expect("valid toml");
+
+        assert_eq!(parsed["model"].as_str(), Some("gpt-5.6-terra"));
+        assert_eq!(parsed["features"]["web_search"].as_bool(), Some(true));
+        assert_eq!(parsed["features"]["scheduled_tasks"].as_bool(), Some(false));
+        assert_eq!(
+            parsed["developer_instructions"].as_str(),
+            Some("be helpful")
+        );
+        assert_eq!(
+            parsed["mcp_servers"]["omar"]["command"].as_str(),
+            Some("/usr/local/bin/omar")
+        );
+        // The pane appends its own working directory as a trusted project.
+        // Carrying the operator's table across could name that directory too,
+        // and a table declared twice makes codex refuse to start at all.
+        assert!(
+            parsed.get("projects").is_none(),
+            "trust records must not be carried over: {config}"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_codex_config_still_yields_a_usable_one() {
+        // The operator may have no `~/.codex/config.toml` at all, and a
+        // damaged one must not take the pane down with it.
+        for base in ["", "this is not toml [[["] {
+            let config = codex_config_toml(
+                base,
+                "be helpful",
+                Path::new("/usr/local/bin/omar"),
+                Path::new("/home/ea/context.json"),
+            );
+            let parsed: toml::Table = toml::from_str(&config).expect("valid toml");
+            assert_eq!(
+                parsed["developer_instructions"].as_str(),
+                Some("be helpful")
+            );
+            assert!(parsed["mcp_servers"]["omar"]["args"].is_array());
+        }
+    }
+
+    #[test]
     fn test_build_ea_command_codex() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = short_tempdir();
         let omar_dir = dir.path();
         let state_dir = ea::ea_state_dir(3, omar_dir);
         std::fs::create_dir_all(&state_dir).unwrap();
@@ -1713,21 +2099,24 @@ mod tests {
             omar_dir,
             &test_mcp_context(omar_dir),
         );
-        // codex stays on the inline path: its `AGENTS.md` auto-discovery
-        // is anchored at the agent's working root (`-C`), not the launch
-        // cwd, so a workspace-dir launch would either load the wrong
-        // `AGENTS.md` or force the manager to operate outside the user's
-        // project. The truncation cap in memory.rs keeps the inlined
-        // prompt under MAX_ARG_STRLEN even with large notes/memory.
+        // codex keeps launching in the user's own project directory: its
+        // `AGENTS.md` auto-discovery is anchored at the agent's working root
+        // (`-C`), not the launch cwd, so a workspace-dir launch would either
+        // load the wrong `AGENTS.md` or force the manager to operate outside
+        // the user's project.
         assert!(
-            cmd.starts_with("codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox -c \"developer_instructions='''"),
-            "unexpected codex manager command prefix: {cmd}"
+            cmd.ends_with("codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox"),
+            "unexpected codex manager command: {cmd}"
         );
-        assert!(cmd.contains("mcp_servers.omar.command="));
-        assert!(cmd.contains("mcp_servers.omar.args="));
-        assert!(cmd.contains("\"mcp-server\""));
-        assert!(cmd.contains("-c features.scheduled_tasks=false"));
-        assert!(cmd.contains("CapX"));
+        let home = crate::channel::codex_home(&cmd).expect("command names a codex home");
+        let config = std::fs::read_to_string(home.join("config.toml"))
+            .unwrap_or_else(|err| panic!("no config at {}: {err} ({cmd})", home.display()));
+        assert!(config.contains("[mcp_servers.omar]"), "{config}");
+        assert!(config.contains("mcp-server"), "{config}");
+        assert!(config.contains("scheduled_tasks = false"), "{config}");
+        // The EA's own name is substituted into the prompt before it lands in
+        // the config rather than by a `sed` at launch.
+        assert!(config.contains("CapX"), "{config}");
         assert!(
             workspace.is_none(),
             "codex manager must not override the launch cwd"

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -507,6 +507,27 @@ const CODEX_NO_ATTACH_FLAGS: &[&str] = &[
 /// `spawn_agent` adds `-c model_reasoning_effort=…` for any agent given a
 /// reasoning effort, and an operator may have configured flags of their own,
 /// so this is a real case rather than a defensive one.
+/// Answer codex's directory-trust prompt before it is asked.
+///
+/// codex blocks on "Do you trust the contents of this directory?" the first
+/// time it runs anywhere new, and nothing in an agent pane ever answers it —
+/// the agent simply hangs. Saying yes is exactly this record appended to the
+/// config, which is what codex itself writes when a human clicks through, so
+/// OMAR writes it for the directory it chose for the agent.
+///
+/// `CODEX_HOME` may or may not be set: the side-channel launch points it at a
+/// per-pane home, and the fallback uses the operator's own.
+fn codex_trust_cwd() -> String {
+    "omar_home=\"${CODEX_HOME:-$HOME/.codex}\"; \
+     mkdir -p \"$omar_home\"; \
+     omar_cwd=\"$(pwd -P | sed 's/[\\\\\"]/\\\\&/g')\"; \
+     touch \"$omar_home/config.toml\"; \
+     grep -qF \"[projects.\\\"$omar_cwd\\\"]\" \"$omar_home/config.toml\" || \
+     printf '\\n[projects.\"%s\"]\\ntrust_level = \"trusted\"\\n' \"$omar_cwd\" \
+     >> \"$omar_home/config.toml\"; "
+        .to_string()
+}
+
 fn codex_refuses_to_attach(base_command: &str) -> bool {
     base_command.split_whitespace().any(|token| {
         let flag = token.split_once('=').map_or(token, |(flag, _)| flag);
@@ -1139,9 +1160,13 @@ pub fn build_agent_command(
                     return codex_home_command(&home, &base_command);
                 }
             }
+            // No channel here, but codex still refuses to start in a directory
+            // it has not been told to trust, and no agent answers that prompt.
             let mut cmd = format!(
-                "{} -c \"developer_instructions='''{}'''\"",
-                base_command, shell_expr
+                "{}{} -c \"developer_instructions='''{}'''\"",
+                codex_trust_cwd(),
+                base_command,
+                shell_expr
             );
             if let Some(overrides) = codex_mcp_overrides(mcp_context) {
                 cmd.push(' ');
@@ -2060,6 +2085,37 @@ mod tests {
     }
 
     #[test]
+    fn a_launch_without_a_side_channel_still_trusts_its_own_directory() {
+        // codex blocks on "Do you trust the contents of this directory?" the
+        // first time it runs anywhere new, and no agent ever answers it. The
+        // side-channel launch writes the record into its own home; this path
+        // uses the operator's, and used to leave the pane hanging forever.
+        let dir = tempfile::tempdir().unwrap();
+        let prompt = dir.path().join("ea.md");
+        std::fs::write(&prompt, "be helpful").unwrap();
+        let cmd = build_agent_command(
+            // a disqualifying flag forces the fallback
+            "codex --no-alt-screen -c model_reasoning_effort='\"high\"'",
+            &prompt,
+            &[],
+            &test_mcp_context(dir.path()),
+        );
+
+        assert!(
+            !cmd.contains("export CODEX_HOME="),
+            "this must be the fallback, not the side-channel launch: {cmd}"
+        );
+        assert!(
+            cmd.contains("trust_level = \"trusted\"") && cmd.contains("$(pwd -P"),
+            "the launch cwd must be trusted or the pane hangs on a prompt: {cmd}"
+        );
+        assert!(
+            cmd.contains("${CODEX_HOME:-$HOME/.codex}"),
+            "with no per-pane home it must write the operator's own: {cmd}"
+        );
+    }
+
+    #[test]
     fn the_socket_bound_is_the_one_codex_enforces_not_the_kernel() {
         // Measured against codex 0.147.0: a 95-byte socket path binds, 96
         // fails with "path must be shorter than SUN_LEN". macOS itself would
@@ -2089,11 +2145,17 @@ mod tests {
             &test_mcp_context(&deep),
         );
         assert!(
-            cmd.starts_with(
+            cmd.contains(
                 "codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox \
                  -c \"developer_instructions='''$(cat '"
             ),
             "unexpected fallback command: {cmd}"
+        );
+        // The trust record is written first, so the pane does not stop on
+        // a prompt before it reaches codex at all.
+        assert!(
+            cmd.starts_with("omar_home=") && cmd.contains("trust_level = \"trusted\""),
+            "the fallback must trust its cwd before launching: {cmd}"
         );
         assert!(cmd.contains("mcp_servers.omar.command"));
         assert!(cmd.contains("mcp_servers.omar.args"));

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -474,10 +474,15 @@ fn codex_mcp_overrides(context: &McpLaunchContext) -> Option<String> {
     ))
 }
 
-/// The longest `sun_path` a Unix socket may have. macOS allows 104 bytes
-/// including the terminator; a per-pane codex home longer than that leaves the
-/// app-server unable to bind, so OMAR declines the side channel instead.
-const SUN_PATH_MAX: usize = 104;
+/// The longest socket path codex will bind.
+///
+/// Not the operating system's limit — macOS itself accepts 103 bytes — but
+/// codex's own, measured against the shipped 0.147.0 binary: 95 binds and 96
+/// fails with "path must be shorter than SUN_LEN". A path in between passes
+/// the OS and is refused by codex, which loses the channel silently and leaves
+/// a home behind for nothing, so the stricter bound is the useful one. It may
+/// move with the codex version.
+const SUN_PATH_MAX: usize = 96;
 
 /// Flags that make codex refuse to attach to a running app-server.
 ///
@@ -2055,10 +2060,23 @@ mod tests {
     }
 
     #[test]
+    fn the_socket_bound_is_the_one_codex_enforces_not_the_kernel() {
+        // Measured against codex 0.147.0: a 95-byte socket path binds, 96
+        // fails with "path must be shorter than SUN_LEN". macOS itself would
+        // take 103, and a path in that gap is the bad case — it passes the
+        // kernel, codex refuses it, and the channel is lost silently while a
+        // home is left behind for nothing.
+        assert_eq!(
+            SUN_PATH_MAX, 96,
+            "the guard must reject the paths codex rejects, not the ones the OS does"
+        );
+    }
+
+    #[test]
     fn a_codex_home_too_deep_for_a_socket_falls_back_to_the_flags() {
-        // `sun_path` is 104 bytes. A pane whose home cannot hold a socket gets
-        // no side channel — but it must still launch, with the configuration
-        // it always had.
+        // A pane whose home cannot hold a socket codex will bind gets no side
+        // channel — but it must still launch, with the configuration it always
+        // had.
         let dir = short_tempdir();
         let deep = dir.path().join("d".repeat(90));
         std::fs::create_dir_all(&deep).unwrap();

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -505,28 +505,32 @@ fn codex_home_dir(context: &McpLaunchContext) -> Option<PathBuf> {
     Some(dir)
 }
 
-/// Drop the codex homes — and the app-servers — of panes that are gone.
+/// Drop the codex homes of panes that are gone.
 ///
-/// Each launch makes a new home, and codex fills it with several megabytes of
-/// state, so without this they accumulate for the life of the machine. The
-/// server matters more than the disk: `tmux kill-session` closes the pane's
-/// terminal without signalling anything in it, so the shell's own trap only
-/// fires when the TUI notices and exits, and an app-server can outlive its
-/// pane indefinitely.
+/// Disk only. The app-server needs no reaping: it is a background job of the
+/// pane's own shell, so it shares the pane's process group and dies with it —
+/// on `tmux kill-session`, and on the TUI exiting and taking the session with
+/// it. But nothing removes the directory, and codex fills each one with
+/// several megabytes of sqlite, so without this they accumulate for the life
+/// of the machine.
 ///
 /// A home is finished when the pane named in it is no longer a tmux session.
-/// One that names no pane yet is mid-launch, and is left alone until it is old
-/// enough that it plainly never got one.
+/// Named, rather than probed for a live socket, because the home holds the
+/// running agent's thread history: deleting one whose app-server happens to be
+/// down would take a working pane's state with it.
+///
+/// One that names no pane yet was written moments ago by `codex_home_dir` and
+/// is about to be claimed, so it is left alone until it is old enough that it
+/// plainly never was.
 fn prune_stale_codex_homes(root: &Path) {
-    const GRACE: Duration = Duration::from_secs(3600);
+    const GRACE: Duration = Duration::from_secs(300);
     let client = TmuxClient::new("");
     let Ok(entries) = std::fs::read_dir(root) else {
         return;
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let pane = std::fs::read_to_string(path.join(CODEX_HOME_SESSION_FILE));
-        let finished = match &pane {
+        let finished = match std::fs::read_to_string(path.join(CODEX_HOME_SESSION_FILE)) {
             Ok(session) => !client.has_session(session.trim()).unwrap_or(true),
             Err(_) => entry
                 .metadata()
@@ -534,41 +538,14 @@ fn prune_stale_codex_homes(root: &Path) {
                 .map(|modified| modified.elapsed().unwrap_or_default() >= GRACE)
                 .unwrap_or(false),
         };
-        if !finished {
-            continue;
+        if finished {
+            let _ = std::fs::remove_dir_all(&path);
         }
-        kill_codex_app_server(&path);
-        let _ = std::fs::remove_dir_all(&path);
     }
 }
 
-/// Where the pane's shell records its app-server, and where provisioning
-/// records which tmux session the home belongs to.
-const CODEX_HOME_PID_FILE: &str = "app-server.pid";
+/// Where provisioning records which tmux session a home belongs to.
 pub(crate) const CODEX_HOME_SESSION_FILE: &str = "omar-session";
-
-/// Stop the app-server a finished home left running.
-///
-/// The recorded pid is checked against what is actually running first: pids
-/// are reused, and killing whatever inherited this one would be far worse than
-/// leaving a server up.
-fn kill_codex_app_server(home: &Path) {
-    let Ok(pid) = std::fs::read_to_string(home.join(CODEX_HOME_PID_FILE)) else {
-        return;
-    };
-    let pid = pid.trim();
-    if pid.is_empty() || pid.parse::<u32>().is_err() {
-        return;
-    }
-    let running = std::process::Command::new("ps")
-        .args(["-p", pid, "-o", "command="])
-        .output()
-        .map(|out| String::from_utf8_lossy(&out.stdout).contains("app-server"))
-        .unwrap_or(false);
-    if running {
-        let _ = std::process::Command::new("kill").arg(pid).status();
-    }
-}
 
 /// The `config.toml` for a per-pane codex home.
 ///
@@ -657,17 +634,22 @@ fn codex_home_launch(context: &McpLaunchContext, developer_instructions: &str) -
 ///    the record a fresh home opens a "do you trust this directory?" prompt
 ///    the agent never answers. Appended only if it is not already there: the
 ///    same table twice is a parse error, and codex refuses to start on one.
-/// 2. An app-server is started on the home's socket. The TUI attaches to it on
-///    its way up, which is what gives OMAR somewhere to inject events. A trap
-///    kills it when the shell exits, and its pid is written down so that
-///    `prune_stale_codex_homes` can finish the job when the shell does not —
-///    `tmux kill-session` signals nothing inside the pane.
+/// 2. An app-server is started, in the background of that same shell. The TUI
+///    attaches to it on its way up, which is what gives OMAR somewhere to
+///    inject events.
 /// 3. The TUI waits for the socket. A brand-new home has no state database
 ///    yet, and a server and a TUI creating it at the same moment collide on
 ///    the migration — codex then refuses to start with a "local database
 ///    appears to be damaged". Waiting for the socket means the server has
 ///    finished. The wait is bounded: past it the TUI starts anyway, with no
 ///    channel, which is the ordinary fallback.
+///
+/// Deliberately no `trap` to kill the server. A plain background job is in the
+/// pane's process group and dies with the pane; a `trap ... HUP` makes the
+/// shell *catch* the hangup instead of dying of it, and a shell blocked in the
+/// TUI never reaches the handler — so it survives, holding the server open.
+/// The trap does not clean up after the pane, it is what stops the pane
+/// cleaning up after itself.
 ///
 /// The TUI itself is launched with no `-c` and no `--profile`: any of those
 /// makes codex refuse to attach, which is the whole reason the configuration
@@ -682,8 +664,6 @@ fn codex_home_command(home: &Path, tui_command: &str) -> String {
          printf '\\n[projects.\"%s\"]\\ntrust_level = \"trusted\"\\n' \"$omar_cwd\" \
          >> \"$CODEX_HOME/config.toml\"; \
          codex app-server --listen unix:// >/dev/null 2>&1 & \
-         echo $! > \"$CODEX_HOME/{CODEX_HOME_PID_FILE}\"; \
-         trap \"kill $! 2>/dev/null\" EXIT HUP TERM; \
          omar_waited=0; \
          while [ ! -S {socket} ] && [ \"$omar_waited\" -lt 100 ]; \
          do sleep 0.2; omar_waited=$((omar_waited+1)); done; \
@@ -1954,7 +1934,14 @@ mod tests {
             cmd.contains("codex app-server --listen unix://"),
             "the pane must own an app-server: {cmd}"
         );
-        assert!(cmd.contains("trap \"kill $!"), "and must kill it: {cmd}");
+        // A background job dies with the pane's process group. A `trap` would
+        // make the shell catch the hangup instead of dying of it, and a shell
+        // sitting in the TUI never reaches the handler — so the pane would
+        // survive its own kill and hold the server open.
+        assert!(
+            !cmd.contains("trap "),
+            "trapping the hangup is what keeps the server alive: {cmd}"
+        );
         assert!(
             cmd.contains(
                 "while [ ! -S \"$CODEX_HOME/app-server-control/app-server-control.sock\" ]"
@@ -2006,8 +1993,8 @@ mod tests {
 
     #[test]
     fn a_codex_home_outlives_its_pane_only_until_the_next_launch() {
-        // `tmux kill-session` signals nothing inside the pane, so the shell's
-        // own trap cannot be relied on to take the app-server down with it.
+        // The app-server dies with the pane on its own; the directory does
+        // not, and each launch mints a multi-megabyte one.
         let dir = short_tempdir();
         let root = dir.path();
 
@@ -2019,7 +2006,7 @@ mod tests {
         )
         .unwrap();
 
-        // Written by the pane's shell before OMAR knows the session name.
+        // Made by `codex_home_dir`, not yet claimed by provisioning.
         let launching = root.join("launching");
         std::fs::create_dir_all(&launching).unwrap();
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -479,6 +479,36 @@ fn codex_mcp_overrides(context: &McpLaunchContext) -> Option<String> {
 /// app-server unable to bind, so OMAR declines the side channel instead.
 const SUN_PATH_MAX: usize = 104;
 
+/// Flags that make codex refuse to attach to a running app-server.
+///
+/// The refusal is silent, so a pane carrying one of these would start a server
+/// nobody joins, sit out the socket wait, and then have provisioning poll it
+/// for ninety seconds — all to arrive where it started. Better to see the flag
+/// and not build the home at all.
+const CODEX_NO_ATTACH_FLAGS: &[&str] = &[
+    "-c",
+    "--config",
+    "--profile",
+    "--strict-config",
+    "--search",
+    "--approve-for-me",
+    "--enable",
+    "--disable",
+    "--dangerously-bypass-hook-trust",
+];
+
+/// Would this command's codex refuse the app-server?
+///
+/// `spawn_agent` adds `-c model_reasoning_effort=…` for any agent given a
+/// reasoning effort, and an operator may have configured flags of their own,
+/// so this is a real case rather than a defensive one.
+fn codex_refuses_to_attach(base_command: &str) -> bool {
+    base_command.split_whitespace().any(|token| {
+        let flag = token.split_once('=').map_or(token, |(flag, _)| flag);
+        CODEX_NO_ATTACH_FLAGS.contains(&flag)
+    })
+}
+
 /// A codex home of OMAR's own, one per launched pane.
 ///
 /// codex's TUI only attaches to an app-server when it is started with no
@@ -519,9 +549,11 @@ fn codex_home_dir(context: &McpLaunchContext) -> Option<PathBuf> {
 /// running agent's thread history: deleting one whose app-server happens to be
 /// down would take a working pane's state with it.
 ///
-/// One that names no pane yet was written moments ago by `codex_home_dir` and
-/// is about to be claimed, so it is left alone until it is old enough that it
-/// plainly never was.
+/// One that names no pane is either mid-launch — `codex_home_dir` made it
+/// moments ago and `claim_codex_home` is about to write the name — or the
+/// leftovers of a launch that never got that far. Age separates the two, and a
+/// live app-server vetoes either way: whatever else is true of a home, if
+/// something is still answering on its socket it is in use.
 fn prune_stale_codex_homes(root: &Path) {
     const GRACE: Duration = Duration::from_secs(300);
     let client = TmuxClient::new("");
@@ -538,10 +570,43 @@ fn prune_stale_codex_homes(root: &Path) {
                 .map(|modified| modified.elapsed().unwrap_or_default() >= GRACE)
                 .unwrap_or(false),
         };
-        if finished {
+        if finished && !codex_home_is_serving(&path) {
             let _ = std::fs::remove_dir_all(&path);
         }
     }
+}
+
+/// Is a pane still using this home?
+///
+/// The home holds the agent's thread history and the config its TUI is
+/// running on, so this is the last check before deleting one. A connection
+/// that is accepted means an app-server is up, which means a pane is up.
+fn codex_home_is_serving(home: &Path) -> bool {
+    std::os::unix::net::UnixStream::connect(crate::channel::codex_socket_path(home)).is_ok()
+}
+
+/// Record which pane a home belongs to, and drop any earlier home that claimed
+/// the same one.
+///
+/// A session name is reused: `ensure_manager_session` and the topology runner
+/// both kill a pane and immediately make another with the same name, so the
+/// home the old pane was using would otherwise keep resolving to a live
+/// session and never be pruned.
+pub(crate) fn claim_codex_home(home: &Path, session: &str) {
+    if let Some(root) = home.parent() {
+        for entry in std::fs::read_dir(root).into_iter().flatten().flatten() {
+            let sibling = entry.path();
+            if sibling == home {
+                continue;
+            }
+            let claimed = std::fs::read_to_string(sibling.join(CODEX_HOME_SESSION_FILE))
+                .is_ok_and(|name| name.trim() == session);
+            if claimed && !codex_home_is_serving(&sibling) {
+                let _ = std::fs::remove_dir_all(&sibling);
+            }
+        }
+    }
+    let _ = std::fs::write(home.join(CODEX_HOME_SESSION_FILE), session);
 }
 
 /// Where provisioning records which tmux session a home belongs to.
@@ -603,16 +668,22 @@ fn codex_config_toml(
 fn codex_home_launch(context: &McpLaunchContext, developer_instructions: &str) -> Option<PathBuf> {
     let server_exe = omar_server_exe()?;
     let context_file = materialize_mcp_context_file(context)?;
-    let home = codex_home_dir(context)?;
     let user_codex = dirs::home_dir()?.join(".codex");
-
     let config = codex_config_toml(
         &std::fs::read_to_string(user_codex.join("config.toml")).unwrap_or_default(),
         developer_instructions,
         &server_exe,
         &context_file,
     );
-    write_private_file(&home.join("config.toml"), config.as_bytes()).ok()?;
+
+    // Made last, once everything that can fail has: a home abandoned between
+    // being created and being filled would have no session name to prune it by
+    // and no server to answer for it, so nothing would ever remove it.
+    let home = codex_home_dir(context)?;
+    if write_private_file(&home.join("config.toml"), config.as_bytes()).is_err() {
+        let _ = std::fs::remove_dir_all(&home);
+        return None;
+    }
 
     // Symlinked, not copied: the token is refreshed in place, and a pane
     // holding a stale copy would be logged out mid-run.
@@ -634,6 +705,8 @@ fn codex_home_launch(context: &McpLaunchContext, developer_instructions: &str) -
 ///    the record a fresh home opens a "do you trust this directory?" prompt
 ///    the agent never answers. Appended only if it is not already there: the
 ///    same table twice is a parse error, and codex refuses to start on one.
+///    `sed` escapes it first, because it goes in as a TOML quoted key and a
+///    directory named with a `"` or a `\` would be the same parse error.
 /// 2. An app-server is started, in the background of that same shell. The TUI
 ///    attaches to it on its way up, which is what gives OMAR somewhere to
 ///    inject events.
@@ -641,7 +714,10 @@ fn codex_home_launch(context: &McpLaunchContext, developer_instructions: &str) -
 ///    yet, and a server and a TUI creating it at the same moment collide on
 ///    the migration — codex then refuses to start with a "local database
 ///    appears to be damaged". Waiting for the socket means the server has
-///    finished. The wait is bounded: past it the TUI starts anyway, with no
+///    finished. The wait ends early if the server dies — a codex too old for
+///    `app-server --listen`, or one that is not on `PATH`, would otherwise
+///    spend twenty seconds of the caller's readiness budget going nowhere —
+///    and is bounded in any case. Past either, the TUI starts with no
 ///    channel, which is the ordinary fallback.
 ///
 /// Deliberately no `trap` to kill the server. A plain background job is in the
@@ -659,13 +735,14 @@ fn codex_home_command(home: &Path, tui_command: &str) -> String {
     let socket = "\"$CODEX_HOME/app-server-control/app-server-control.sock\"";
     format!(
         "export CODEX_HOME={home}; \
-         omar_cwd=\"$(pwd -P)\"; \
+         omar_cwd=\"$(pwd -P | sed 's/[\\\\\"]/\\\\&/g')\"; \
          grep -qF \"[projects.\\\"$omar_cwd\\\"]\" \"$CODEX_HOME/config.toml\" || \
          printf '\\n[projects.\"%s\"]\\ntrust_level = \"trusted\"\\n' \"$omar_cwd\" \
          >> \"$CODEX_HOME/config.toml\"; \
          codex app-server --listen unix:// >/dev/null 2>&1 & \
-         omar_waited=0; \
-         while [ ! -S {socket} ] && [ \"$omar_waited\" -lt 100 ]; \
+         omar_srv=$!; omar_waited=0; \
+         while [ ! -S {socket} ] && [ \"$omar_waited\" -lt 100 ] \
+         && kill -0 \"$omar_srv\" 2>/dev/null; \
          do sleep 0.2; omar_waited=$((omar_waited+1)); done; \
          {tui_command}"
     )
@@ -1037,7 +1114,11 @@ pub fn build_agent_command(
         Some(BackendKind::Codex) => {
             // Preferred: everything in a per-pane home's `config.toml`, so the
             // TUI carries no `-c` and will attach to an app-server OMAR can
-            // reach. Falls back to the flags if the home cannot be written.
+            // reach. Falls back to the flags if the home cannot be written, or
+            // if the command already carries something codex will not attach
+            // with — a home built for a TUI that refuses to join it is worse
+            // than none, because the pane pays for the server twice over and
+            // still ends up on the input box.
             let instructions = std::fs::read_to_string(prompt_file).map(|body| {
                 substitutions
                     .iter()
@@ -1045,11 +1126,13 @@ pub fn build_agent_command(
                         body.replace(pattern, replacement)
                     })
             });
-            if let Some(home) = instructions
-                .ok()
-                .and_then(|instructions| codex_home_launch(mcp_context, &instructions))
-            {
-                return codex_home_command(&home, &base_command);
+            if !codex_refuses_to_attach(&base_command) {
+                if let Some(home) = instructions
+                    .ok()
+                    .and_then(|instructions| codex_home_launch(mcp_context, &instructions))
+                {
+                    return codex_home_command(&home, &base_command);
+                }
             }
             let mut cmd = format!(
                 "{} -c \"developer_instructions='''{}'''\"",
@@ -1950,8 +2033,16 @@ mod tests {
              state database and codex refuses to start: {cmd}"
         );
         assert!(
-            cmd.contains("trust_level = \"trusted\"") && cmd.contains("$(pwd -P)"),
+            cmd.contains("trust_level = \"trusted\"") && cmd.contains("$(pwd -P"),
             "the launch cwd must be trusted or codex blocks on a prompt: {cmd}"
+        );
+        assert!(
+            cmd.contains(r#"sed 's/[\\"]/\\&/g'"#),
+            "the cwd goes in as a TOML quoted key and must be escaped: {cmd}"
+        );
+        assert!(
+            cmd.contains("kill -0 \"$omar_srv\""),
+            "the wait must end when the server dies: {cmd}"
         );
 
         // The configuration the flags used to carry now lives in the home.
@@ -1989,6 +2080,100 @@ mod tests {
         assert!(cmd.contains("mcp_servers.omar.command"));
         assert!(cmd.contains("mcp_servers.omar.args"));
         assert!(cmd.contains("-c features.scheduled_tasks=false"));
+    }
+
+    #[test]
+    fn a_codex_that_will_not_attach_is_launched_the_old_way() {
+        // `spawn_agent` adds `-c model_reasoning_effort=…` for any agent given
+        // one, and codex then refuses the app-server. Building a home anyway
+        // would start a second codex nobody joins, spend the pane's readiness
+        // budget waiting for a socket, and poll it for ninety seconds — to end
+        // up on the input box regardless.
+        let dir = short_tempdir();
+        let prompt = dir.path().join("agent.md");
+        std::fs::write(&prompt, "be helpful").unwrap();
+
+        for base in [
+            "codex --no-alt-screen -c model_reasoning_effort='\"high\"'",
+            "codex --no-alt-screen --profile work",
+            "codex --no-alt-screen --search",
+            "codex --no-alt-screen --enable web_search",
+            "codex --no-alt-screen --config model=\"o3\"",
+        ] {
+            let cmd = build_agent_command(base, &prompt, &[], &test_mcp_context(dir.path()));
+            assert!(
+                cmd.contains("developer_instructions='''"),
+                "{base} must take the flag path: {cmd}"
+            );
+            assert!(
+                crate::channel::codex_home(&cmd).is_none(),
+                "{base} must not be given a home it cannot attach to: {cmd}"
+            );
+        }
+
+        // The flags OMAR always adds are not on that list.
+        for base in [
+            "codex --no-alt-screen",
+            "codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox --model gpt-5.6-sol",
+        ] {
+            let cmd = build_agent_command(base, &prompt, &[], &test_mcp_context(dir.path()));
+            assert!(
+                crate::channel::codex_home(&cmd).is_some(),
+                "{base} should still get a home: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_home_whose_server_is_answering_is_never_deleted() {
+        // The pane's TUI is a client of that server, and the home holds the
+        // thread history it is running on. Deleting either out from under a
+        // live pane takes the agent with it, so a live socket vetoes every
+        // path that removes a home — however the session bookkeeping reads.
+        let dir = short_tempdir();
+        let root = dir.path();
+
+        let live = root.join("live");
+        std::fs::create_dir_all(crate::channel::codex_socket_path(&live).parent().unwrap())
+            .unwrap();
+        let _listener =
+            std::os::unix::net::UnixListener::bind(crate::channel::codex_socket_path(&live))
+                .unwrap();
+        // Everything the bookkeeping could get wrong, at once: it claims a
+        // session that does not exist, and it is older than the grace.
+        std::fs::write(live.join(CODEX_HOME_SESSION_FILE), "omar-agent-gone-9z8y7x").unwrap();
+
+        prune_stale_codex_homes(root);
+        assert!(live.exists(), "a live app-server must veto the prune");
+
+        // And the same veto covers the sweep of an earlier home for a reused
+        // session name.
+        let newer = root.join("newer");
+        std::fs::create_dir_all(&newer).unwrap();
+        claim_codex_home(&newer, "omar-agent-gone-9z8y7x");
+        assert!(live.exists(), "a live app-server must veto the sweep too");
+    }
+
+    #[test]
+    fn an_earlier_home_for_the_same_pane_is_reclaimed() {
+        // `ensure_manager_session` kills a pane and makes another with the
+        // same name, so the old home's recorded session resolves again and it
+        // would never be pruned.
+        let dir = short_tempdir();
+        let root = dir.path();
+        let old = root.join("old");
+        let new = root.join("new");
+        std::fs::create_dir_all(&old).unwrap();
+        std::fs::create_dir_all(&new).unwrap();
+        std::fs::write(old.join(CODEX_HOME_SESSION_FILE), "omar-agent-1-work").unwrap();
+
+        claim_codex_home(&new, "omar-agent-1-work");
+
+        assert!(!old.exists(), "the previous home for this pane must go");
+        assert_eq!(
+            std::fs::read_to_string(new.join(CODEX_HOME_SESSION_FILE)).unwrap(),
+            "omar-agent-1-work"
+        );
     }
 
     #[test]

--- a/tests/ci/tmux_codex_fallback.sh
+++ b/tests/ci/tmux_codex_fallback.sh
@@ -35,6 +35,8 @@ state_file="__STATE_FILE__"
 prev_attempt=$(cat "${state_file}.count" 2>/dev/null || echo 0)
 attempt=$(( prev_attempt + 1 ))
 printf '%s\n' "$*" >> "$state_file"
+# Recorded so the test can find the per-pane config, when there is one.
+printf 'CODEX_HOME=%s\n' "${CODEX_HOME:-}" >> "$state_file"
 echo "$attempt" > "${state_file}.count"
 printf '%s\n' "attempt ${attempt}" >> "$state_file"
 
@@ -151,16 +153,38 @@ if ! grep -q "^attempt 1$" "$state_file"; then
   fail "failed to observe first startup attempt"
 fi
 
-if ! grep -q "mcp_servers\\.omar\\.command" "$state_file"; then
-  fail "found startup attempt without omar MCP command override"
+# codex is configured one of two ways, and which one a machine takes is not a
+# choice this test gets to make.
+#
+# Its TUI only attaches to an app-server when started with no `-c` overrides at
+# all, so OMAR writes a per-pane `CODEX_HOME/config.toml` when it can. It
+# cannot when the socket that home implies would exceed `sun_path` -- 96 bytes
+# -- and that depends on where `mktemp` puts a directory: about 87 bytes on
+# Linux, about 129 under macOS's `/var/folders`. Then it falls back to `-c`
+# flags on the command line, which is why this passed on a mac and failed in
+# CI while both were behaving correctly.
+#
+# So assert what codex was told, not which route carried it.
+configured() {
+  local flag_pattern="$1" toml_pattern="$2" home
+  if grep -q "$flag_pattern" "$state_file"; then
+    return 0
+  fi
+  home="$(grep -m1 '^CODEX_HOME=' "$state_file" 2>/dev/null | cut -d= -f2-)"
+  [ -n "$home" ] && [ -f "$home/config.toml" ] &&
+    grep -q "$toml_pattern" "$home/config.toml"
+}
+
+if ! configured "mcp_servers\\.omar\\.command" "\\[mcp_servers\\.omar\\]"; then
+  fail "codex was not told how to launch omar's MCP server"
 fi
 
-if ! grep -q "mcp_servers\\.omar\\.args" "$state_file"; then
-  fail "found startup attempt without omar MCP args override"
+if ! configured "mcp_servers\\.omar\\.args" "mcp-server"; then
+  fail "codex was not told what arguments omar's MCP server takes"
 fi
 
-if ! grep -q "features.scheduled_tasks=false" "$state_file"; then
-  fail "found startup attempt without disabling codex scheduled tasks"
+if ! configured "features.scheduled_tasks=false" "scheduled_tasks = false"; then
+  fail "codex scheduled tasks were not disabled"
 fi
 
 if grep -q "^attempt 2$" "$state_file"; then


### PR DESCRIPTION
Stacked on #224 — targets `feat/out-of-band-event-delivery`, because the `Channel` enum this extends only exists there. Review the diff against that branch.

codex was the last backend without a side channel. Its events went through the composer, on top of whatever the user was typing, and read as something the user had said.

## The flag that made it impossible

codex's TUI is a client of an app-server: JSON-RPC over WebSocket over a Unix socket at `$CODEX_HOME/app-server-control/app-server-control.sock`. `thread/inject_items` appends to the thread without starting a turn and without drawing anything — exactly what an event wants to be.

A TUI attaches to a running app-server on its way up, but **only if it was started with no config override at all**: any `-c`, `--profile`, `--strict-config`, `--enable`/`--disable` and it refuses. OMAR was passing three `-c` flags — `developer_instructions`, `features.scheduled_tasks=false`, and `mcp_servers.omar.command`/`.args`.

So the flags become a file. Each codex pane gets a `CODEX_HOME` of its own under `~/.omar/codex/`, holding a `config.toml` with everything the flags used to carry, and the TUI launches bare.

Per-pane, not per-EA: the MCP context file it names is per-agent, and two panes sharing one home would share one app-server and one ambiguous thread list.

**`--remote unix://` is not the answer**, though it does attach with `-c` present: the wire config is a six-key allowlist that silently discards `mcp_servers`, and the cwd it reports is not the canonical one.

## The home is the operator's config, plus ours

`~/.codex/config.toml` is the base — model, reasoning effort, plugins, their own MCP servers, notify — so a pane is still configured the way they configured codex. On top of that: `developer_instructions` (rendered by OMAR now, not by a `$(cat)` at launch), `features.scheduled_tasks = false`, and `[mcp_servers.omar]`.

`projects` is the one table dropped. The pane appends its own working directory as a trusted project, and a table declared twice makes codex refuse to start at all.

`auth.json` is symlinked, not copied — the token is refreshed in place and a pane holding a stale copy would be logged out mid-run. `version.json` is copied: a home that has never seen an update check opens the release prompt over the TUI and waits for a keypress that never comes.

## Four things the pane's own shell does

```sh
export CODEX_HOME='...'; omar_cwd="$(pwd -P)"
grep -qF "[projects.\"$omar_cwd\"]" "$CODEX_HOME/config.toml" || printf ... >> ...
codex app-server --listen unix:// >/dev/null 2>&1 & echo $! > "$CODEX_HOME/app-server.pid"
trap "kill $! 2>/dev/null" EXIT HUP TERM
omar_waited=0; while [ ! -S "$CODEX_HOME/..." ] && [ "$omar_waited" -lt 100 ]; do sleep 0.2; ...; done
codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox
```

**Trust from the shell**, because only the shell knows the pane's directory, and `pwd -P` resolves it the way codex does — a `/tmp/x` in the config does not match the `/private/tmp/x` codex asks about. Without the record a fresh home opens *"Do you trust the contents of this directory?"* and blocks. Appended only if absent, so a re-run cannot produce the duplicate table above.

**The wait is load-bearing.** A brand-new home has no state database. Started together, the server and the TUI collide on the migration and codex refuses to start:

```
Codex couldn't start because its local database appears to be damaged.
  Cause: ... while executing migration 1: table threads already exists
```

That is not theoretical — it is what the second concurrent pane did before the wait went in. Bounded at 20s, after which the TUI starts anyway with no channel, which is the ordinary fallback.

## The trap was the leak

An earlier revision of this PR gave the pane a `trap "kill $!" EXIT HUP TERM` to take the app-server down with it. It did the opposite, and the reason is worth writing down.

`tmux kill-session` **does** signal the pane — it sends SIGHUP to the process group. A plain background job dies with it. A shell carrying `trap ... HUP` *catches* the hangup instead of dying of it, and a shell blocked in the codex TUI never reaches the handler. So the shell survives, reparented to the tmux server, still holding the app-server open.

Controlled pair — same machine, same minute, the exact `tmux new-session … sh -lc <command>` argv `TmuxClient::new_session` builds, real codex TUI in the foreground of both, only the `trap` differing:

| | pane shell after `kill-session` | app-server after `kill-session` |
|---|---|---|
| **with** trap | alive (reparented to tmux server) | alive |
| **without** trap | gone | gone |

A clean `/quit` from the TUI is the same: shell exits, session ends, SIGHUP, server gone.

So the trap is out, and with it the pid file, the `ps` liveness check and the kill. Nothing reaps the process because nothing needs to.

## Pruning, for the disk

What does *not* clean itself up is the directory. Every launch mints a home and codex fills it with several megabytes of sqlite, so `prune_stale_codex_homes` runs on each codex launch and removes the home of any pane that is no longer a tmux session.

By session name rather than by probing the socket: the home holds the running agent's thread history, and deleting one whose app-server merely happens to be down would take a working pane's state with it. A home that names no pane yet was made moments earlier by `codex_home_dir` and is about to be claimed by `provision_in_background`, so it gets a 5-minute grace.

**Known bound:** pruning only runs when the next codex pane launches. Kill your last codex agent and start no other, and its home sits on disk until you do. That is a few megabytes, not a process — worth stating rather than fixing here.

## Delivery, and the thread it is sure of

Stamp is `codex:<socket path>` — the socket only. The thread is resolved at delivery time.

**OMAR injects only when exactly one thread is loaded.** The app-server will say which threads a pane has loaded, never which one it is *showing*, and no ordering separates them:

- `/new` leaves the old thread loaded and moves the pane to a **newer** id.
- `/resume` moves the pane back to an **older** id while the abandoned new thread stays loaded.

Verified on a live pane: after `/resume`, `thread/loaded/list` returned `[…2354, …2355]`, the pane was showing `…2354`, and a newest-id rule picks `…2355`. An event injected there is accepted, acknowledged, and never read — silent loss, which is the one failure this whole PR exists to avoid. So an ambiguous pane reports no channel and delivery goes through the input box, which since #223 protects the draft.

Cost: a pane where the user has worked in one thread and then started another loses the side channel for the rest of that session. `/new` on an untouched thread does not — codex reuses the empty one, verified.

The WebSocket client is hand-rolled over a `UnixStream` rather than through `tungstenite::connect`: the client handshake is a fixed six-line request and a wait for `101`, it needs no URL, and `src/serve.rs` already answers the server half the same way. That also sidesteps #222 — no `Cargo.toml` change here, so nothing to conflict.

Everything degrades to the old behaviour rather than failing. A home that cannot be written, a socket path that would not fit in `sun_path` (104 bytes), or a command carrying a flag codex will not attach with (`-c`, `--profile`, `--search`, `--enable`/`--disable`, …, which `spawn_agent` adds for any agent given a reasoning effort) all fall back to the `-c` flags and no channel. An app-server that never comes up means no stamp, `resolve` returns `None`, and delivery goes through the input box.

## The pane now depends on a process it did not before

**If the app-server dies, the agent pane dies.** Verified: killed the server, and four seconds later the tmux session was gone and the pane pid with it.

This is inherent to auto-attach, not an implementation choice. A codex TUI with no server running keeps its session in-process and opens no socket (verified). Attaching *means* becoming a client of an external process — that is exactly what puts the pane's thread somewhere `thread/inject_items` can reach. The only other way in is `--remote unix://`, which attaches even with `-c` present but silently discards `mcp_servers` and reports a non-canonical cwd. There is no flag that makes the TUI host the socket itself.

So a codex pane is less self-contained than it was before this PR. What bounds it:

- **The server is a background job of the pane's own shell.** Nothing else starts it, nothing else holds it, and it dies with the pane.
- **Nothing in OMAR kills an app-server.** The code that did was removed in `1d11a16`; there is no `kill` on this path at all any more.
- **A live app-server vetoes every path that removes a home** — the prune and the reused-name sweep both check it, whatever the session bookkeeping says. `a_home_whose_server_is_answering_is_never_deleted` gives that invariant a test, with the bookkeeping deliberately wrong in both ways at once.
- **The work survives.** The home and its sqlite are intact after the server dies (verified), so the thread history is recoverable even though the pane is not.

## Verified live, on a real codex pane

Launched through `build_agent_command`'s own output, in a tmux session of its own, with the real `omar` binary as the MCP server.

| | |
|---|---|
| YOLO still on | `permissions: YOLO mode` in the banner — **the flag and auto-attach are not exclusive**, the whole approach hinged on this |
| No trust prompt | pane goes straight to the composer; `[projects."/private/tmp/cxwork3"]` appended by the shell |
| No update prompt | banner only, not the blocking dialog |
| MCP wired | agent answered `list_agents` when asked to name an omar MCP tool |
| Operator's config kept | `model: gpt-5.5 medium`, from `~/.codex/config.toml` |
| Attached | `provision_in_background` polled the socket, got the thread, and stamped `OMAR_DELIVERY=codex:/...sock` into the tmux session env |
| Draft untouched | three-line draft in the composer, `shasum` of the pane identical before and after injection, nothing rendered |
| Agent sees it | next turn answered `BASSOON-4413`, the magic word injected while the draft sat there |
| Two panes at once | two concurrent panes, own homes, own app-servers, both clean |
| Nothing left behind | pane killed → shell, TUI and app-server all gone (`pgrep -f 'codex app-server'` → 0); prune removes the home |
| Server death kills the pane | killed the app-server → session gone, pane pid gone in 4s; home and sqlite intact |
| Ambiguous thread refused | after `/resume`, two threads loaded, pane on the older — delivery declines rather than guessing |

## Tests

`cargo test --bin omar` 369 green, `clippy --workspace --all-targets -D warnings` clean, `fmt --check` clean — locally, because `.github/workflows/ci.yml` is `pull_request: branches: [main]` and a stacked PR does not trigger it. Only `Web` runs here. The Rust jobs run when the stack reaches `main`.

- `an_event_reaches_codex_as_an_injected_item_over_the_app_server_socket` — a real `UnixListener` plays the app-server: handshake, an unsolicited notification before the `initialize` reply (a reply is found by id, not by being next), the four-message sequence, and the newest of two loaded threads.
- `test_build_agent_command_codex` / `test_build_ea_command_codex` — updated, not deleted: the TUI ends the command bare, no ` -c ` anywhere, and the config the flags used to carry is read back off disk from the home the command names.
- `a_codex_home_too_deep_for_a_socket_falls_back_to_the_flags` — the old command, intact.
- `a_codex_config_keeps_the_operators_own_settings_but_not_their_trust_records`, `an_unreadable_codex_config_still_yields_a_usable_one`.
- `a_codex_home_outlives_its_pane_only_until_the_next_launch` — a home naming a dead session goes, an unclaimed one stays.
- `test_build_agent_command_codex` asserts the command contains **no** `trap`, with the reason: trapping the hangup is what stops the pane cleaning up after itself.
- `a_codex_stamp_names_the_socket_to_inject_through`, `a_codex_home_is_read_back_out_of_a_launch_command`, `the_newest_thread_is_the_one_the_pane_is_showing`, `a_pane_that_is_gone_takes_its_app_server_with_it`, `a_dead_app_server_is_a_failed_delivery_rather_than_a_panic`.

## Not verified

- **Linux.** All of the above is macOS. `sun_path` is 108 there rather than 104, `pwd -P` / `sed` / `kill -0` are the same, and `tmux kill-session` may deliver signals differently — the no-trap construction relies on the pane's process group dying, which is the common case, not on anything macOS-specific.
- **codex versions other than 0.147.0.** `thread/inject_items`, `thread/loaded/list`, the disqualifier list and the `/new` vs `/resume` behaviour are all read off this build.
- **Long-lived homes.** Pruning has only been exercised over minutes, not weeks.
- **A pane whose home is reused.** Cannot happen from OMAR — every launch mints a fresh id — but a stale socket file with no server behind it kills the TUI outright (`transport failed: Connection reset without closing handshake`), so anything that reuses a home would need to clear it first.
- **`~/.omar/codex` pollution from `cargo test`.** Reported, and I could not reproduce it: with the directory emptied, neither `cargo test --bin omar`, nor `cargo test --test integration_test`, nor a full `cargo test` run with nothing else on the machine created anything there. The artefact that was seen had only `thread-writer-locks` in it and no `config.toml`, which is the shape of a home abandoned between being created and being filled — so a stalled e2e run against the real `~/.omar` fits it better than a unit test does. Fixed the shape anyway: the home is now made last, after everything that can fail, and removed if the config write fails.
- **One pre-existing flaky test.** `tmux::client::tests::an_answered_prompt_is_delivered_even_if_the_pane_does_not_change` fails intermittently under a loaded machine and passes in isolation. It is on the base branch and untouched here.
