### PR TITLE
Check for a hardcoded claude only where it could send anyone to claude

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,15 +404,38 @@ jobs:
 
       - name: Verify no hardcoded claude references in runtime paths
         run: |
-          # Ensure no hardcoded "claude --dangerously-skip-permissions" remains
-          # outside of config.rs (where it's the fallback default)
-          MATCHES=$(grep -rn '"claude --dangerously-skip-permissions"' src/ --include='*.rs' | grep -v 'src/config.rs' || true)
+          # A ratchet, not a compatibility test. Making OMAR multi-backend
+          # removed this command from everywhere but `config.rs`, where it is
+          # the documented fallback; this keeps one from creeping back, because
+          # a runtime path that spells claude out is a path opencode cannot
+          # take.
+          #
+          # Runtime paths only, which is what the name says. A `#[cfg(test)]`
+          # module is compiled out of the binary, so a literal there cannot
+          # send anyone to claude -- and a test asserting claude-specific
+          # behaviour has to be able to name claude.
+          #
+          # The boundary is `#[cfg(test)]` followed by `mod`, the trailing test
+          # module. Not `#[cfg(test)]` alone: it also guards individual
+          # test-only helpers part way up a file, and stopping at the first one
+          # would leave everything below it unread -- which is most of the file
+          # and the whole point of the check.
+          MATCHES=$(
+            for file in $(grep -rl '"claude --dangerously-skip-permissions"' src/ --include='*.rs'); do
+              [ "$file" = "src/config.rs" ] && continue
+              awk -v f="$file" '
+                previous ~ /^#\[cfg\(test\)\]$/ && /^mod / { exit }
+                /"claude --dangerously-skip-permissions"/ { print f ":" NR ":" $0 }
+                { previous = $0 }
+              ' "$file"
+            done
+          )
           if [ -n "$MATCHES" ]; then
-            echo "Found hardcoded claude command outside config.rs:"
+            echo "Found hardcoded claude command in a runtime path:"
             echo "$MATCHES"
             exit 1
           fi
-          echo "No hardcoded claude references found outside config.rs"
+          echo "No hardcoded claude references in runtime paths"
 
   build:
     name: Build


### PR DESCRIPTION
The step is called *"Verify no hardcoded claude references in runtime paths"* and did not look at paths:

```bash
grep -rn '"claude --dangerously-skip-permissions"' src/ --include='*.rs' | grep -v 'src/config.rs'
```

Every `.rs` file under `src/` but one. So a test that asserts claude-specific behaviour reads as a hardcoded backend and fails the build. That is #224 today — two lines, both inside `#[cfg(test)] mod tests`, in a test whose subject *is* claude:

```
src/manager/mod.rs:1630:  for base in ["claude --dangerously-skip-permissions", "claude"] {
src/manager/mod.rs:1650:  "claude --dangerously-skip-permissions",
```

`a_claude_session_accepts_events_from_omar_over_its_peer_socket` — that claude is launched with `--settings '{"crossSessionInbound":"accept"}'`, without which OMAR's events sit behind an approval dialog covering the composer and never arrive.

## What the check is for, unchanged

A ratchet. `2e96d60` made OMAR multi-backend and took this command out of everything but `config.rs`, where it is the documented fallback. A runtime path that spells claude out is a path opencode cannot take. This keeps one from creeping back.

A `#[cfg(test)]` module is compiled out of the binary, so a literal there cannot make opencode launch claude — the only thing the check guards against. It now stops at the trailing test module.

## The boundary is not `#[cfg(test)]` alone

My first attempt exited at the first column-zero `#[cfg(test)]`, and I nearly shipped it. That attribute also guards individual test-only helpers part way up a file:

```
src/manager/mod.rs:144:  #[cfg(test)]
src/manager/mod.rs:145:  fn global_home_env_lock() -> ...
```

Stopping there leaves the 1300 lines below unread — most of the file, and the whole point of the check. It would have passed CI while quietly guarding nothing.

The boundary is `#[cfg(test)]` followed by `mod`. Test-only helper functions are still scanned, which is slightly strict and the right way for a ratchet to err.

## Verified against all three cases

| | expected | result |
|---|---|---|
| hardcode injected at `src/manager/mod.rs:192` (runtime) | flag | flags |
| `main` unmodified | silent | silent |
| #224's tree, hits inside `mod tests` | silent | silent |

The injected case is the one the first attempt missed, which is why it is here.

Unblocks #224 without touching that PR: `pull_request` checks run against the merge with the base, so a re-run picks this up once it lands.