### PR TITLE
Write the trust record in one place

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -141,6 +141,13 @@ impl Channel {
     ///
     /// `pane_pid` is the pane's own process. The backend may be a child of it
     /// when the pane runs a shell, so its children are checked too.
+    ///
+    /// `Some` means a channel looks available, not that a delivery through it
+    /// will land. codex resolves on the socket file existing and only
+    /// discovers in [`Channel::deliver`] that the pane has more than one
+    /// thread loaded and cannot be addressed. Callers must treat the error
+    /// from `deliver` as the real answer — the scheduler does, by protecting
+    /// the draft again before it falls back to the input box.
     pub fn resolve(backend: &str, pane_pid: u32, stamp: Option<&str>) -> Option<Channel> {
         // A stamp is written when the backend needed provisioning at launch;
         // it names the port and session an event must be addressed to.

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -2159,6 +2159,84 @@ mod tests {
         assert!(cmd.contains("-c features.scheduled_tasks=false"));
     }
 
+    /// Both launch paths now splice in the same generated fragment, so run
+    /// the shell rather than spell-check it: the assertions elsewhere are
+    /// `contains`, and those pass just as happily on a fragment `sh` rejects.
+    #[test]
+    fn the_trust_record_is_written_once_however_odd_the_directory_name() {
+        // The two characters the `sed` escapes, in the name it has to survive.
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = dir.path().join("wei\"rd\\dir");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let home = dir.path().join("codex-home");
+
+        let run = || {
+            let out = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(codex_trust_cwd())
+                .current_dir(&cwd)
+                .env("CODEX_HOME", &home)
+                .output()
+                .expect("run the trust shell");
+            assert!(
+                out.status.success(),
+                "the trust shell failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run();
+        run();
+
+        let config = std::fs::read_to_string(home.join("config.toml")).unwrap();
+        let real = std::fs::canonicalize(&cwd).unwrap().display().to_string();
+        let want = format!(
+            "[projects.\"{}\"]",
+            real.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        assert_eq!(
+            config.matches(&want).count(),
+            1,
+            "written once, and recognised by the second run: {config}"
+        );
+        assert!(config.contains("trust_level = \"trusted\""));
+    }
+
+    /// The dedup joined two strings; a missing separator is a launch that
+    /// never reaches codex, and no `contains` assertion would notice.
+    #[test]
+    fn a_provisioning_launch_is_valid_shell() {
+        let out = std::process::Command::new("sh")
+            .args(["-n", "-c", ""])
+            .output()
+            .expect("sh -n");
+        assert!(out.status.success(), "sh cannot syntax-check");
+
+        let cmd = codex_home_command(Path::new("/tmp/omar-home"), "codex --no-alt-screen");
+        let checked = std::process::Command::new("sh")
+            .arg("-n")
+            .stdin(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .and_then(|mut child| {
+                use std::io::Write;
+                child.stdin.take().unwrap().write_all(cmd.as_bytes())?;
+                child.wait_with_output()
+            })
+            .expect("syntax-check the launch command");
+        assert!(
+            checked.status.success(),
+            "generated launch is not valid shell: {}\n{}",
+            String::from_utf8_lossy(&checked.stderr),
+            cmd
+        );
+        // Syntax alone does not catch a lost separator: the append would just
+        // redirect into `config.tomlcodex` and `sh -n` would still be happy.
+        assert!(
+            cmd.contains("; codex app-server"),
+            "the trust fragment must end in a separator: {cmd}"
+        );
+    }
+
     #[test]
     fn a_codex_that_will_not_attach_is_launched_the_old_way() {
         // `spawn_agent` adds `-c model_reasoning_effort=…` for any agent given

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -760,17 +760,14 @@ fn codex_home_command(home: &Path, tui_command: &str) -> String {
     let home = shell_single_quote(&home.display().to_string());
     let socket = "\"$CODEX_HOME/app-server-control/app-server-control.sock\"";
     format!(
-        "export CODEX_HOME={home}; \
-         omar_cwd=\"$(pwd -P | sed 's/[\\\\\"]/\\\\&/g')\"; \
-         grep -qF \"[projects.\\\"$omar_cwd\\\"]\" \"$CODEX_HOME/config.toml\" || \
-         printf '\\n[projects.\"%s\"]\\ntrust_level = \"trusted\"\\n' \"$omar_cwd\" \
-         >> \"$CODEX_HOME/config.toml\"; \
+        "export CODEX_HOME={home}; {trust}\
          codex app-server --listen unix:// >/dev/null 2>&1 & \
          omar_srv=$!; omar_waited=0; \
          while [ ! -S {socket} ] && [ \"$omar_waited\" -lt 100 ] \
          && kill -0 \"$omar_srv\" 2>/dev/null; \
          do sleep 0.2; omar_waited=$((omar_waited+1)); done; \
-         {tui_command}"
+         {tui_command}",
+        trust = codex_trust_cwd()
     )
 }
 


### PR DESCRIPTION
Two follow-ups to #225, both small.

## One writer for the trust record

Both codex launch paths append the same record:

```toml
[projects."<cwd>"]
trust_level = "trusted"
```

and both had their own copy of the shell that does it. The fallback's became a function because it needed to default `CODEX_HOME` to the operator's own directory; the side channel's stayed inline. Two copies of the same escaping, free to drift.

The function already handled both cases — `${CODEX_HOME:-$HOME/.codex}` picks up the per-pane home the side channel exports a moment earlier — so the inline copy is gone.

**Verified live**, since this is shell escaping and unit tests only check shape: the generated side-channel command, run in a directory codex had never seen, reached `› Ask Codex to do anything` with no trust prompt, and left the record in the pane's own config.

## What `Channel::resolve` actually promises

`Some` means a channel *looks* available, not that a delivery will land. codex resolves on the socket file existing, and only discovers in `deliver` that the pane has two threads loaded and cannot be addressed unambiguously.

That is safe today — `deliver_to_tmux` treats the error as its cue and protects the draft again before falling back to the input box — but nothing said so, and the scheduler decides whether to skip capturing a draft based on `resolve` alone. Now documented, so the next person doesn't build on it.

- `cargo test -- --test-threads=1` — 385 pass
- clippy `-D warnings` clean, `fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-up

Review found no defects. It did surface that the fragment had **no execution coverage**: every assertion on it is a `contains`, which passes just as happily on a fragment a real `sh` rejects. For a change that is purely a splice, that is the gap worth closing.

Two tests added:

- `the_trust_record_is_written_once_however_odd_the_directory_name` — runs the fragment twice against a directory named `wei"rd\dir`, asserting the record lands **once**. Exercises both the `sed` escaping and the `grep -qF` idempotence on the two characters that matter.
- `a_provisioning_launch_is_valid_shell` — syntax-checks a full provisioning launch through `sh -n`.

**Mutation-tested, including what they miss:**

| Mutation | Caught by |
|---|---|
| Unbalance a quote in the wait loop | `sh -n` check |
| Drop the `sed` escaping | escaping test |
| Drop the trailing `;` separator | **neither** — `sh -n` is happy to redirect into `config.tomlcodex` |

The third now has an explicit assertion, since that is precisely the failure a splice refactor can introduce.

Tests: 387 + 7 + 3 + 24 + 9 + 10 pass; clippy `-D warnings` and `fmt --check` clean.