### PR TITLE
Let `omar kill ea` kill the pane `omar list` calls `ea`

### DIFF
--- a/src/omar.rs
+++ b/src/omar.rs
@@ -401,6 +401,7 @@ async fn async_main() -> Result<()> {
                 kill_agent(
                     &client,
                     &name,
+                    &ea::ea_manager_session(target.id, &config.dashboard.session_prefix),
                     &scheduler::Scheduler::with_store(scheduler::events_store_path(&omar_dir)),
                     target.id,
                 )
@@ -674,9 +675,18 @@ fn sessions_for_ea(base_prefix: &str, ea_id: ea::EaId) -> Result<Vec<tmux::Sessi
     Ok(sessions)
 }
 
+/// What the CLI calls the EA's own pane.
+///
+/// Not the name of its session. A worker is `<prefix><ea>-<name>` and the
+/// manager is `<prefix>ea-<id>`, so the manager cannot be reached by the rule
+/// that reaches everything else. The scheduler already addresses it by this
+/// name -- an event's receiver is `"ea"` -- so the listing is not inventing
+/// one, and `omar kill` should answer to it too.
+const CLI_MANAGER_NAME: &str = "ea";
+
 fn display_cli_session_name(session_name: &str, prefix: &str, manager_session: &str) -> String {
     if session_name == manager_session {
-        "ea".to_string()
+        CLI_MANAGER_NAME.to_string()
     } else {
         session_name
             .strip_prefix(prefix)
@@ -702,13 +712,27 @@ fn spawn_agent(
     Ok(())
 }
 
+/// The session a name from `omar list` refers to.
+///
+/// The inverse of `display_cli_session_name`, and the reason this exists: the
+/// listing prints the manager as `ea`, and without an inverse that is the one
+/// name in the listing `omar kill` cannot resolve.
+fn cli_session_name(client: &TmuxClient, name: &str, manager_session: &str) -> String {
+    if name == CLI_MANAGER_NAME {
+        manager_session.to_string()
+    } else {
+        client.session_for(name)
+    }
+}
+
 fn kill_agent(
     client: &TmuxClient,
     name: &str,
+    manager_session: &str,
     scheduler: &scheduler::Scheduler,
     ea_id: ea::EaId,
 ) -> Result<()> {
-    let full_name = client.session_for(name);
+    let full_name = cli_session_name(client, name, manager_session);
 
     if !client.has_session(&full_name)? {
         anyhow::bail!("Session '{}' not found", name);
@@ -2193,6 +2217,35 @@ mod tests {
             "{dir:?}"
         );
         assert!(dir.ends_with("topologies/Cadence"), "{dir:?}");
+    }
+
+    /// Every name `omar list` prints is a name `omar kill` can resolve.
+    ///
+    /// The manager is the one that got this wrong: the listing calls it `ea`,
+    /// and resolution ran it through the worker rule -- `<prefix><ea>-<name>`
+    /// -- producing `omar-agent-0-ea`, a session that has never existed. So
+    /// `omar kill ea` answered "Session 'ea' not found" about the pane it had
+    /// just been shown.
+    #[test]
+    fn a_name_the_listing_prints_is_a_name_kill_resolves() {
+        let base = "omar-agent-";
+        let prefix = ea::ea_prefix(0, base);
+        let manager = ea::ea_manager_session(0, base);
+        let client = TmuxClient::new(prefix.clone());
+
+        // The manager and a worker, as tmux actually names them.
+        for session in [manager.as_str(), "omar-agent-0-worker"] {
+            let shown = display_cli_session_name(session, &prefix, &manager);
+            assert_eq!(
+                cli_session_name(&client, &shown, &manager),
+                session,
+                "listing shows '{shown}' for {session}, which does not resolve back"
+            );
+        }
+
+        // And the manager is spelled the way the scheduler already addresses
+        // it, so killing it cancels its events too.
+        assert_eq!(display_cli_session_name(&manager, &prefix, &manager), "ea");
     }
 
     #[cfg(target_os = "macos")]

--- a/src/tmux/client.rs
+++ b/src/tmux/client.rs
@@ -924,9 +924,17 @@ impl TmuxClient {
     }
 
     /// Find a session by exact name.
+    ///
+    /// Unfiltered, unlike `list_sessions`: the caller has already named one
+    /// session, and the prefix is for enumerating an EA's agents rather than
+    /// for deciding whether a named one exists. Filtering here could not see
+    /// the EA's own pane at all -- the manager is `<prefix>ea-<id>` where a
+    /// worker is `<prefix><ea>-<name>` -- so `ensure_session_not_attached`
+    /// called it missing while `has_session`, which asks tmux directly, found
+    /// it.
     pub fn get_session(&self, name: &str) -> Result<Option<Session>> {
         let target = exact_session_target(name);
-        let sessions = self.list_sessions()?;
+        let sessions = self.list_all_sessions()?;
         Ok(sessions
             .into_iter()
             .find(|session| exact_session_target(&session.name) == target))


### PR DESCRIPTION
Reported:

```
$ omar list
NAME                 ATTACHED     PID
ea                   no           190518

$ omar kill ea
Error: Session 'ea' not found

$ tmux ls
omar-agent-ea-0: 1 windows
```

The listing prints a name the killer cannot resolve, and it is the only name in the listing that behaves that way.

## One cause, two layers

The EA's own pane does not follow the naming rule that reaches every other agent:

| | session | listing shows | `kill` looked for |
|---|---|---|---|
| worker `foo` | `omar-agent-0-foo` | `foo` | `omar-agent-0-foo` ✓ |
| the EA | `omar-agent-ea-0` | `ea` | `omar-agent-0-ea` ✗ |

**The missing inverse.** `display_cli_session_name` special-cases the manager to `ea`, and nothing converted it back — `kill` ran `ea` through the worker rule. `cli_session_name` is that inverse, and `CLI_MANAGER_NAME` gives the two functions one spelling to share.

**The prefix filter underneath.** With the name fixed, it still failed — differently:

```
Error: Session 'omar-agent-ea-0' not found
```

`get_session` filtered by the client's prefix, and `omar-agent-ea-0` does not start with `omar-agent-0-`. That is enumeration logic in an exact lookup, contradicting the function's own doc — *"Find a session by exact name"* — and it is why `has_session` could see the manager while `ensure_session_not_attached` could not. It now uses the unfiltered listing.

Scope: `get_session` has exactly one caller, `ensure_session_not_attached`, and all four of *its* callers pass an already-resolved, already-EA-scoped name. The filter was adding nothing.

## Not a display invention

`"ea"` is how the scheduler already addresses the manager — `receiver == "ea" || receiver == "omar"` — so `kill_agent` cancelling the pane's events under that name was already correct. Only the tmux lookup was wrong.

## Verified

Against real tmux sessions, both paths:

```
=== omar kill ea ===      Killed agent: ea
=== omar kill worker ===  Killed agent: worker
=== tmux after ===        no server running
```

`a_name_the_listing_prints_is_a_name_kill_resolves` asserts the round trip for the manager and a worker. Confirmed it reproduces the report: restore the old resolution and it fails with `listing shows 'ea' for omar-agent-ea-0, which does not resolve back`.

386 tests, fmt and clippy clean. The one failure in a full run is #207, which reproduces on `main` at the same rate and does not touch this path.