### PR TITLE
Let the library do the websocket handshake

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -536,8 +536,21 @@ impl CodexSession {
         stream.set_read_timeout(Some(WRITE_TIMEOUT))?;
         stream.set_write_timeout(Some(WRITE_TIMEOUT))?;
 
-        let (socket, _) = tungstenite::client("ws://localhost/", stream)
-            .map_err(|error| anyhow::anyhow!("websocket upgrade failed: {error}"))?;
+        let (socket, _) = tungstenite::client("ws://localhost/", stream).map_err(|error| {
+            match error {
+                // The read timeout set above surfaces as WouldBlock, which
+                // tungstenite renders as a bare "Interrupted handshake" —
+                // say what actually ran out, since provisioning retries this
+                // for 90s and every line would otherwise read the same.
+                tungstenite::HandshakeError::Interrupted(_) => anyhow::anyhow!(
+                    "app-server did not answer the websocket upgrade within {}s",
+                    WRITE_TIMEOUT.as_secs()
+                ),
+                tungstenite::HandshakeError::Failure(error) => {
+                    anyhow::anyhow!("websocket upgrade failed: {error}")
+                }
+            }
+        })?;
 
         let mut session = CodexSession { socket, next_id: 1 };
         session
@@ -1272,6 +1285,32 @@ mod tests {
         }
         .deliver("standup in 5")
         .is_err());
+    }
+
+    /// Provisioning retries `open` for 90s, so a bare "Interrupted handshake"
+    /// would be 90s of identical lines that name neither the socket nor the
+    /// timeout that produced them.
+    #[test]
+    fn a_silent_app_server_names_the_timeout_rather_than_the_symptom() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("mute.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        // Accept, then say nothing: the upgrade waits out the read timeout.
+        let server = std::thread::spawn(move || {
+            let held = listener.accept();
+            std::thread::sleep(WRITE_TIMEOUT + Duration::from_secs(1));
+            drop(held);
+        });
+
+        let error = Channel::CodexAppServer { socket }
+            .deliver("standup in 5")
+            .expect_err("a server that never answers cannot take a delivery");
+        let error = format!("{error:#}");
+        assert!(
+            error.contains("did not answer the websocket upgrade"),
+            "want the timeout named, got: {error}"
+        );
+        server.join().unwrap();
     }
 
     #[test]

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -517,19 +517,12 @@ fn provision_codex(home: &Path) -> Option<String> {
     None
 }
 
-/// The RFC 6455 example nonce.
-///
-/// The server's `Sec-WebSocket-Accept` is derived from this and we do not
-/// check it — there is no proxy or cache between two ends of a Unix socket to
-/// confuse — so a constant keeps the request a fixed string.
-const WS_NONCE: &str = "dGhlIHNhbXBsZSBub25jZQ==";
-
 /// A JSON-RPC conversation with a codex app-server.
 ///
-/// The transport is a WebSocket over a Unix socket. The upgrade request is
-/// written by hand rather than through `tungstenite::connect`, which is behind
-/// a feature this crate's own manifest turns off and which only speaks in
-/// terms of URLs — `src/serve.rs` answers the server half the same way.
+/// The transport is a WebSocket over a Unix socket. `tungstenite::client`
+/// performs the upgrade: it wants a URL only to build the request line and
+/// `Host` header, so a placeholder is fine — the bytes go wherever the stream
+/// already points, which here is a socket path.
 struct CodexSession {
     socket: tungstenite::WebSocket<UnixStream>,
     next_id: u64,
@@ -538,52 +531,15 @@ struct CodexSession {
 impl CodexSession {
     /// Connect, upgrade, and complete the app-server's opening handshake.
     fn open(path: &Path) -> Result<CodexSession> {
-        let mut stream =
+        let stream =
             UnixStream::connect(path).with_context(|| format!("connect to {}", path.display()))?;
         stream.set_read_timeout(Some(WRITE_TIMEOUT))?;
         stream.set_write_timeout(Some(WRITE_TIMEOUT))?;
-        stream
-            .write_all(
-                format!(
-                    "GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\n\
-                     Connection: Upgrade\r\nSec-WebSocket-Key: {}\r\n\
-                     Sec-WebSocket-Version: 13\r\n\r\n",
-                    WS_NONCE
-                )
-                .as_bytes(),
-            )
-            .context("send websocket upgrade")?;
-        stream.flush()?;
 
-        // One byte at a time so nothing past the header is swallowed — the
-        // first data frame may already be in the same read.
-        let mut header = Vec::new();
-        let mut byte = [0u8; 1];
-        while !header.ends_with(b"\r\n\r\n") {
-            if std::io::Read::read(&mut stream, &mut byte).context("read upgrade response")? == 0 {
-                anyhow::bail!("app-server closed during the upgrade");
-            }
-            header.push(byte[0]);
-            if header.len() > 4096 {
-                anyhow::bail!("app-server sent no upgrade response");
-            }
-        }
-        let header = String::from_utf8_lossy(&header);
-        if !header.starts_with("HTTP/1.1 101") {
-            anyhow::bail!(
-                "app-server refused the upgrade: {}",
-                header.lines().next().unwrap_or_default()
-            );
-        }
+        let (socket, _) = tungstenite::client("ws://localhost/", stream)
+            .map_err(|error| anyhow::anyhow!("websocket upgrade failed: {error}"))?;
 
-        let mut session = CodexSession {
-            socket: tungstenite::WebSocket::from_raw_socket(
-                stream,
-                tungstenite::protocol::Role::Client,
-                None,
-            ),
-            next_id: 1,
-        };
+        let mut session = CodexSession { socket, next_id: 1 };
         session
             .call(
                 "initialize",
@@ -1208,35 +1164,10 @@ mod tests {
     /// asked, so the framing is checked against a real socket rather than a
     /// string.
     fn fake_app_server(listener: UnixListener, threads: Vec<&'static str>) -> Vec<String> {
-        let (mut stream, _) = listener.accept().unwrap();
-
-        let mut header = Vec::new();
-        let mut byte = [0u8; 1];
-        while !header.ends_with(b"\r\n\r\n") {
-            stream.read_exact(&mut byte).unwrap();
-            header.push(byte[0]);
-        }
-        let request = String::from_utf8_lossy(&header).into_owned();
-        let key = request
-            .lines()
-            .find_map(|line| line.strip_prefix("Sec-WebSocket-Key: "))
-            .expect("a websocket upgrade");
-        stream
-            .write_all(
-                format!(
-                    "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\
-                     Connection: Upgrade\r\nSec-WebSocket-Accept: {}\r\n\r\n",
-                    tungstenite::handshake::derive_accept_key(key.trim().as_bytes())
-                )
-                .as_bytes(),
-            )
-            .unwrap();
-
-        let mut socket = tungstenite::WebSocket::from_raw_socket(
-            stream,
-            tungstenite::protocol::Role::Server,
-            None,
-        );
+        let (stream, _) = listener.accept().unwrap();
+        // `tungstenite::accept` answers the upgrade, so the test exercises the
+        // same handshake the app-server does rather than a hand-made reply.
+        let mut socket = tungstenite::accept(stream).unwrap();
         let answer = |socket: &mut tungstenite::WebSocket<UnixStream>,
                       request: &serde_json::Value,
                       result: serde_json::Value| {


### PR DESCRIPTION
Follow-up to #222, #225.

## Why now

The codex channel wrote its own WebSocket upgrade: build the request by hand, read the response a byte at a time, check for a `101`, then hand the raw stream to `WebSocket::from_raw_socket`. It did that for a stated reason —

> written by hand rather than through `tungstenite::connect`, which is behind a feature this crate's own manifest turns off

— and that stopped being true when **#222** turned the `handshake` feature on for `serve.rs`. The comment described a constraint that no longer existed, and the workaround was 82 lines of protocol handling standing in for one call.

## What changed

`tungstenite::client("ws://localhost/", stream)`. The URL is only used to build the request line and `Host` header; the bytes go wherever the stream already points, which here is a Unix socket path.

Two things the library does that the hand-written version did not:

- a **fresh random nonce** per connection, rather than the RFC's example nonce as a constant
- **validating the server's `Sec-WebSocket-Accept`** against that nonce

The constant went with the rest of it.

The test's fake app-server now answers with `tungstenite::accept` instead of a hand-assembled reply, so it exercises the same handshake a real server performs rather than one written to match our own client.

**−69 lines net** (13 added, 82 removed).

## Verified

Against a live codex app-server, not just the double — a real pane, a real socket:

```
before: 07bc6fa637e45d96a0f3b8d3     (capture-pane -e, sha256)
DELIVER=Ok(())
after:  07bc6fa637e45d96a0f3b8d3     identical
event found in: rollout-2026-08-22T23-10-03-01a02b18-….jsonl
```

A two-line draft sat in the composer throughout and was untouched.

- `cargo test -- --test-threads=1` — 385 pass
- `cargo clippy --workspace --all-targets -D warnings` clean, `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-up

**Timeout diagnostics restored.** The socket's 3s read timeout surfaces as `WouldBlock`, which tungstenite renders as the fixed string `Interrupted handshake (WouldBlock)` — naming neither the socket nor the timeout. Provisioning retries `open` for 90s, so that was 90 seconds of identical, unactionable lines. A timeout now says so; a refusal keeps the server's own status line. Covered by `a_silent_app_server_names_the_timeout_rather_than_the_symptom`, mutation-tested — reverting the change gives exactly:

```
want the timeout named, got: websocket upgrade failed: Interrupted handshake (WouldBlock)
```

**The narrowing is safe — measured, not argued.** `verify_response` is stricter than the old `starts_with("HTTP/1.1 101")`: it requires the whole `Connection` value to equal `Upgrade` rather than merely contain the token, and rejects a `Sec-WebSocket-Protocol` the client never asked for. Captured the real server's reply off a raw `UnixStream` (codex-cli 0.149.0):

```
HTTP/1.1 101 Switching Protocols
connection: Upgrade
upgrade: websocket
sec-websocket-accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
```

Three headers. `connection: Upgrade` is a whole-value match, so the equality check passes. No `Sec-WebSocket-Protocol` is ever sent — probed by offering one, and the server echoes nothing back, so that rule cannot fire. Offering `Connection: keep-alive, Upgrade` still gets `connection: Upgrade` in return.

**One forward-looking caveat.** If a client offers `Sec-WebSocket-Extensions: permessage-deflate`, this server replies with nothing and closes. Unreachable today — `tungstenite` is pinned `default-features = false, features = ["handshake"]`, so deflate is off — but turning that feature on would break the handshake against this server.

## Live e2e

Against real `codex app-server` processes, three consecutive full runs:

| Case | Result |
|---|---|
| 15 sequential deliveries per run | **45/45** — 1.7–4.8 ms after warm-up, no degradation on delivery 2+ |
| 6 threads x 3 deliveries, one server | **54/54** |
| 3 servers, separate sockets | **27/27** |

Deliveries were confirmed *landed*, not merely acked: every message appears in the thread's rollout JSONL — 15/15 sequential, 18/18 concurrent, every run.

Error paths, all clean `Err`, no panic and no unbounded hang:

| Case | Result | Time |
|---|---|---|
| Socket file present, nothing listening | `Connection refused (os error 61)` | 0.2–0.4 ms |
| Server gone | `No such file or directory (os error 2)` | 0.02 ms |
| Accepts, never answers | `app-server did not answer the websocket upgrade within 3s` | **3.0012 s** |
| Killed mid-session | `write to the app-server: Broken pipe (os error 32)` | 0.05 ms |

The third lands exactly on `WRITE_TIMEOUT` and hits this PR's new message.

Tests: 386 + 7 + 3 + 24 + 9 + 10 pass; clippy `-D warnings` and `fmt --check` clean.