### PR TITLE
Make the blind-delivery test actually blind

### DIFF
--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -2101,9 +2101,21 @@ mod tests {
         //
         // Nothing reaches the screen, so the copies are counted in the file
         // `cat` writes instead of in the pane.
-        let sink = std::env::temp_dir().join(format!("omar-answered-probe-{}", std::process::id()));
-        let _ = std::fs::remove_file(&sink);
-        let run = format!("stty -echo; cat > {}", sink.display());
+        let sink =
+            std::env::temp_dir().join(format!("omar-answered-probe-{}.txt", uuid::Uuid::new_v4()));
+        let sink_str = match sink.to_str() {
+            Some(s) => s,
+            None => {
+                eprintln!("Skipping test: temp path is not valid UTF-8: {:?}", sink);
+                return;
+            }
+        };
+        // Single-quote-escape the path so a TMPDIR holding spaces or shell
+        // metacharacters can't redirect the copies somewhere we never read —
+        // which would mask a real regression as "saw 0 paste(s)".
+        let run = format!("stty -echo; cat > '{}'", sink_str.replace('\'', r"'\''"));
+        // Remove the sink on every exit path, including a failed assertion.
+        let _sink_guard = TempPathGuard(sink.clone());
         let ok = tmux_command()
             .args(["new-session", "-d", "-s", session, &run])
             .status()
@@ -2138,27 +2150,46 @@ mod tests {
             "expected the blind delivery to retry, saw {pasted} paste(s)"
         );
 
-        // Told the agent answered, the same delivery succeeds without a second
-        // copy — which is the part that matters, since re-delivering is what
-        // the runtime rejects.
-        let _ = tmux_command()
-            .args(["kill-session", "-t", session])
-            .output();
-        let _ = std::fs::remove_file(&sink);
-        let _ = tmux_command()
-            .args(["new-session", "-d", "-s", session, &run])
-            .status();
-        let answered = client.deliver_prompt_until(session, "OMAR ANSWERED PROBE", &opts, &|| true);
-        assert!(answered.is_ok(), "an answered prompt was delivered");
-        let pasted = std::fs::read_to_string(&sink)
-            .unwrap_or_default()
-            .matches("OMAR ANSWERED PROBE")
-            .count();
+        // The regression this test is named for lives one level down, in
+        // `wait_for_change`: an agent that answers between the paste and the
+        // submit has already drawn its output, so Enter causes no change and
+        // only `answered` proves the prompt arrived. Exercise it directly —
+        // routing through `deliver_prompt_until` cannot reach it, because the
+        // same `stty -echo` that makes the blind case above deterministic
+        // also keeps the paste from rendering, so every attempt retries
+        // before it ever submits.
+        let content_before = client.capture_pane(session, 50).unwrap_or_default();
+        let activity_before = client.get_pane_activity(session).unwrap_or(0);
+
         assert!(
-            pasted <= 1,
-            "an answered prompt must not be delivered twice, saw {pasted}"
+            !client.wait_for_change(
+                session,
+                activity_before,
+                &content_before,
+                Duration::from_millis(300),
+                opts.poll_interval,
+                &|| false,
+            ),
+            "a pane that never changes cannot verify an unanswered prompt"
         );
-        let _ = std::fs::remove_file(&sink);
+
+        // Same still pane, same snapshot — `answered` is the only difference.
+        let started = Instant::now();
+        assert!(
+            client.wait_for_change(
+                session,
+                activity_before,
+                &content_before,
+                Duration::from_secs(2),
+                opts.poll_interval,
+                &|| true,
+            ),
+            "an answered prompt needs no pane change to count as delivered"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "the answered check must short-circuit, not wait out the timeout"
+        );
     }
 
     fn extract_sentinel_id(hay: &str, prefix: &str) -> Option<String> {

--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -2093,11 +2093,19 @@ mod tests {
             .output();
         let _guard = SessionGuard(session.to_string());
 
-        // `cat` into nothing: it swallows the paste and prints nothing back, so
-        // pressing Enter leaves the pane exactly as it was. A shell would echo
-        // a fresh prompt and hide the very case under test.
+        // The pane must never change, or the delivery could confirm itself and
+        // there would be no blind case to test. `stty -echo` is what makes
+        // that true rather than merely likely: without it the tty echoes the
+        // paste back, the end sentinel appears, and verification succeeds —
+        // which it did, about one run in eight, under parallel load.
+        //
+        // Nothing reaches the screen, so the copies are counted in the file
+        // `cat` writes instead of in the pane.
+        let sink = std::env::temp_dir().join(format!("omar-answered-probe-{}", std::process::id()));
+        let _ = std::fs::remove_file(&sink);
+        let run = format!("stty -echo; cat > {}", sink.display());
         let ok = tmux_command()
-            .args(["new-session", "-d", "-s", session, "cat > /dev/null"])
+            .args(["new-session", "-d", "-s", session, &run])
             .status()
             .map(|s| s.success())
             .unwrap_or(false);
@@ -2121,8 +2129,7 @@ mod tests {
         // every attempt pastes the prompt again.
         let blind = client.deliver_prompt_until(session, "OMAR ANSWERED PROBE", &opts, &|| false);
         assert!(blind.is_err(), "a pane that never changes cannot confirm");
-        let pasted = client
-            .capture_pane_plain(session, 400)
+        let pasted = std::fs::read_to_string(&sink)
             .unwrap_or_default()
             .matches("OMAR ANSWERED PROBE")
             .count();
@@ -2137,13 +2144,13 @@ mod tests {
         let _ = tmux_command()
             .args(["kill-session", "-t", session])
             .output();
+        let _ = std::fs::remove_file(&sink);
         let _ = tmux_command()
-            .args(["new-session", "-d", "-s", session, "cat > /dev/null"])
+            .args(["new-session", "-d", "-s", session, &run])
             .status();
         let answered = client.deliver_prompt_until(session, "OMAR ANSWERED PROBE", &opts, &|| true);
         assert!(answered.is_ok(), "an answered prompt was delivered");
-        let pasted = client
-            .capture_pane_plain(session, 400)
+        let pasted = std::fs::read_to_string(&sink)
             .unwrap_or_default()
             .matches("OMAR ANSWERED PROBE")
             .count();
@@ -2151,6 +2158,7 @@ mod tests {
             pasted <= 1,
             "an answered prompt must not be delivered twice, saw {pasted}"
         );
+        let _ = std::fs::remove_file(&sink);
     }
 
     fn extract_sentinel_id(hay: &str, prefix: &str) -> Option<String> {


### PR DESCRIPTION
`an_answered_prompt_is_delivered_even_if_the_pane_does_not_change` fails about **one run in eight** of a parallel `cargo test`. CI runs `--test-threads=1` so it stays green there, which is why it has survived — it only costs developer time locally.

Review then turned up a second, worse problem in the same test, fixed here too.

## Why it flaked

It always failed on the same assertion:

```rust
assert!(blind.is_err(), "a pane that never changes cannot confirm");
```

The delivery it expects to *fail* had succeeded.

The test asked one pane for two contradictory things. It had to **never change**, so the delivery could not confirm itself — that is the whole case under test. And it had to **show the pasted text**, so the retries could be counted.

Those are the same property. `cat > /dev/null` swallows the *data*, but it does not stop the tty echoing the paste back, so the end sentinel reached the screen. Whether verification spotted it inside its 600 ms came down to how loaded the machine was. The comment claimed the pane "prints nothing back", which was simply not true.

**Fix:** the pane runs `stty -echo` and `cat` writes to a file. Nothing reaches the screen, so the delivery cannot confirm — by construction rather than by timing — and the retries are counted in the file instead of the pane.

## Phase 2 could not fail

Phase 2 asserted through `deliver_prompt_until` with `answered = || true`. That returns at the top-of-attempt gate, before any `C-u`, paste or Enter — so it counted **zero** copies and `pasted <= 1` held no matter what the code did.

Measured, not argued: with the `answered` check inside `wait_for_change` deleted — the exact regression the test is named for — the old test still passed.

```
test ...an_answered_prompt_is_delivered_even_if_the_pane_does_not_change ... ok
```

No other test in the repo covers that path.

Routing through `deliver_prompt_until` cannot reach it, either: the `stty -echo` that makes phase 1 deterministic also stops the paste from rendering, so every attempt retries before it ever submits.

**Fix:** call `wait_for_change` directly — same still pane, same snapshot, `answered` the only difference between the two assertions. With the check deleted it now fails:

```
panicked at src/tmux/client.rs:2172:
an answered prompt needs no pane change to count as delivered
```

## Also

The sink now matches its two sibling tests: a UUID name rather than the PID (`/tmp` is world-writable and PIDs collide across containers), single-quote escaping so a TMPDIR with spaces cannot redirect the copies somewhere unread, and `TempPathGuard` so a failing assertion does not leak the file.

## Verified

- **Mutation-tested both ways** — the new test fails with the regression, the old one passed with it
- **12 consecutive runs: 12 passed, 0 failed.** It previously tripped in roughly one of every eight
- `cargo test --workspace` — 385 + 7 + 3 + 24 + 9 + 10 pass
- clippy `-D warnings` clean, `fmt --check` clean

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)